### PR TITLE
permeability arrays are optional

### DIFF
--- a/src/fdtdx/core/physics/metrics.py
+++ b/src/fdtdx/core/physics/metrics.py
@@ -14,7 +14,7 @@ def compute_energy(
     E: jax.Array,
     H: jax.Array,
     inv_permittivity: jax.Array,
-    inv_permeability: jax.Array,
+    inv_permeability: jax.Array | float,
 ) -> jax.Array:
     """Computes the total electromagnetic energy density of the field.
 
@@ -41,7 +41,7 @@ def normalize_by_energy(
     E: jax.Array,
     H: jax.Array,
     inv_permittivity: jax.Array,
-    inv_permeability: jax.Array,
+    inv_permeability: jax.Array | float,
 ) -> tuple[jax.Array, jax.Array]:
     """Normalizes electromagnetic fields by their total energy.
 

--- a/src/fdtdx/fdtd/forward.py
+++ b/src/fdtdx/fdtd/forward.py
@@ -28,7 +28,7 @@ def forward_single_args_wrapper(
     jax.Array,
     jax.Array,
     jax.Array,
-    jax.Array,
+    jax.Array | float,
     dict[str, BaseBoundaryState],
     dict[str, DetectorState],
     RecordingState | None,

--- a/src/fdtdx/materials.py
+++ b/src/fdtdx/materials.py
@@ -1,3 +1,5 @@
+import math
+
 from fdtdx.core.jax.pytrees import ExtendedTreeClass, extended_autoinit
 
 
@@ -28,6 +30,18 @@ class Material(ExtendedTreeClass):
     permittivity: float
     permeability: float = 1.0
     conductivity: float = 0.0
+
+    def __post_init__(self):
+        if self.is_conductive:
+            raise NotImplementedError()
+
+    @property
+    def is_magnetic(self) -> bool:
+        return not math.isclose(self.permeability, 1.0)
+
+    @property
+    def is_conductive(self) -> bool:
+        return not math.isclose(self.conductivity, 0.0)
 
 
 def compute_ordered_material_name_tuples(

--- a/src/fdtdx/objects/boundaries/boundary.py
+++ b/src/fdtdx/objects/boundaries/boundary.py
@@ -54,7 +54,7 @@ class BaseBoundary(SimulationObject, ABC):
         self,
         H: jax.Array,
         boundary_state: BaseBoundaryState,
-        inverse_permeability: jax.Array,
+        inverse_permeability: jax.Array | float,
     ) -> jax.Array:
         raise NotImplementedError()
 

--- a/src/fdtdx/objects/boundaries/perfectly_matched_layer.py
+++ b/src/fdtdx/objects/boundaries/perfectly_matched_layer.py
@@ -317,7 +317,7 @@ class PerfectlyMatchedLayer(BaseBoundary):
         self,
         H: jax.Array,
         boundary_state: BoundaryState,
-        inverse_permeability: jax.Array,
+        inverse_permeability: jax.Array | float,
     ) -> jax.Array:
         phi_Hx = boundary_state.psi_Hx[1] - boundary_state.psi_Hx[2]
         phi_Hy = boundary_state.psi_Hy[2] - boundary_state.psi_Hy[0]
@@ -325,7 +325,8 @@ class PerfectlyMatchedLayer(BaseBoundary):
         phi_H = jnp.stack((phi_Hx, phi_Hy, phi_Hz), axis=0)
 
         H = H.at[:, *self.grid_slice].divide(boundary_state.kappa)
-        inv_perm_slice = inverse_permeability[self.grid_slice]
-        update = -self._config.courant_number * inv_perm_slice * phi_H
+        if isinstance(inverse_permeability, jax.Array) and inverse_permeability.ndim > 0:
+            inverse_permeability = inverse_permeability[self.grid_slice]
+        update = -self._config.courant_number * inverse_permeability * phi_H
         H = H.at[:, *self.grid_slice].add(update)
         return H

--- a/src/fdtdx/objects/boundaries/periodic.py
+++ b/src/fdtdx/objects/boundaries/periodic.py
@@ -196,7 +196,7 @@ class PeriodicBoundary(BaseBoundary):
         self,
         H: jax.Array,
         boundary_state: PeriodicBoundaryState,
-        inverse_permeability: jax.Array,
+        inverse_permeability: jax.Array | float,
     ) -> jax.Array:
         del boundary_state, inverse_permeability
         # Get the boundary slice

