### PR TITLE
Add precision to _compute_mode in tidy3d

### DIFF
--- a/src/fdtdx/core/modes.py
+++ b/src/fdtdx/core/modes.py
@@ -102,6 +102,7 @@ def compute_modes(
         freq=constants.c / (wavelength),
         mode_spec=mode_spec,
         direction=direction,
+        precision=precision,
     )
     ((Ex, Ey, Ez), (Hx, Hy, Hz)) = EH.squeeze()
 

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -86,6 +86,7 @@ def compute_modes(
         # freq=tidy3d.C_0 / (wavelength / 1e-6),
         mode_spec=mode_spec,
         direction=direction,
+        precision=precision,
     )
     ((Ex, Ey, Ez), (Hx, Hy, Hz)) = EH.squeeze()
 


### PR DESCRIPTION
It seems like the new tidy3d version brought along a change in the _compute_modes function, which now expects the precision to be passed explicitly. I have added this in both instances where this method is called.