### PR TITLE
Implementation of Periodic Boundary Condition and Bugfix for plotting on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ scripts/configs/run_config.yaml
 *.jsonl
 .aider*
 .DS_Store
+.cursorignore
 site
 
 # Byte-compiled / optimized / DLL files

--- a/examples/simulate_gaussian_source.py
+++ b/examples/simulate_gaussian_source.py
@@ -11,7 +11,7 @@ from fdtdx.fdtd.backward import full_backward
 from fdtdx.fdtd.fdtd import checkpointed_fdtd
 from fdtdx.interfaces.modules import DtypeConversion
 from fdtdx.interfaces.recorder import Recorder
-from fdtdx.objects.boundaries.initialization import BoundaryConfig, pml_objects_from_config
+from fdtdx.objects.boundaries.initialization import BoundaryConfig, boundary_objects_from_config
 from fdtdx.objects.container import ArrayContainer, ParameterContainer
 from fdtdx.objects.detectors.energy import EnergyDetector
 from fdtdx.objects.initialization import apply_params, place_objects
@@ -57,8 +57,12 @@ def main():
         partial_real_shape=(12.0e-6, 12e-6, 12e-6),
     )
 
-    bound_cfg = BoundaryConfig.from_uniform_bound(thickness=10)
-    bound_dict, c_list = pml_objects_from_config(bound_cfg, volume)
+    periodic = True
+    if periodic:
+        bound_cfg = BoundaryConfig.from_uniform_bound(boundary_type="periodic")
+    else:
+        bound_cfg = BoundaryConfig.from_uniform_bound(thickness=10, boundary_type="pml")
+    bound_dict, c_list = boundary_objects_from_config(bound_cfg, volume)
     constraints.extend(c_list)
 
     source = GaussianPlaneSource(

--- a/src/fdtdx/fdtd/update.py
+++ b/src/fdtdx/fdtd/update.py
@@ -3,9 +3,26 @@ import pytreeclass as tc
 
 from fdtdx.core.config import SimulationConfig
 from fdtdx.fdtd.curl import curl_E, curl_H, interpolate_fields
+from fdtdx.objects.boundaries.periodic import PeriodicBoundary
 from fdtdx.objects.container import ArrayContainer, ObjectContainer
 from fdtdx.objects.detectors.detector import Detector
 from fdtdx.shared.misc import add_boundary_interfaces, collect_boundary_interfaces
+
+
+def get_periodic_axes(objects: ObjectContainer) -> tuple[bool, bool, bool]:
+    """Determines which axes have periodic boundary conditions.
+
+    Args:
+        objects: Container with simulation objects including boundaries
+
+    Returns:
+        tuple[bool, bool, bool]: Tuple indicating which axes (x,y,z) are periodic
+    """
+    periodic_axes = [False, False, False]
+    for boundary in objects.boundary_objects:
+        if isinstance(boundary, PeriodicBoundary):
+            periodic_axes[boundary.axis] = True
+    return tuple(periodic_axes)
 
 
 def update_E(
@@ -18,29 +35,31 @@ def update_E(
     """Updates the electric field (E) according to Maxwell's equations using the FDTD method.
 
     Implements the discretized form of dE/dt = (1/ε)∇×H on the Yee grid. Updates include:
-    1. PML boundary conditions if simulate_boundaries=True
+    1. PML/periodic boundary conditions if simulate_boundaries=True
     2. Source contributions for active sources
     3. Field updates based on curl of H field
 
     Args:
         time_step: Current simulation time step
         arrays: Container with E, H fields and material properties
-        objects: Container with sources, PML and other simulation objects
+        objects: Container with sources, boundaries and other simulation objects
         config: Simulation configuration parameters
-        simulate_boundaries: Whether to apply PML boundary conditions
+        simulate_boundaries: Whether to apply boundary conditions
 
     Returns:
         Updated ArrayContainer with new E field values
     """
     boundary_states = {}
     if simulate_boundaries:
-        for pml in objects.pml_objects:
-            boundary_states[pml.name] = pml.update_E_boundary_state(
-                boundary_state=arrays.boundary_states[pml.name],
+        for boundary in objects.boundary_objects:
+            boundary_states[boundary.name] = boundary.update_E_boundary_state(
+                boundary_state=arrays.boundary_states[boundary.name],
                 H=arrays.H,
             )
 
-    E = arrays.E + config.courant_number * curl_H(arrays.H) * arrays.inv_permittivities
+    # Get periodic axes for curl operation
+    periodic_axes = get_periodic_axes(objects)
+    E = arrays.E + config.courant_number * curl_H(arrays.H, periodic_axes) * arrays.inv_permittivities
 
     for source in objects.sources:
 
@@ -60,10 +79,10 @@ def update_E(
         )
 
     if simulate_boundaries:
-        for pml in objects.pml_objects:
-            E = pml.update_E(
+        for boundary in objects.boundary_objects:
+            E = boundary.update_E(
                 E=E,
-                boundary_state=boundary_states[pml.name],
+                boundary_state=boundary_states[boundary.name],
                 inverse_permittivity=arrays.inv_permittivities,
             )
 
@@ -95,21 +114,6 @@ def update_E_reverse(
     Returns:
         Updated ArrayContainer with reversed E field values
     """
-    """Reverse time step update for the electric field used in automatic differentiation.
-
-    Implements the inverse update step that transforms the electromagnetic field state 
-    from time step t+1 to time step t, leveraging the time-reversibility property of
-    Maxwell's equations.
-
-    Args:
-        time_step: Current simulation time step
-        arrays: Container with E, H fields and material properties
-        objects: Container with sources and other simulation objects
-        config: Simulation configuration parameters
-
-    Returns:
-        Updated ArrayContainer with reversed E field values
-    """
     E = arrays.E
     for source in objects.sources:
 
@@ -128,7 +132,9 @@ def update_E_reverse(
             lambda: E,
         )
 
-    E = E - config.courant_number * curl_H(arrays.H) * arrays.inv_permittivities
+    # Get periodic axes for curl operation
+    periodic_axes = get_periodic_axes(objects)
+    E = E - config.courant_number * curl_H(arrays.H, periodic_axes) * arrays.inv_permittivities
 
     arrays = arrays.at["E"].set(E)
 
@@ -145,7 +151,7 @@ def update_H(
     """Updates the magnetic field (H) according to Maxwell's equations using the FDTD method.
 
     Implements the discretized form of dH/dt = -(1/μ)∇×E on the Yee grid. Updates include:
-    1. PML boundary conditions if simulate_boundaries=True
+    1. PML/periodic boundary conditions if simulate_boundaries=True
     2. Source contributions for active sources
     3. Field updates based on curl of E field
 
@@ -155,22 +161,24 @@ def update_H(
     Args:
         time_step: Current simulation time step
         arrays: Container with E, H fields and material properties
-        objects: Container with sources, PML and other simulation objects
+        objects: Container with sources, boundaries and other simulation objects
         config: Simulation configuration parameters
-        simulate_boundaries: Whether to apply PML boundary conditions
+        simulate_boundaries: Whether to apply boundary conditions
 
     Returns:
         Updated ArrayContainer with new H field values
     """
     boundary_states = {}
     if simulate_boundaries:
-        for pml in objects.pml_objects:
-            boundary_states[pml.name] = pml.update_H_boundary_state(
-                boundary_state=arrays.boundary_states[pml.name],
+        for boundary in objects.boundary_objects:
+            boundary_states[boundary.name] = boundary.update_H_boundary_state(
+                boundary_state=arrays.boundary_states[boundary.name],
                 E=arrays.E,
             )
 
-    H = arrays.H - config.courant_number * curl_E(arrays.E) * arrays.inv_permeabilities
+    # Get periodic axes for curl operation
+    periodic_axes = get_periodic_axes(objects)
+    H = arrays.H - config.courant_number * curl_E(arrays.E, periodic_axes) * arrays.inv_permeabilities
 
     for source in objects.sources:
 
@@ -190,10 +198,10 @@ def update_H(
         )
 
     if simulate_boundaries:
-        for pml in objects.pml_objects:
-            H = pml.update_H(
+        for boundary in objects.boundary_objects:
+            H = boundary.update_H(
                 H=H,
-                boundary_state=boundary_states[pml.name],
+                boundary_state=boundary_states[boundary.name],
                 inverse_permeability=arrays.inv_permeabilities,
             )
 
@@ -210,21 +218,6 @@ def update_H_reverse(
     objects: ObjectContainer,
     config: SimulationConfig,
 ) -> ArrayContainer:
-    """Reverse time step update for the magnetic field used in automatic differentiation.
-
-    Implements the inverse update step that transforms the electromagnetic field state
-    from time step t+1 to time step t, leveraging the time-reversibility property of
-    Maxwell's equations.
-
-    Args:
-        time_step: Current simulation time step
-        arrays: Container with E, H fields and material properties
-        objects: Container with sources and other simulation objects
-        config: Simulation configuration parameters
-
-    Returns:
-        Updated ArrayContainer with reversed H field values
-    """
     """Reverse time step update for the magnetic field used in automatic differentiation.
 
     Implements the inverse update step that transforms the electromagnetic field state
@@ -258,9 +251,12 @@ def update_H_reverse(
             lambda: H,
         )
 
-    H = H + config.courant_number * curl_E(arrays.E) * arrays.inv_permeabilities
+    # Get periodic axes for curl operation
+    periodic_axes = get_periodic_axes(objects)
+    H = H + config.courant_number * curl_E(arrays.E, periodic_axes) * arrays.inv_permeabilities
 
     arrays = arrays.at["H"].set(H)
+
     return arrays
 
 
@@ -288,26 +284,11 @@ def update_detector_states(
     Returns:
         Updated ArrayContainer with new detector states
     """
-    """Updates detector states based on current field values.
-
-    Handles field interpolation for accurate detector measurements. By default,
-    interpolation is disabled for performance during optimization, but can be
-    enabled for final evaluation. Interpolation is needed due to the staggered
-    nature of E and H fields on the Yee grid.
-
-    Args:
-        time_step: Current simulation time step
-        arrays: Container with E, H fields and material properties
-        objects: Container with detectors and other simulation objects
-        H_prev: Previous H field values for interpolation
-        inverse: Whether this is a forward or reverse update
-
-    Returns:
-        Updated ArrayContainer with new detector states
-    """
+    periodic_axes = get_periodic_axes(objects)
     interpolated_E, interpolated_H = interpolate_fields(
         E_field=arrays.E,
         H_field=(H_prev + arrays.H) / 2,
+        periodic_axes=periodic_axes,
     )
 
     def helper_fn(E_input, H_input, detector: Detector):
@@ -359,22 +340,6 @@ def collect_interfaces(
     Returns:
         Updated ArrayContainer with recorded interface values
     """
-    """Collects field values at PML interfaces for gradient computation.
-
-    Part of the memory-efficient automatic differentiation implementation.
-    Saves field values at boundaries between PML and inner simulation volume
-    since PML updates are not time-reversible.
-
-    Args:
-        time_step: Current simulation time step
-        arrays: Container with fields and material properties
-        objects: Container with PML and other simulation objects
-        config: Simulation configuration with gradient settings
-        key: Random key for compression
-
-    Returns:
-        Updated ArrayContainer with recorded interface values
-    """
     if config.gradient_config is None or config.gradient_config.recorder is None:
         raise Exception("Need recorder to record boundaries")
     if arrays.recording_state is None:
@@ -400,22 +365,6 @@ def add_interfaces(
     config: SimulationConfig,
     key: jax.Array,
 ) -> ArrayContainer:
-    """Adds previously collected interface values back to the fields.
-
-    Part of the memory-efficient automatic differentiation implementation.
-    Restores saved field values at PML boundaries during reverse propagation
-    since PML updates are not time-reversible.
-
-    Args:
-        time_step: Current simulation time step
-        arrays: Container with fields and material properties
-        objects: Container with PML and other simulation objects
-        config: Simulation configuration with gradient settings
-        key: Random key for decompression
-
-    Returns:
-        Updated ArrayContainer with restored interface values
-    """
     """Adds previously collected interface values back to the fields.
 
     Part of the memory-efficient automatic differentiation implementation.

--- a/src/fdtdx/objects/boundaries/periodic.py
+++ b/src/fdtdx/objects/boundaries/periodic.py
@@ -1,0 +1,310 @@
+from typing import Literal
+
+import jax
+import jax.numpy as jnp
+import pytreeclass as tc
+
+from fdtdx.core.jax.typing import GridShape3D, Slice3D, SliceTuple3D
+from fdtdx.core.plotting.colors import LIGHT_BLUE
+from fdtdx.objects.material import NoMaterial
+
+
+@tc.autoinit
+class PeriodicBoundaryState(tc.TreeClass):
+    """State container for periodic boundary conditions.
+
+    Stores the field values at the opposite boundary for periodic wrapping.
+
+    Attributes:
+        E_opposite: Electric field values from opposite boundary
+        H_opposite: Magnetic field values from opposite boundary
+    """
+
+    E_opposite: jax.Array
+    H_opposite: jax.Array
+
+
+@tc.autoinit
+class PeriodicBoundary(NoMaterial):
+    """Implements periodic boundary conditions.
+
+    The periodic boundary connects opposite sides of the simulation domain,
+    making waves that exit one side reenter from the opposite side.
+
+    Attributes:
+        axis: Principal axis for periodicity (0=x, 1=y, 2=z)
+        direction: Direction along axis ("+" or "-")
+        color: RGB color tuple for visualization
+    """
+
+    axis: int = tc.field(init=True, kind="KW_ONLY")  # type: ignore
+    direction: Literal["+", "-"] = tc.field(  # type: ignore
+        init=True,
+        kind="KW_ONLY",
+        on_getattr=[tc.unfreeze],
+        on_setattr=[tc.freeze],
+    )
+    color: tuple[float, float, float] = LIGHT_BLUE
+
+    @property
+    def descriptive_name(self) -> str:
+        """Gets a human-readable name describing this periodic boundary's location.
+
+        Returns:
+            str: Description like "min_x" or "max_z" indicating position
+        """
+        axis_str = "x" if self.axis == 0 else "y" if self.axis == 1 else "z"
+        direction_str = "min" if self.direction == "-" else "max"
+        return f"{direction_str}_{axis_str}"
+
+    @property
+    def thickness(self) -> int:
+        """Gets the thickness of the periodic boundary layer in grid points.
+
+        Returns:
+            int: Number of grid points in the boundary layer (always 1 for periodic)
+        """
+        return 1
+
+    def init_state(
+        self,
+    ) -> PeriodicBoundaryState:
+        """Initializes the periodic boundary state.
+
+        Creates storage for field values from opposite boundary needed for
+        periodic wrapping.
+
+        Returns:
+            PeriodicBoundaryState: Initialized state container
+        """
+        dtype = self._config.dtype
+        ext_shape = (3,) + self.grid_shape
+
+        boundary_state = PeriodicBoundaryState(
+            E_opposite=jnp.zeros(shape=ext_shape, dtype=dtype),
+            H_opposite=jnp.zeros(shape=ext_shape, dtype=dtype),
+        )
+        return boundary_state
+
+    def reset_state(self, state: PeriodicBoundaryState) -> PeriodicBoundaryState:
+        """Resets the periodic boundary state.
+
+        Args:
+            state: Current boundary state to reset
+
+        Returns:
+            PeriodicBoundaryState: New state with zeroed fields
+        """
+        new_state = PeriodicBoundaryState(
+            E_opposite=state.E_opposite * 0,
+            H_opposite=state.H_opposite * 0,
+        )
+        return new_state
+
+    def boundary_interface_grid_shape(self) -> GridShape3D:
+        """Gets the shape of the periodic boundary interface.
+
+        Returns:
+            GridShape3D: 3D shape tuple with 1 in the periodic axis dimension
+        """
+        if self.axis == 0:
+            return 1, self.grid_shape[1], self.grid_shape[2]
+        elif self.axis == 1:
+            return self.grid_shape[0], 1, self.grid_shape[2]
+        elif self.axis == 2:
+            return self.grid_shape[0], self.grid_shape[1], 1
+        raise Exception(f"Invalid axis: {self.axis=}")
+
+    def boundary_interface_slice_tuple(self) -> SliceTuple3D:
+        """Gets the slice tuple for accessing the periodic boundary interface.
+
+        Returns:
+            SliceTuple3D: Tuple of slices defining the interface boundary
+        """
+        slice_list = [*self._grid_slice_tuple]
+        if self.direction == "+":
+            slice_list[self.axis] = (self._grid_slice_tuple[self.axis][0], self._grid_slice_tuple[self.axis][0] + 1)
+        elif self.direction == "-":
+            slice_list[self.axis] = (self._grid_slice_tuple[self.axis][1] - 1, self._grid_slice_tuple[self.axis][1])
+        return slice_list[0], slice_list[1], slice_list[2]
+
+    def boundary_interface_slice(self) -> Slice3D:
+        """Gets the slice object for accessing the periodic boundary interface.
+
+        Returns:
+            Slice3D: Slice object defining the interface boundary
+        """
+        slice_list = [*self.grid_slice]
+        if self.direction == "+":
+            slice_list[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][0], self._grid_slice_tuple[self.axis][0] + 1
+            )
+        elif self.direction == "-":
+            slice_list[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][1] - 1, self._grid_slice_tuple[self.axis][1]
+            )
+        return slice_list[0], slice_list[1], slice_list[2]
+
+    def update_E_boundary_state(
+        self,
+        boundary_state: PeriodicBoundaryState,
+        H: jax.Array,
+    ) -> PeriodicBoundaryState:
+        """Updates the periodic boundary state for electric field.
+
+        Stores both E and H field values from the opposite boundary for periodic wrapping.
+
+        Args:
+            boundary_state: Current boundary state
+            H: Magnetic field array
+
+        Returns:
+            PeriodicBoundaryState: Updated boundary state
+        """
+        # Get field values from opposite boundary
+        opposite_slice = list(self.grid_slice)
+        if self.direction == "+":
+            opposite_slice[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][1] - 1, self._grid_slice_tuple[self.axis][1]
+            )
+        else:
+            opposite_slice[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][0], self._grid_slice_tuple[self.axis][0] + 1
+            )
+
+        # Store H field values from opposite boundary
+        H_opposite = jnp.array(H[..., opposite_slice[0], opposite_slice[1], opposite_slice[2]])
+
+        return PeriodicBoundaryState(
+            E_opposite=boundary_state.E_opposite,  # Keep existing E values
+            H_opposite=H_opposite,  # Update H values
+        )
+
+    def update_H_boundary_state(
+        self,
+        boundary_state: PeriodicBoundaryState,
+        E: jax.Array,
+    ) -> PeriodicBoundaryState:
+        """Updates the periodic boundary state for magnetic field.
+
+        Stores both E and H field values from the opposite boundary for periodic wrapping.
+
+        Args:
+            boundary_state: Current boundary state
+            E: Electric field array
+
+        Returns:
+            PeriodicBoundaryState: Updated boundary state
+        """
+        # Get field values from opposite boundary
+        opposite_slice = list(self.grid_slice)
+        if self.direction == "+":
+            opposite_slice[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][1] - 1, self._grid_slice_tuple[self.axis][1]
+            )
+        else:
+            opposite_slice[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][0], self._grid_slice_tuple[self.axis][0] + 1
+            )
+
+        # Store E field values from opposite boundary
+        E_opposite = jnp.array(E[..., opposite_slice[0], opposite_slice[1], opposite_slice[2]])
+
+        return PeriodicBoundaryState(
+            E_opposite=E_opposite,  # Update E values
+            H_opposite=boundary_state.H_opposite,  # Keep existing H values
+        )
+
+    def update_E(
+        self,
+        E: jax.Array,
+        boundary_state: PeriodicBoundaryState,
+        inverse_permittivity: jax.Array,
+    ) -> jax.Array:
+        """Updates the electric field at the periodic boundary.
+
+        Applies periodic boundary conditions by copying field values from the
+        opposite boundary, maintaining field continuity.
+
+        Args:
+            E: Electric field array to update
+            boundary_state: Current boundary state
+            inverse_permittivity: Inverse permittivity array
+
+        Returns:
+            jax.Array: Updated electric field array
+        """
+        # Get the boundary slice
+        boundary_slice = list(self.grid_slice)
+        if self.direction == "+":
+            boundary_slice[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][0], self._grid_slice_tuple[self.axis][0] + 1
+            )
+            # Copy from opposite boundary (last slice)
+            opposite_slice = list(self.grid_slice)
+            opposite_slice[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][1] - 1, self._grid_slice_tuple[self.axis][1]
+            )
+        else:
+            boundary_slice[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][1] - 1, self._grid_slice_tuple[self.axis][1]
+            )
+            # Copy from opposite boundary (first slice)
+            opposite_slice = list(self.grid_slice)
+            opposite_slice[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][0], self._grid_slice_tuple[self.axis][0] + 1
+            )
+
+        # Copy field values from opposite boundary
+        E = E.at[..., boundary_slice[0], boundary_slice[1], boundary_slice[2]].set(
+            E[..., opposite_slice[0], opposite_slice[1], opposite_slice[2]]
+        )
+
+        return E
+
+    def update_H(
+        self,
+        H: jax.Array,
+        boundary_state: PeriodicBoundaryState,
+        inverse_permeability: jax.Array,
+    ) -> jax.Array:
+        """Updates the magnetic field at the periodic boundary.
+
+        Applies periodic boundary conditions by copying field values from the
+        opposite boundary, maintaining field continuity.
+
+        Args:
+            H: Magnetic field array to update
+            boundary_state: Current boundary state
+            inverse_permeability: Inverse permeability array
+
+        Returns:
+            jax.Array: Updated magnetic field array
+        """
+        # Get the boundary slice
+        boundary_slice = list(self.grid_slice)
+        if self.direction == "+":
+            boundary_slice[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][0], self._grid_slice_tuple[self.axis][0] + 1
+            )
+            # Copy from opposite boundary (last slice)
+            opposite_slice = list(self.grid_slice)
+            opposite_slice[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][1] - 1, self._grid_slice_tuple[self.axis][1]
+            )
+        else:
+            boundary_slice[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][1] - 1, self._grid_slice_tuple[self.axis][1]
+            )
+            # Copy from opposite boundary (first slice)
+            opposite_slice = list(self.grid_slice)
+            opposite_slice[self.axis] = slice(
+                self._grid_slice_tuple[self.axis][0], self._grid_slice_tuple[self.axis][0] + 1
+            )
+
+        # Copy field values from opposite boundary
+        H = H.at[..., boundary_slice[0], boundary_slice[1], boundary_slice[2]].set(
+            H[..., opposite_slice[0], opposite_slice[1], opposite_slice[2]]
+        )
+
+        return H

--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -55,7 +55,7 @@ def plot_from_slices(
     if device_pixel_ratio != 1:
         width = int(width * device_pixel_ratio)
         height = int(height * device_pixel_ratio)
-    
+
     try:
         data = np.frombuffer(fig.canvas.buffer_rgba(), dtype=np.uint8)  # type: ignore
         data = data.reshape(height, width, 4)

--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -49,8 +49,13 @@ def plot_from_slices(
     )
     # Convert matplotlib figure to a numpy array
     fig.canvas.draw()
-    # Get the canvas dimensions
+    # Get the canvas dimensions, accounting for device pixel ratio
     width, height = fig.canvas.get_width_height()
+    device_pixel_ratio = fig.canvas.device_pixel_ratio
+    if device_pixel_ratio != 1:
+        width = int(width * device_pixel_ratio)
+        height = int(height * device_pixel_ratio)
+    
     try:
         data = np.frombuffer(fig.canvas.buffer_rgba(), dtype=np.uint8)  # type: ignore
         data = data.reshape(height, width, 4)

--- a/src/fdtdx/objects/initialization.py
+++ b/src/fdtdx/objects/initialization.py
@@ -241,18 +241,18 @@ def _init_arrays(
 
     # boundary states
     boundary_states = {}
-    for pml in objects.pml_objects:
-        boundary_states[pml.name] = pml.init_state()
+    for boundary in objects.boundary_objects:
+        boundary_states[boundary.name] = boundary.init_state()
 
     # interfaces
     recording_state = None
     if config.gradient_config is not None and config.gradient_config.recorder is not None:
         input_shape_dtypes = {}
-        for pml in objects.pml_objects:
-            cur_shape = pml.boundary_interface_grid_shape()
+        for boundary in objects.boundary_objects:
+            cur_shape = boundary.boundary_interface_grid_shape()
             extended_shape = (3, *cur_shape)
-            input_shape_dtypes[f"{pml.name}_E"] = jax.ShapeDtypeStruct(shape=extended_shape, dtype=config.dtype)
-            input_shape_dtypes[f"{pml.name}_H"] = jax.ShapeDtypeStruct(shape=extended_shape, dtype=config.dtype)
+            input_shape_dtypes[f"{boundary.name}_E"] = jax.ShapeDtypeStruct(shape=extended_shape, dtype=config.dtype)
+            input_shape_dtypes[f"{boundary.name}_H"] = jax.ShapeDtypeStruct(shape=extended_shape, dtype=config.dtype)
         recorder = config.gradient_config.recorder
         recorder, recording_state = recorder.init_state(
             input_shape_dtypes=input_shape_dtypes,

--- a/src/fdtdx/shared/plot_setup.py
+++ b/src/fdtdx/shared/plot_setup.py
@@ -5,6 +5,7 @@ from matplotlib.patches import Patch, Rectangle
 
 from fdtdx.core.config import SimulationConfig
 from fdtdx.objects.boundaries.perfectly_matched_layer import PerfectlyMatchedLayer
+from fdtdx.objects.boundaries.periodic import PeriodicBoundary
 from fdtdx.objects.container import ObjectContainer
 from fdtdx.objects.object import SimulationObject
 
@@ -44,9 +45,9 @@ def plot_setup(
         The plots show object positions in micrometers, converting from simulation units.
         PML objects are automatically excluded from their respective boundary planes.
     """
-    # add pml to exclude lists
+    # add boundaries to exclude lists
     for o in objects.objects:
-        if not isinstance(o, PerfectlyMatchedLayer):
+        if not isinstance(o, (PerfectlyMatchedLayer, PeriodicBoundary)):
             continue
         if o.axis == 0:
             exclude_yz_plane_object_list.append(o)
@@ -109,6 +110,7 @@ def plot_setup(
                     (slices[1][1] - slices[1][0]) * resolution,
                     color=color,
                     alpha=0.5,
+                    linestyle="--" if isinstance(obj, PeriodicBoundary) else "-",
                 )
             )
 
@@ -121,6 +123,7 @@ def plot_setup(
                     (slices[2][1] - slices[2][0]) * resolution,
                     color=color,
                     alpha=0.5,
+                    linestyle="--" if isinstance(obj, PeriodicBoundary) else "-",
                 )
             )
 
@@ -133,24 +136,26 @@ def plot_setup(
                     (slices[2][1] - slices[2][0]) * resolution,
                     color=color,
                     alpha=0.5,
+                    linestyle="--" if isinstance(obj, PeriodicBoundary) else "-",
                 )
             )
 
+    # Set labels and titles
+    axs[0].set_xlabel("x (µm)")
+    axs[0].set_ylabel("y (µm)")
     axs[0].set_title("XY plane")
-    axs[0].set_xlabel("X axis (µm)")
-    axs[0].set_ylabel("Y axis (µm)")
     axs[0].set_xlim([0, volume.grid_shape[0] * resolution])
     axs[0].set_ylim([0, volume.grid_shape[1] * resolution])
 
+    axs[1].set_xlabel("x (µm)")
+    axs[1].set_ylabel("z (µm)")
     axs[1].set_title("XZ plane")
-    axs[1].set_xlabel("X axis (µm)")
-    axs[1].set_ylabel("Z axis (µm)")
     axs[1].set_xlim([0, volume.grid_shape[0] * resolution])
     axs[1].set_ylim([0, volume.grid_shape[2] * resolution])
 
+    axs[2].set_xlabel("y (µm)")
+    axs[2].set_ylabel("z (µm)")
     axs[2].set_title("YZ plane")
-    axs[2].set_xlabel("Y axis (µm)")
-    axs[2].set_ylabel("Z axis (µm)")
     axs[2].set_xlim([0, volume.grid_shape[1] * resolution])
     axs[2].set_ylim([0, volume.grid_shape[2] * resolution])
 
@@ -160,7 +165,6 @@ def plot_setup(
         ax.grid(True)
 
     if filename is not None:
-        plt.tight_layout()
-        plt.savefig(filename, dpi=300)
+        plt.savefig(filename, bbox_inches="tight", dpi=300)
         plt.close()
     return plt.gcf() if fig is None else fig


### PR DESCRIPTION
Implemented periodic boundary condition that wraps around the boundaries. Can be applies to any pair of xyz planes.

Bug fix for plotting on Mac that has DPI scaling