### PR TITLE
Continuous Device in addition to discrete device

### DIFF
--- a/docs/tutorials/constraint_mapping.md
+++ b/docs/tutorials/constraint_mapping.md
@@ -3,14 +3,14 @@
 When using inverse design with FDTDX, fabrication constraints have to be specified. The basic building block for an object optimizable by inverse design is a Device:
 
 ```python
-from fdtdx.objects.multi_material.device import Device
+from fdtdx.objects.multi_material.device import DiscreteDevice
 from fdtdx.core.physics import constants
 
 permittivity_config = {
     "Air": constants.relative_permittivity_air,
     "Polymer": constants.relative_permittivity_ma_N_1400_series,
 }
-device_scatter = Device(
+device_scatter = DiscreteDevice(
     name="Device",
     partial_real_shape=(1e-6, 1e-6, 1e-6),
     permittivity_config=permittivity_config,

--- a/examples/optimize_ceviche_corner.py
+++ b/examples/optimize_ceviche_corner.py
@@ -30,7 +30,7 @@ from fdtdx.objects.detectors.energy import EnergyDetector
 from fdtdx.objects.detectors.poynting_flux import PoyntingFluxDetector
 from fdtdx.objects.initialization import apply_params, place_objects
 from fdtdx.objects.material import SimulationVolume, Substrate, WaveGuide
-from fdtdx.objects.multi_material.device import Device
+from fdtdx.objects.multi_material.device import DiscreteDevice
 from fdtdx.objects.object import SimulationObject
 from fdtdx.objects.sources.plane_source import ModePlaneSource
 from fdtdx.shared.logger import Logger
@@ -127,7 +127,7 @@ def main(
         ),
         IndicesToInversePermittivities(),
     ]
-    device = Device(
+    device = DiscreteDevice(
         name="Device",
         partial_real_shape=(1.6e-6, 1.6e-6, height),
         permittivity_config=permittivity_config,
@@ -408,7 +408,7 @@ def main(
                 ),
             )
             new_object_list = [
-                o if not isinstance(o, Device) else o.aset("constraint_mapping", new_constraints)
+                o if not isinstance(o, DiscreteDevice) else o.aset("constraint_mapping", new_constraints)
                 for o in objects.objects
             ]
             objects = objects.aset("object_list", new_object_list)

--- a/examples/optimize_vertical_polymer_coupler.py
+++ b/examples/optimize_vertical_polymer_coupler.py
@@ -33,7 +33,7 @@ from fdtdx.objects.detectors.energy import EnergyDetector
 from fdtdx.objects.detectors.poynting_flux import PoyntingFluxDetector
 from fdtdx.objects.initialization import apply_params, place_objects
 from fdtdx.objects.material import SimulationVolume, Substrate, WaveGuide
-from fdtdx.objects.multi_material.device import Device
+from fdtdx.objects.multi_material.device import DiscreteDevice
 from fdtdx.objects.object import SimulationObject
 from fdtdx.objects.sources.plane_source import GaussianPlaneSource
 from fdtdx.shared.logger import Logger
@@ -174,7 +174,7 @@ def main(
             ]
         )
 
-    device = Device(
+    device = DiscreteDevice(
         name="Device",
         permittivity_config=permittivity_config,
         partial_real_shape=(25.0e-6, 25.0e-6, device_z),

--- a/examples/optimize_vertical_silicon_coupler.py
+++ b/examples/optimize_vertical_silicon_coupler.py
@@ -23,7 +23,7 @@ from fdtdx.objects.detectors.energy import EnergyDetector
 from fdtdx.objects.detectors.poynting_flux import PoyntingFluxDetector
 from fdtdx.objects.initialization import apply_params, place_objects
 from fdtdx.objects.material import SimulationVolume, Substrate, WaveGuide
-from fdtdx.objects.multi_material.device import Device
+from fdtdx.objects.multi_material.device import DiscreteDevice
 from fdtdx.objects.object import SimulationObject
 from fdtdx.objects.sources.plane_source import ConstantAmplitudePlaneSource
 from fdtdx.shared.logger import Logger
@@ -153,7 +153,7 @@ def main(
         "Air": constants.relative_permittivity_air,
         "Silicon": permittivity_silicon,
     }
-    device = Device(
+    device = DiscreteDevice(
         name="Device",
         partial_real_shape=(3e-6, 3e-6, 300e-9),
         permittivity_config=permittivity_config,

--- a/examples/optimize_waveguide_stitching.py
+++ b/examples/optimize_waveguide_stitching.py
@@ -24,7 +24,7 @@ from fdtdx.objects.detectors.energy import EnergyDetector
 from fdtdx.objects.detectors.poynting_flux import PoyntingFluxDetector
 from fdtdx.objects.initialization import apply_params, place_objects
 from fdtdx.objects.material import SimulationVolume, Substrate, WaveGuide
-from fdtdx.objects.multi_material.device import Device
+from fdtdx.objects.multi_material.device import DiscreteDevice
 from fdtdx.objects.object import SimulationObject
 from fdtdx.objects.sources.plane_source import ModePlaneSource
 from fdtdx.shared.logger import Logger
@@ -121,7 +121,7 @@ def main(
         "Air": constants.relative_permittivity_air,
         "Polymer": constants.relative_permittivity_ma_N_1400_series,
     }
-    device_scatter = Device(
+    device_scatter = DiscreteDevice(
         name="Device-Scatter",
         partial_real_shape=(device_x, device_width, device_height),
         permittivity_config=permittivity_config,
@@ -158,7 +158,7 @@ def main(
         ]
     )
 
-    device_gather = Device(
+    device_gather = DiscreteDevice(
         name="Device-Gather",
         partial_real_shape=(device_x, device_width, device_height),
         permittivity_config=permittivity_config,

--- a/examples/speed_benchmark.py
+++ b/examples/speed_benchmark.py
@@ -28,7 +28,7 @@ from fdtdx.objects.detectors.energy import EnergyDetector
 from fdtdx.objects.detectors.poynting_flux import PoyntingFluxDetector
 from fdtdx.objects.initialization import apply_params, place_objects
 from fdtdx.objects.material import SimulationVolume, Substrate, WaveGuide
-from fdtdx.objects.multi_material.device import Device
+from fdtdx.objects.multi_material.device import DiscreteDevice
 from fdtdx.objects.object import SimulationObject
 from fdtdx.objects.sources.plane_source import ConstantAmplitudePlaneSource
 from fdtdx.shared.logger import Logger
@@ -144,7 +144,7 @@ def main(
         "Silicon": permittivity_silicon,
     }
     
-    device = Device(
+    device = DiscreteDevice(
         name="Device",
         partial_real_shape=(3e-6, 3e-6, 300e-9),
         permittivity_config=permittivity_config,

--- a/src/fdtdx/constraints/module.py
+++ b/src/fdtdx/constraints/module.py
@@ -307,21 +307,21 @@ class ContinuousPermittivityTransition(ConstraintModule):
             raise Exception(
                 f"ContinuousPermittivityTransition only works with exactly 2 materials, got {len(self._allowed_permittivities)}"
             )
-            
+
         result = {}
         for k, v in input_params.items():
             # Scale input to [0, 1] range for interpolation
             v_scaled = (v - v.min()) / (v.max() - v.min())
-            
+
             # Get permittivity values for interpolation
             lower_perm = self._allowed_permittivities[0]
             upper_perm = self._allowed_permittivities[1]
-            
+
             # Interpolate in permittivity domain
             interpolated_perms = (1 - v_scaled) * lower_perm + v_scaled * upper_perm
-            
+
             # Convert to inverse permittivity
             interpolated_inv_perms = 1.0 / interpolated_perms
-            
+
             result[k] = interpolated_inv_perms.astype(self._config.dtype)
         return result

--- a/src/fdtdx/objects/container.py
+++ b/src/fdtdx/objects/container.py
@@ -15,7 +15,7 @@ from fdtdx.interfaces.state import RecordingState
 from fdtdx.objects.boundaries.perfectly_matched_layer import BoundaryState, PerfectlyMatchedLayer
 from fdtdx.objects.boundaries.periodic import PeriodicBoundary, PeriodicBoundaryState
 from fdtdx.objects.detectors.detector import Detector, DetectorState
-from fdtdx.objects.multi_material.device import Device
+from fdtdx.objects.multi_material.device import BaseDevice
 from fdtdx.objects.object import SimulationObject
 from fdtdx.objects.sources.source import Source
 
@@ -49,15 +49,15 @@ class ObjectContainer(ExtendedTreeClass):
 
     @property
     def static_material_objects(self) -> list[SimulationObject]:
-        return [o for o in self.objects if not isinstance(o, Device)]
+        return [o for o in self.objects if not isinstance(o, BaseDevice)]
 
     @property
     def sources(self) -> list[Source]:
         return [o for o in self.objects if isinstance(o, Source)]
 
     @property
-    def devices(self) -> list[Device]:
-        return [o for o in self.objects if isinstance(o, Device)]
+    def devices(self) -> list[BaseDevice]:
+        return [o for o in self.objects if isinstance(o, BaseDevice)]
 
     @property
     def detectors(self) -> list[Detector]:

--- a/src/fdtdx/objects/initialization.py
+++ b/src/fdtdx/objects/initialization.py
@@ -439,7 +439,7 @@ def _resolve_object_constraints(
                         resolved_something = True
                     elif slice_dict[o][axis][b_idx] != cur_size:
                         raise Exception(
-                            f"Inconsisten grid coordinates for object: "
+                            f"Inconsistent grid coordinates for object: "
                             f"{slice_dict[o][axis][b_idx]} != {cur_size} for {axis=} {o.name} ({o.__class__}). "
                         )
             # absolute real coordinate constraints
@@ -453,7 +453,7 @@ def _resolve_object_constraints(
                         resolved_something = True
                     elif slice_dict[o][axis][b_idx] != cur_size:
                         raise Exception(
-                            f"Inconsisten grid coordinates for object: "
+                            f"Inconsistent grid coordinates for object: "
                             f"{slice_dict[o][axis][b_idx]} != {cur_size} for {axis=} {o.name} ({o.__class__}). "
                         )
             # size constraints
@@ -479,7 +479,7 @@ def _resolve_object_constraints(
                         resolved_something = True
                     elif shape_dict[o][axis] != object_shape:
                         raise Exception(
-                            "Inconsisten grid shape for object: ",
+                            "Inconsistent grid shape for object: ",
                             f"{shape_dict[o][axis]} != {object_shape} for {axis=}, {o.name} ({o.__class__}). ",
                             "Please check if there are multiple constraints or sizes specified for the object.",
                         )
@@ -521,7 +521,7 @@ def _resolve_object_constraints(
                         resolved_something = True
                     elif old_b0 != b0:
                         raise Exception(
-                            f"Inconsisten grid shape (may be due to extension to infinity) at lower bound: "
+                            f"Inconsistent grid shape (may be due to extension to infinity) at lower bound: "
                             f"{old_b0} != {b0} for {axis=}, {o.name} ({o.__class__}). "
                             f"Object has a position constraint that puts the lower boundary at {b0}, "
                             f"but the lower bound was alreay computed to be at {old_b0}. "
@@ -534,7 +534,7 @@ def _resolve_object_constraints(
                         resolved_something = True
                     elif old_b1 != b1:
                         raise Exception(
-                            f"Inconsisten grid shape (may be due to extension to infinity) at lower bound: "
+                            f"Inconsistent grid shape (may be due to extension to infinity) at lower bound: "
                             f"{old_b1} != {b1} for {axis=}, {o.name} ({o.__class__}). "
                             f"Object has a position constraint that puts the upper boundary at {b1}, "
                             f"but the lower bound was alreay computed to be at {old_b1}. "
@@ -573,7 +573,7 @@ def _resolve_object_constraints(
                     resolved_something = True
                 elif old_val != other_anchor:
                     raise Exception(
-                        f"Inconsisten grid shape at bound {c.direction}: "
+                        f"Inconsistent grid shape at bound {c.direction}: "
                         f"{old_val} != {other_anchor} for {axis=}, "
                         f"{o.name} ({o.__class__})."
                     )

--- a/src/fdtdx/objects/multi_material/device.py
+++ b/src/fdtdx/objects/multi_material/device.py
@@ -2,9 +2,14 @@ from typing import Self
 
 import jax
 import jax.numpy as jnp
+from abc import ABC, abstractmethod
 
 from fdtdx.constraints.mapping import ConstraintMapping
-from fdtdx.constraints.module import ConstraintInterface
+from fdtdx.constraints.module import (
+    ConstraintInterface,
+    ContinuousPermittivityTransition,
+    StandardToInversePermittivityRange,
+)
 from fdtdx.core.config import SimulationConfig
 from fdtdx.core.jax.pytrees import extended_autoinit, frozen_field
 from fdtdx.core.jax.typing import SliceTuple3D
@@ -14,13 +19,112 @@ from fdtdx.objects.multi_material.multi_material import MultiMaterial
 
 
 @extended_autoinit
-class Device(MultiMaterial):
-    """Object with an array of permittivities that can be optimized.
+class BaseDevice(MultiMaterial, ABC):
+    """Abstract base class for devices with optimizable permittivity distributions.
 
-    A Device represents a simulation object whose permittivity distribution can be
-    optimized through gradient-based methods. The permittivity values are controlled
-    by parameters that are mapped through constraints to produce the final device
-    structure.
+    This class defines the common interface and functionality for both discrete and
+    continuous devices that can be optimized through gradient-based methods.
+
+    Attributes:
+        name: Optional name identifier for the device
+        dtype: Data type for device parameters, defaults to float32
+        color: RGB color tuple for visualization, defaults to pink
+    """
+
+    name: str = frozen_field(default=None, kind="KW_ONLY")  # type: ignore
+    dtype: jnp.dtype = frozen_field(
+        default=jnp.float32,
+        kind="KW_ONLY",
+    )
+    color: tuple[float, float, float] = frozen_field(default=PINK)
+
+    @abstractmethod
+    def place_on_grid(
+        self: Self,
+        grid_slice_tuple: SliceTuple3D,
+        config: SimulationConfig,
+        key: jax.Array,
+    ) -> Self:
+        """Places the device on the simulation grid and initializes constraints.
+
+        Args:
+            grid_slice_tuple: Tuple of slices defining device position on grid
+            config: Simulation configuration parameters
+            key: JAX random key for initialization
+
+        Returns:
+            Self with updated grid position and initialized constraint mapping
+        """
+        return super().place_on_grid(
+            grid_slice_tuple=grid_slice_tuple,
+            config=config,
+            key=key,
+        )
+
+    @abstractmethod
+    def init_params(
+        self,
+        key: jax.Array,
+    ) -> dict[str, jax.Array]:
+        """Initializes optimization parameters for the device.
+
+        Args:
+            key: JAX random key for parameter initialization
+
+        Returns:
+            Dictionary mapping parameter names to their initial values
+        """
+        pass
+
+    @abstractmethod
+    def get_inv_permittivity(
+        self,
+        prev_inv_permittivity: jax.Array,
+        params: dict[str, jax.Array] | None,
+    ) -> tuple[jax.Array, dict]:
+        """Computes inverse permittivity distribution from optimization parameters.
+
+        Args:
+            prev_inv_permittivity: Previous inverse permittivity values
+            params: Dictionary of optimization parameters
+
+        Returns:
+            Tuple containing:
+                - Array of inverse permittivity values
+                - Dictionary with additional computation info
+        """
+        pass
+
+    def get_inv_permeability(
+        self,
+        prev_inv_permeability: jax.Array,
+        params: dict[str, jax.Array] | None,
+    ) -> tuple[jax.Array, dict]:
+        """Returns unchanged inverse permeability values.
+
+        Device optimization only modifies permittivity, not permeability.
+
+        Args:
+            prev_inv_permeability: Previous inverse permeability values
+            params: Device parameters (unused)
+
+        Returns:
+            Tuple containing:
+                - Unchanged inverse permeability array
+                - Empty info dictionary
+        """
+        del params
+        return prev_inv_permeability, {}
+
+
+@extended_autoinit
+class DiscreteDevice(BaseDevice):
+    """A device with discrete material states.
+
+    This class represents a simulation object whose permittivity distribution can be
+    optimized through gradient-based methods, with discrete transitions between materials.
+    The permittivity values are controlled by parameters that are mapped through constraints
+    to produce the final device structure.
 
     Attributes:
         name: Optional name identifier for the device
@@ -29,13 +133,7 @@ class Device(MultiMaterial):
         color: RGB color tuple for visualization, defaults to pink
     """
 
-    name: str = frozen_field(default=None, kind="KW_ONLY")  # type: ignore
     constraint_mapping: ConstraintMapping = frozen_field(kind="KW_ONLY")  # type: ignore
-    dtype: jnp.dtype = frozen_field(
-        default=jnp.float32,
-        kind="KW_ONLY",
-    )
-    color: tuple[float, float, float] = frozen_field(default=PINK)
 
     def place_on_grid(
         self: Self,
@@ -102,7 +200,7 @@ class Device(MultiMaterial):
         self,
         prev_inv_permittivity: jax.Array,
         params: dict[str, jax.Array] | None,
-    ) -> tuple[jax.Array, dict]:  # permittivity and info dict
+    ) -> tuple[jax.Array, dict]:
         """Computes inverse permittivity distribution from optimization parameters.
 
         Maps the optimization parameters through constraints to produce the final
@@ -131,27 +229,6 @@ class Device(MultiMaterial):
         )
         return extended_params, {}
 
-    def get_inv_permeability(
-        self,
-        prev_inv_permeability: jax.Array,
-        params: dict[str, jax.Array] | None,
-    ) -> tuple[jax.Array, dict]:  # permeability and info dict
-        """Returns unchanged inverse permeability values.
-
-        Device optimization only modifies permittivity, not permeability.
-
-        Args:
-            prev_inv_permeability: Previous inverse permeability values
-            params: Device parameters (unused)
-
-        Returns:
-            Tuple containing:
-                - Unchanged inverse permeability array
-                - Empty info dictionary
-        """
-        del params
-        return prev_inv_permeability, {}
-
     def get_indices(
         self,
         params: dict[str, jax.Array],
@@ -172,3 +249,183 @@ class Device(MultiMaterial):
         raw_indices = jnp.arange(len(self.allowed_inverse_permittivities))[None, None, None, :]
         indices_3d = (index_mask * raw_indices).sum(axis=-1)
         return indices_3d
+
+
+@extended_autoinit
+class ContinuousDevice(BaseDevice):
+    """A device that supports continuous transitions between materials.
+
+    This class represents a simulation object whose permittivity distribution can be
+    optimized with continuous transitions between different materials. The permittivity
+    values are controlled by parameters that are mapped through constraints to produce
+    the final device structure with smooth material transitions.
+
+    Attributes:
+        name: Optional name identifier for the device
+        dtype: Data type for device parameters, defaults to float32
+        color: RGB color tuple for visualization, defaults to pink
+    """
+
+    name: str = frozen_field(default=None, kind="KW_ONLY")  # type: ignore
+    dtype: jnp.dtype = frozen_field(
+        default=jnp.float32,
+        kind="KW_ONLY",
+    )
+    color: tuple[float, float, float] = frozen_field(default=PINK)
+
+    def place_on_grid(
+        self: Self,
+        grid_slice_tuple: SliceTuple3D,
+        config: SimulationConfig,
+        key: jax.Array,
+    ) -> Self:
+        """Places the device on the simulation grid and initializes constraints.
+
+        Args:
+            grid_slice_tuple: Tuple of slices defining device position on grid
+            config: Simulation configuration parameters
+            key: JAX random key for initialization
+
+        Returns:
+            Self with updated grid position and initialized constraint mapping
+        """
+        self = super().place_on_grid(
+            grid_slice_tuple=grid_slice_tuple,
+            config=config,
+            key=key,
+        )
+
+        # Create constraint mapping for continuous material transitions
+        constraint_mapping = ConstraintMapping(
+            modules=[
+                StandardToInversePermittivityRange(),
+                ContinuousPermittivityTransition(),
+            ]
+        )
+
+        # Initialize the constraint mapping
+        mapping = constraint_mapping.init_modules(
+            config=config,
+            permittivity_config=self.permittivity_config,
+            output_interface=ConstraintInterface(
+                shapes={"out": self.matrix_voxel_grid_shape},
+                type="inv_permittivity",
+            ),
+        )
+        self = self.aset("constraint_mapping", mapping)
+        return self
+
+    def init_params(
+        self,
+        key: jax.Array,
+        initial_values: dict[str, jax.Array] | None = None,
+    ) -> dict[str, jax.Array]:
+        """Initializes optimization parameters for the device.
+
+        Creates parameters either from provided initial values or randomly between 0 and 1
+        for each input shape defined in the constraint mapping interface.
+
+        Args:
+            key: JAX random key for parameter initialization
+            initial_values: Optional dictionary of initial parameter values
+
+        Returns:
+            Dictionary mapping parameter names to their initial values
+
+        Raises:
+            Exception: If initial_values shapes don't match required shapes
+        """
+        shapes = self.constraint_mapping._input_interface.shapes
+        
+        # If initial values are provided, validate and use them
+        if initial_values is not None:
+            for k, s in shapes.items():
+                if k not in initial_values:
+                    raise Exception(f"Missing initial value for parameter {k}")
+                if initial_values[k].shape != s:
+                    raise Exception(
+                        f"Shape mismatch for parameter {k}: "
+                        f"expected {s}, got {initial_values[k].shape}"
+                    )
+            return initial_values
+
+        # Otherwise initialize randomly
+        params = {}
+        for k, s in shapes.items():
+            key, subkey = jax.random.split(key)
+            p = jax.random.uniform(
+                key=subkey,
+                shape=s,
+                minval=0,  # parameter always live between 0 and 1
+                maxval=1,
+                dtype=self._config.dtype,
+            )
+            params[k] = p
+        return params
+
+    def set_params_from_array(
+        self,
+        array: jax.Array,
+    ) -> dict[str, jax.Array]:
+        """Sets device parameters from a JAX array.
+
+        Converts the input array into the required parameter format. The array values
+        should be in the range [0,1] as they will be mapped to permittivity values
+        through the constraint mapping.
+
+        Args:
+            array: JAX array with values in [0,1] range matching the device's matrix shape
+
+        Returns:
+            Dictionary containing the array as parameters in the required format
+
+        Raises:
+            Exception: If array shape doesn't match device's matrix shape
+        """
+        expected_shape = self.matrix_voxel_grid_shape
+        if array.shape != expected_shape:
+            raise Exception(
+                f"Array shape {array.shape} doesn't match required shape {expected_shape}"
+            )
+        
+        # Ensure values are in [0,1] range
+        array = jnp.clip(array, 0.0, 1.0)
+        
+        # Convert to parameter dictionary format
+        params = {"out": array.astype(self._config.dtype)}
+        
+        return params
+
+    def get_inv_permittivity(
+        self,
+        prev_inv_permittivity: jax.Array,
+        params: dict[str, jax.Array] | None,
+    ) -> tuple[jax.Array, dict]:
+        """Computes inverse permittivity distribution from optimization parameters.
+
+        Maps the optimization parameters through constraints to produce the final
+        inverse permittivity distribution for the device with continuous material
+        transitions.
+
+        Args:
+            prev_inv_permittivity: Previous inverse permittivity values (unused)
+            params: Dictionary of optimization parameters, cannot be None
+
+        Returns:
+            Tuple containing:
+                - Array of inverse permittivity values
+                - Dictionary with additional computation info
+
+        Raises:
+            Exception: If params is None
+        """
+        del prev_inv_permittivity
+        if params is None:
+            raise Exception("Device params cannot be None")
+        quantized_array = self.constraint_mapping(params)
+        extended_params = expand_matrix(
+            matrix=quantized_array,
+            grid_points_per_voxel=self.single_voxel_grid_shape,
+            add_channels=False,
+        )
+        return extended_params, {}

--- a/src/fdtdx/objects/multi_material/device.py
+++ b/src/fdtdx/objects/multi_material/device.py
@@ -1,8 +1,8 @@
+from abc import ABC, abstractmethod
 from typing import Self
 
 import jax
 import jax.numpy as jnp
-from abc import ABC, abstractmethod
 
 from fdtdx.constraints.mapping import ConstraintMapping
 from fdtdx.constraints.module import (
@@ -336,7 +336,7 @@ class ContinuousDevice(BaseDevice):
             Exception: If initial_values shapes don't match required shapes
         """
         shapes = self.constraint_mapping._input_interface.shapes
-        
+
         # If initial values are provided, validate and use them
         if initial_values is not None:
             for k, s in shapes.items():
@@ -344,8 +344,7 @@ class ContinuousDevice(BaseDevice):
                     raise Exception(f"Missing initial value for parameter {k}")
                 if initial_values[k].shape != s:
                     raise Exception(
-                        f"Shape mismatch for parameter {k}: "
-                        f"expected {s}, got {initial_values[k].shape}"
+                        f"Shape mismatch for parameter {k}: " f"expected {s}, got {initial_values[k].shape}"
                     )
             return initial_values
 
@@ -384,16 +383,14 @@ class ContinuousDevice(BaseDevice):
         """
         expected_shape = self.matrix_voxel_grid_shape
         if array.shape != expected_shape:
-            raise Exception(
-                f"Array shape {array.shape} doesn't match required shape {expected_shape}"
-            )
-        
+            raise Exception(f"Array shape {array.shape} doesn't match required shape {expected_shape}")
+
         # Ensure values are in [0,1] range
         array = jnp.clip(array, 0.0, 1.0)
-        
+
         # Convert to parameter dictionary format
         params = {"out": array.astype(self._config.dtype)}
-        
+
         return params
 
     def get_inv_permittivity(


### PR DESCRIPTION
This pull request includes several changes to the `fdtdx` package, focusing on updating the device class structure and fixing some inconsistencies. The most important changes include replacing the `Device` class with `DiscreteDevice` and introducing a new abstract base class `BaseDevice`. Additionally, a new constraint module `ContinuousPermittivityTransition` has been added, and some minor typo corrections were made. I insist on separating the original device with continuous device due to the fact that in the future, support for multiple optimization scheme might be necessary, and I hope to maintain simplicity for each class (instead of having a lot of if-else statements). This allows for devices that has already been manually sub-pixel averaged to be simulated.

### Device Class Structure Update:
* [`src/fdtdx/objects/multi_material/device.py`](diffhunk://#diff-691621a129deb81d8d1729195709553d6defdf09d0dd2e47b427fcca11150cefR1-R12): Replaced the `Device` class with `DiscreteDevice` and introduced an abstract base class `BaseDevice` for better structure and flexibility. [[1]](diffhunk://#diff-691621a129deb81d8d1729195709553d6defdf09d0dd2e47b427fcca11150cefR1-R12) [[2]](diffhunk://#diff-691621a129deb81d8d1729195709553d6defdf09d0dd2e47b427fcca11150cefL17-R137)
* Updated all references to `Device` in example files to use `DiscreteDevice` instead. [[1]](diffhunk://#diff-e5585e39caadfb4b6b88cfb08edae95c739c46ca95bb50ae8d9966eb983c7975L33-R33) [[2]](diffhunk://#diff-0619cf9ea8bfc1518c36cab41ddfcee2c8c7413ca92cc83b901e39c227184cccL36-R36) [[3]](diffhunk://#diff-c05759641a90655e1e70e5dbedbc2a5cf666266cac0d803592c35c933ca555d8L26-R26) [[4]](diffhunk://#diff-13ab48a9b564aebcea5ac57c74f2c471eefae26ee4cf796da25264ea790e2798L27-R27) [[5]](diffhunk://#diff-f68c7ac09a32ab5958a815152e984bb87184adab37c3f4d76e3c684859104323L31-R31)

### New Constraint Module:
* [`src/fdtdx/constraints/module.py`](diffhunk://#diff-0010d8c59f9a4b119b9f3beaa2103897b354a52ceaa7f196a0f5d6e8b6cf6f8bR269-R327): Added a new constraint module `ContinuousPermittivityTransition` to enable smooth interpolation between materials.

### Typo Corrections:
* [`src/fdtdx/objects/initialization.py`](diffhunk://#diff-7b0de6371d06955cf39c3edfe9a78017ff8b07cf9224b148c2096266a1de55f7L442-R442): Fixed multiple instances of the typo "Inconsisten" to "Inconsistent". [[1]](diffhunk://#diff-7b0de6371d06955cf39c3edfe9a78017ff8b07cf9224b148c2096266a1de55f7L442-R442) [[2]](diffhunk://#diff-7b0de6371d06955cf39c3edfe9a78017ff8b07cf9224b148c2096266a1de55f7L456-R456) [[3]](diffhunk://#diff-7b0de6371d06955cf39c3edfe9a78017ff8b07cf9224b148c2096266a1de55f7L482-R482) [[4]](diffhunk://#diff-7b0de6371d06955cf39c3edfe9a78017ff8b07cf9224b148c2096266a1de55f7L524-R524) [[5]](diffhunk://#diff-7b0de6371d06955cf39c3edfe9a78017ff8b07cf9224b148c2096266a1de55f7L537-R537) [[6]](diffhunk://#diff-7b0de6371d06955cf39c3edfe9a78017ff8b07cf9224b148c2096266a1de55f7L576-R576)

### Other Minor Changes:
* [`src/fdtdx/objects/container.py`](diffhunk://#diff-76929e368368bb789cf15017f6e7dbc5c29222e866427cf2d94d09b6f6fd77d6L18-R18): Updated references from `Device` to `BaseDevice` in property methods. [[1]](diffhunk://#diff-76929e368368bb789cf15017f6e7dbc5c29222e866427cf2d94d09b6f6fd77d6L18-R18) [[2]](diffhunk://#diff-76929e368368bb789cf15017f6e7dbc5c29222e866427cf2d94d09b6f6fd77d6L52-R60)