--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -214,7 +214,7 @@ class Detector(SimulationObject, ABC):
         H: jax.Array,
         state: DetectorState,
         inv_permittivity: jax.Array,
-        inv_permeability: jax.Array,
+        inv_permeability: jax.Array | float,
     ) -> DetectorState:
         """Updates detector state with current field values.
 

--- a/src/fdtdx/objects/detectors/diffractive.py
+++ b/src/fdtdx/objects/detectors/diffractive.py
@@ -99,7 +99,7 @@ class DiffractiveDetector(Detector):
         H: jax.Array,
         state: DetectorState,
         inv_permittivity: jax.Array,
-        inv_permeability: jax.Array,
+        inv_permeability: jax.Array | float,
     ) -> DetectorState:
         del inv_permittivity, inv_permeability
 

--- a/src/fdtdx/objects/detectors/energy.py
+++ b/src/fdtdx/objects/detectors/energy.py
@@ -46,12 +46,16 @@ class EnergyDetector(Detector):
         H: jax.Array,
         state: DetectorState,
         inv_permittivity: jax.Array,
-        inv_permeability: jax.Array,
+        inv_permeability: jax.Array | float,
     ) -> DetectorState:
         cur_E = E[:, *self.grid_slice]
         cur_H = H[:, *self.grid_slice]
         cur_inv_permittivity = inv_permittivity[self.grid_slice]
-        cur_inv_permeability = inv_permeability[self.grid_slice]
+        if isinstance(inv_permeability, jax.Array) and inv_permeability.ndim > 0:
+            cur_inv_permeability = inv_permeability[self.grid_slice]
+        else:
+            cur_inv_permeability = inv_permeability
+
         energy = compute_energy(
             E=cur_E,
             H=cur_H,

--- a/src/fdtdx/objects/detectors/phasor.py
+++ b/src/fdtdx/objects/detectors/phasor.py
@@ -62,7 +62,7 @@ class PhasorDetector(Detector):
         H: jax.Array,
         state: DetectorState,
         inv_permittivity: jax.Array,
-        inv_permeability: jax.Array,
+        inv_permeability: jax.Array | float,
     ) -> DetectorState:
         del inv_permeability, inv_permittivity
         time_passed = time_step * self._config.time_step_duration

--- a/src/fdtdx/objects/detectors/poynting_flux.py
+++ b/src/fdtdx/objects/detectors/poynting_flux.py
@@ -58,7 +58,7 @@ class PoyntingFluxDetector(Detector):
         H: jax.Array,
         state: DetectorState,
         inv_permittivity: jax.Array,
-        inv_permeability: jax.Array,
+        inv_permeability: jax.Array | float,
     ) -> DetectorState:
         del inv_permeability, inv_permittivity
         cur_E = E[:, *self.grid_slice]

--- a/src/fdtdx/objects/sources/profile.py
+++ b/src/fdtdx/objects/sources/profile.py
@@ -60,6 +60,7 @@ class GaussianPulseProfile(TemporalProfile):
         period: float,
         phase_shift: float = 0.0,
     ) -> jax.Array:
+        del period
         # Calculate envelope parameters
         sigma_t = 1.0 / (2 * jnp.pi * self.spectral_width)
         t0 = 6 * sigma_t  # Offset peak to avoid discontinuity at t=0

--- a/src/fdtdx/objects/sources/source.py
+++ b/src/fdtdx/objects/sources/source.py
@@ -24,7 +24,7 @@ class Source(SimulationObject, ABC):
         self,
         E: jax.Array,
         inv_permittivities: jax.Array,
-        inv_permeabilities: jax.Array,
+        inv_permeabilities: jax.Array | float,
         time_step: jax.Array,
         inverse: bool,
     ) -> jax.Array:
@@ -47,7 +47,7 @@ class Source(SimulationObject, ABC):
         self,
         H: jax.Array,
         inv_permittivities: jax.Array,
-        inv_permeabilities: jax.Array,
+        inv_permeabilities: jax.Array | float,
         time_step: jax.Array,
         inverse: bool,
     ) -> jax.Array:
@@ -70,7 +70,7 @@ class Source(SimulationObject, ABC):
         self,
         key: jax.Array,
         inv_permittivities: jax.Array,
-        inv_permeabilities: jax.Array,
+        inv_permeabilities: jax.Array | float,
     ) -> Self:
         """Apply source-specific initialization and setup.
 


### PR DESCRIPTION
This commit makes the permeability arrays optional, such that the array is only initialized if a magnetic material is present in the simulation scene.