### PR TITLE
Documentation improvement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,10 @@ repos:
     rev: 0.6.2
     hooks:
       - id: pydoclint
-        args: [--style=google, --check-return-types=False]
+        args:
+          - --style=google
+          - --check-return-types=False
+          - --check-arg-types=False
   - repo: local
     hooks:
       - id: mkdocs-build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         args:
           - --style=google
           - --check-return-types=False
-          - --check-arg-types=False
+          - --arg-type-hints-in-docstring=False
   - repo: local
     hooks:
       - id: mkdocs-build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,11 @@ repos:
           - --fix
       # Run the formatter.
       - id: ruff-format
+  - repo: https://github.com/jsh9/pydoclint
+    rev: 0.6.2
+    hooks:
+      - id: pydoclint
+        args: [--style=google, --check-return-types=False]
   - repo: local
     hooks:
       - id: mkdocs-build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         args: [--assume-in-merge]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.2
+    rev: v0.11.2
     hooks:
       # Run the linter.
       - id: ruff
@@ -35,6 +35,6 @@ repos:
         always_run: true # Usually you want to build every time
         stages: [pre-commit]
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v0.9.2
+    rev: v1.5.2
     hooks:
       - id: zizmor

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,13 @@ plugins:
           options:
             show_root_heading: true
             show_source: true
+            show_signature: true
+            separate_signature: true
+            #show_bases: true
+            #merge_init_into_class: true
+            #inherited_members: true
+            group_by_category: true
+            show_category_heading: true
             docstring_style: google
 extra_css:
   - stylesheets/extra.css

--- a/src/fdtdx/conversion/export.py
+++ b/src/fdtdx/conversion/export.py
@@ -84,6 +84,9 @@ def export_stl(
 
     Raises:
         Exception: If input matrix is not 3-dimensional.
+
+    Returns:
+        trimesh.Trimesh: A 3D mesh representation of the input matrix.
     """
     if matrix.ndim != 3:
         raise Exception(f"Invalid matrix shape: {matrix.shape}")

--- a/src/fdtdx/core/jax/sharding.py
+++ b/src/fdtdx/core/jax/sharding.py
@@ -21,9 +21,6 @@ def get_named_sharding_from_shape(
 
     Returns:
         NamedSharding object specifying how to distribute the array across available devices
-
-    Raises:
-        ValueError: If shape[sharding_axis] is not divisible by number of devices
     """
     compute_devices = jax.devices()
     num_dims = len(shape)

--- a/src/fdtdx/core/jax/ste.py
+++ b/src/fdtdx/core/jax/ste.py
@@ -25,9 +25,6 @@ def straight_through_estimator(x: jax.Array, y: jax.Array) -> jax.Array:
         jax.Array: The result of applying the straight through estimator, which
         is the same shape as `x` and `y`. In the forward pass this equals y,
         but gradients flow through x.
-
-    Raises:
-        ValueError: If x and y have different shapes.
     """
 
     return x - jax.lax.stop_gradient(x) + jax.lax.stop_gradient(y)

--- a/src/fdtdx/core/misc.py
+++ b/src/fdtdx/core/misc.py
@@ -38,6 +38,9 @@ def is_on_at_time_step(
 
     Returns:
         bool: True if the component should be active at the given time step
+
+    Raises:
+        Exception: If period is not specified when using period-based timing or invalid or conflicting start/end time specifications are provided
     """
     if not is_on:
         return False
@@ -173,7 +176,7 @@ def ensure_slice_tuple(t: Sequence[slice | int | Tuple[int, int]]) -> Tuple[slic
     return tuple(to_slice(loc) for loc in t)
 
 
-def is_float_divisible(a, b, tolerance=1e-15):
+def is_float_divisible(a: float, b: float, tolerance: float = 1e-15) -> bool:
     """
     Checks if a floating-point number 'a' is divisible by another floating-point number 'b'.
 
@@ -202,7 +205,7 @@ def is_index_in_slice(index, slice, seq_length):
     return start <= index < stop
 
 
-def cast_floating_to_numpy(vals: dict[str, np.ndarray], dtype) -> dict[str, np.ndarray]:
+def cast_floating_to_numpy(vals: dict[str, np.ndarray], dtype: np.dtype) -> dict[str, np.ndarray]:
     """Casts floating point arrays in a dictionary to a specified numpy dtype.
 
     Args:
@@ -578,6 +581,9 @@ def advanced_padding(
         tuple[jax.Array, tuple[slice, ...]]: Tuple containing:
             - Padded array
             - Slice tuple to extract original array region
+
+    Raises:
+        Exception: If padding configuration is invalid or incompatible with array dimensions
     """
     # default values
     if len(padding_cfg.widths) == 1:

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -37,20 +37,20 @@ def compute_modes(
     waveguide cross-section defined by its permittivity distribution.
 
     Args:
-        frequency (float): Operating frequency in Hz
-        permittivity_cross_section (np.ndarray): 2D array of relative permittivity values
-        coords (List[np.ndarray]): List of coordinate arrays [x, y] defining the grid
-        direction (Literal["+", "-"]): Propagation direction, either "+" or "-"
-        target_neff (float | None, optional): Target effective index to search around. Defaults to None.
-        angle_theta (float, optional): Polar angle in radians. Defaults to 0.0.
-        angle_phi (float, optional): Azimuthal angle in radians. Defaults to 0.0.
-        num_modes (int, optional): Number of modes to compute. Defaults to 10.
-        precision (Literal["single", "double"], optional): Numerical precision. Defaults to "double".
-        filter_pol (Literal["te", "tm"] | None, optional): Mode polarization filter. Defaults to None.
+        frequency: Operating frequency in Hz
+        permittivity_cross_section: 2D array of relative permittivity values
+        coords: List of coordinate arrays [x, y] defining the grid
+        direction: Propagation direction, either "+" or "-"
+        target_neff: Target effective index to search around. Defaults to None.
+        angle_theta: Polar angle in radians. Defaults to 0.0.
+        angle_phi: Azimuthal angle in radians. Defaults to 0.0.
+        num_modes: Number of modes to compute. Defaults to 10.
+        precision: Numerical precision. Defaults to "double".
+        filter_pol: Mode polarization filter. Defaults to None.
 
     Returns:
-        List[ModeTupleType]: List of computed modes sorted by decreasing real part of
-            effective index. Each mode contains the field components and effective index.
+        List of computed modes sorted by decreasing real part of
+        effective index. Each mode contains the field components and effective index.
     """
     # see https://docs.flexcompute.com/projects/tidy3d/en/latest/_autosummary/tidy3d.ModeSpec.html#tidy3d.ModeSpec
     mode_spec = SimpleNamespace(

--- a/src/fdtdx/core/plotting/debug.py
+++ b/src/fdtdx/core/plotting/debug.py
@@ -7,20 +7,21 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-def generate_unique_filename(prefix="file", extension=None):
+def generate_unique_filename(prefix: str = "file", extension: str = None) -> str:
     """
     Generate a unique filename using timestamp and UUID.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     prefix : str, optional
-        Prefix for the filename
+        Prefix for the filename. Default is "file".
     extension : str, optional
-        File extension (without dot)
+        File extension (without dot). Default is None.
 
-    Returns:
-    --------
-    str : Unique filename
+    Returns
+    -------
+    str
+        Unique filename
     """
     # Get current timestamp
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/src/fdtdx/core/plotting/device_permittivity_index_utils.py
+++ b/src/fdtdx/core/plotting/device_permittivity_index_utils.py
@@ -56,9 +56,8 @@ def device_matrix_index_figure(
     Args:
         device_matrix_indices: A 3D JAX array containing the device matrix indices.
             Shape should be (height, width, channels) where channels is typically 1.
-        permittivity_configs: A tuple of (name, value) pairs defining the permittivity
-            configurations, where name is a string identifier (e.g., "Air") and value
-            is the corresponding permittivity value.
+        material: A dictionary mapping material names to Material objects defining
+            the permittivity configurations.
 
     Returns:
         A matplotlib Figure object containing the visualization with:

--- a/src/fdtdx/core/plotting/utils.py
+++ b/src/fdtdx/core/plotting/utils.py
@@ -59,6 +59,8 @@ def plot_filled_std_curves(
     Raises:
         ValueError: If neither std nor both upper/lower bounds are provided, or if only
             one of upper/lower is provided.
+        Exception: If there's an unexpected internal state where upper or lower bounds
+            are None despite previous validation.
 
     Example:
         >>> x = np.linspace(0, 10, 100)

--- a/src/fdtdx/core/wavelength.py
+++ b/src/fdtdx/core/wavelength.py
@@ -7,9 +7,7 @@ class WaveCharacter(ExtendedTreeClass):
     """Class describing a wavelength/period/frequency in free space.
 
     Attributes:
-        _period: Optional period in seconds. Mutually exclusive with _wavelength and _frequency.
-        _wavelength: Optional wavelength in meters. Mutually exclusive with _period and _frequency.
-        _frequency: Optional frequency in Hz. Mutually exclusive with _period and _wavelength.
+        phase_shift: Phase shift in radians.
     """
 
     phase_shift: float = 0.0
@@ -70,6 +68,9 @@ class WaveCharacter(ExtendedTreeClass):
 
         Returns:
             float: The frequency in Hz.
+
+        Raises:
+            Exception: If neither period nor wavelength nor frequency is set, or if more than one is set.
         """
         self._check_input()
         if self._period is not None:

--- a/src/fdtdx/fdtd/fdtd.py
+++ b/src/fdtdx/fdtd/fdtd.py
@@ -30,18 +30,18 @@ def reversible_fdtd(
     recorded during the forward pass and replayed during backpropagation.
 
     Args:
-        arrays (ArrayContainer): Initial state of the simulation containing:
+        arrays: Initial state of the simulation containing:
             - E, H: Electric and magnetic field arrays
             - inv_permittivities, inv_permeabilities: Material properties
             - boundary_states: Dictionary of boundary conditions
             - detector_states: Dictionary of field detectors
             - recording_state: Optional state for recording field evolution
-        objects (ObjectContainer): Collection of physical objects in the simulation
+        objects: Collection of physical objects in the simulation
             (sources, detectors, boundaries, etc.)
-        config (SimulationConfig): Simulation parameters including:
+        config: Simulation parameters including:
             - time_steps_total: Total number of steps to simulate
             - invertible_optimization: Whether to record boundaries for backprop
-        key (jax.Array): JAX PRNGKey for any stochastic operations
+        key: JAX PRNGKey for any stochastic operations
 
     Returns:
         SimulationState: Tuple containing:
@@ -169,9 +169,9 @@ def reversible_fdtd(
         return time_step >= start_time_step
 
     def fdtd_bwd(
-        residual,
-        cot,
-    ):
+        residual: tuple,
+        cot: tuple,
+    ) -> tuple:
         """Backward pass for reversible FDTD simulation.
 
         Implements the custom vector-Jacobian product for backpropagation through
@@ -331,10 +331,10 @@ def checkpointed_fdtd(
     states as needed.
 
     Args:
-        arrays (ArrayContainer): Initial state of the simulation containing fields and materials
-        objects (ObjectContainer): Collection of physical objects in the simulation
-        config (SimulationConfig): Simulation parameters including checkpointing settings
-        key (jax.Array): JAX PRNGKey for any stochastic operations
+        arrays: Initial state of the simulation containing fields and materials
+        objects: Collection of physical objects in the simulation
+        config: Simulation parameters including checkpointing settings
+        key: JAX PRNGKey for any stochastic operations
 
     Returns:
         SimulationState: Tuple containing final time step and ArrayContainer with final state
@@ -381,14 +381,14 @@ def custom_fdtd_forward(
     allowing partial time evolution and customization of recording behavior.
 
     Args:
-        arrays (ArrayContainer): Initial state of the simulation
-        objects (ObjectContainer): Collection of physical objects
-        config (SimulationConfig): Simulation parameters
-        key (jax.Array): JAX PRNGKey for stochastic operations
-        reset_container (bool): Whether to reset the array container before starting
-        record_detectors (bool): Whether to record detector readings
-        start_time (int | jax.Array): Time step to start from
-        end_time (int | jax.Array): Time step to end at
+        arrays: Initial state of the simulation
+        objects: Collection of physical objects
+        config: Simulation parameters
+        key: JAX PRNGKey for stochastic operations
+        reset_container: Whether to reset the array container before starting
+        record_detectors: Whether to record detector readings
+        start_time: Time step to start from
+        end_time: Time step to end at
 
     Returns:
         SimulationState: Tuple containing final time step and ArrayContainer with final state

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -188,6 +188,10 @@ def _init_arrays(
             - ArrayContainer with initialized arrays and states
             - Updated SimulationConfig
             - Dictionary with initialization info
+
+    Raises:
+        Exception: If an unknown object type is encountered
+        NotImplementedError: If a ContinuousMaterialRange is used with a StaticMultiMaterialObject
     """
     # create E/H fields
     volume_shape = objects.volume.grid_shape

--- a/src/fdtdx/fdtd/update.py
+++ b/src/fdtdx/fdtd/update.py
@@ -343,6 +343,9 @@ def collect_interfaces(
 
     Returns:
         Updated ArrayContainer with recorded interface values
+
+    Raises:
+        Exception: If gradient_config or recorder is None, or if recording_state is None
     """
     if config.gradient_config is None or config.gradient_config.recorder is None:
         raise Exception("Need recorder to record boundaries")
@@ -384,6 +387,9 @@ def add_interfaces(
 
     Returns:
         Updated ArrayContainer with restored interface values
+
+    Raises:
+        Exception: If gradient_config or recorder is None, or if recording_state is None
     """
     if config.gradient_config is None or config.gradient_config.recorder is None:
         raise Exception("Need recorder to record boundaries")

--- a/src/fdtdx/interfaces/modules.py
+++ b/src/fdtdx/interfaces/modules.py
@@ -15,14 +15,10 @@ class CompressionModule(ExtendedTreeClass, ABC):
     This class provides an interface for modules that compress and decompress field data
     during FDTD simulations. Implementations can perform operations like quantization,
     dimensionality reduction, or other compression techniques.
-
-    Attributes:
-        _input_shape_dtypes: Dictionary mapping field names to their input shapes/dtypes.
-        _output_shape_dtypes: Dictionary mapping field names to their output shapes/dtypes.
     """
 
-    _input_shape_dtypes: dict[str, jax.ShapeDtypeStruct] = frozen_private_field(default=None)  # type: ignore
-    _output_shape_dtypes: dict[str, jax.ShapeDtypeStruct] = frozen_private_field(default=None)  # type: ignore
+    _input_shape_dtypes: dict[str, jax.ShapeDtypeStruct] = frozen_private_field(default=None)
+    _output_shape_dtypes: dict[str, jax.ShapeDtypeStruct] = frozen_private_field(default=None)
 
     @abstractmethod
     def init_shapes(
@@ -43,6 +39,10 @@ class CompressionModule(ExtendedTreeClass, ABC):
                 - Self: Updated instance of the compression module
                 - Dictionary mapping field names to their output shapes/dtypes
                 - Dictionary mapping field names to their state shapes/dtypes
+
+        Raises:
+            NotImplementedError: This is an abstract method that should be implemented
+                by subclasses.
         """
         del input_shape_dtypes
         raise NotImplementedError()
@@ -68,6 +68,10 @@ class CompressionModule(ExtendedTreeClass, ABC):
             Tuple containing:
                 - Dictionary of compressed field values
                 - Updated recording state
+
+        Raises:
+            NotImplementedError: This is an abstract method that should be implemented
+                by subclasses.
         """
         del values, state, key
         raise NotImplementedError()
@@ -88,6 +92,10 @@ class CompressionModule(ExtendedTreeClass, ABC):
 
         Returns:
             Dictionary mapping field names to their decompressed values.
+
+        Raises:
+            NotImplementedError: This is an abstract method that should be implemented
+                by subclasses.
         """
         del (
             values,

--- a/src/fdtdx/interfaces/time_filter.py
+++ b/src/fdtdx/interfaces/time_filter.py
@@ -16,12 +16,6 @@ class TimeStepFilter(ExtendedTreeClass, ABC):
     This class provides an interface for filters that process simulation data at specific
     time steps. Implementations can perform operations like downsampling, collation, or
     other temporal processing of field data.
-
-    Attributes:
-        _time_steps_max: Maximum number of time steps in the simulation.
-        _array_size: Size of the array used to store filtered data.
-        _input_shape_dtypes: Dictionary mapping field names to their input shapes/dtypes.
-        _output_shape_dtypes: Dictionary mapping field names to their output shapes/dtypes.
     """
 
     _time_steps_max: int = frozen_private_field(default=-1)  # type: ignore
@@ -52,6 +46,9 @@ class TimeStepFilter(ExtendedTreeClass, ABC):
             - Size of array for storing filtered data
             - Dictionary of data shapes/dtypes
             - Dictionary of state shapes/dtypes
+
+        Raises:
+            NotImplementedError: This is an abstract method that must be implemented by subclasses.
         """
         del input_shape_dtypes, time_steps_max
         raise NotImplementedError()
@@ -69,6 +66,9 @@ class TimeStepFilter(ExtendedTreeClass, ABC):
         Returns:
             The corresponding array index if the time step is not filtered,
             or -1 if the time step is filtered out.
+
+        Raises:
+            NotImplementedError: This is an abstract method that must be implemented by subclasses.
         """
         del time_idx
         raise NotImplementedError()
@@ -96,6 +96,9 @@ class TimeStepFilter(ExtendedTreeClass, ABC):
             Tuple containing:
             - Dictionary of compressed field values
             - Updated recording state
+
+        Raises:
+            NotImplementedError: This is an abstract method that must be implemented by subclasses.
         """
         del values, state, time_idx, key
         raise NotImplementedError()
@@ -112,6 +115,9 @@ class TimeStepFilter(ExtendedTreeClass, ABC):
 
         Returns:
             Array of indices needed to reconstruct the data for this time step.
+
+        Raises:
+            NotImplementedError: This is an abstract method that must be implemented by subclasses.
         """
         del time_idx
         raise NotImplementedError()
@@ -136,6 +142,9 @@ class TimeStepFilter(ExtendedTreeClass, ABC):
 
         Returns:
             Dictionary of reconstructed field values.
+
+        Raises:
+            NotImplementedError: This is an abstract method that must be implemented by subclasses.
         """
         del values, state, arr_indices, time_idx, key
         raise NotImplementedError()
@@ -151,8 +160,6 @@ class LinearReconstructEveryK(TimeStepFilter):
     Attributes:
         k: Number of time steps between saved values.
         start_recording_after: Time step to start recording from.
-        _save_time_steps: Array of time steps that are saved.
-        _time_to_arr_idx: Mapping from time steps to array indices.
     """
 
     k: int = frozen_field()

--- a/src/fdtdx/materials.py
+++ b/src/fdtdx/materials.py
@@ -11,17 +11,25 @@ class Material(ExtendedTreeClass):
     This class stores the fundamental electromagnetic properties of a material for use
     in electromagnetic simulations.
 
+    Attributes:
+        permittivity: The relative permittivity (dielectric constant) of the material,
+            which describes how the electric field is affected by the material.
+        permeability: The relative permeability of the material, which
+            describes how the magnetic field is affected by the material.
+        conductivity: The electrical conductivity of the material in siemens
+            per meter (S/m), which describes how easily electric current can flow through it.
+
     Args:
-        permittivity (float): The relative permittivity (dielectric constant) of the material,
+        permittivity: The relative permittivity (dielectric constant) of the material,
             which describes how the electric field is affected by the material. Higher values
             indicate greater electric polarization in response to an applied electric field.
 
-        permeability (float, optional): The relative permeability of the material, which
+        permeability: The relative permeability of the material, which
             describes how the magnetic field is affected by the material. Higher values
             indicate greater magnetic response to an applied magnetic field.
             Defaults to 1.0 (non-magnetic material).
 
-        conductivity (float, optional): The electrical conductivity of the material in siemens
+        conductivity: The electrical conductivity of the material in siemens
             per meter (S/m), which describes how easily electric current can flow through it.
             Higher values indicate materials that conduct electricity more easily.
             Defaults to 0.0 (perfect insulator).

--- a/src/fdtdx/objects/boundaries/utils.py
+++ b/src/fdtdx/objects/boundaries/utils.py
@@ -193,8 +193,7 @@ def standard_sigma_from_direction_axis(
             - jax.Array: Conductivity values for H-field
 
     Raises:
-        Exception: If direction is not "+" or "-"
-        Exception: If axis is not 0, 1, or 2
+        Exception: If direction is not "+" or "-", or if axis is not 0, 1, or 2
     """
     # compute sigma values based on direction
     if direction == "-":
@@ -250,8 +249,7 @@ def kappa_from_direction_axis(
         jax.Array: Kappa values linearly varying from start to end value
 
     Raises:
-        Exception: If direction is not "+" or "-"
-        Exception: If axis is not 0, 1, or 2
+        Exception: If direction is not "+" or "-", or if axis is not 0, 1, or 2
     """
     if direction == "-":
         kappa_vals = jnp.linspace(kappa_end, kappa_start, thickness, dtype=dtype)
@@ -283,8 +281,7 @@ def axis_direction_from_kind(kind: str) -> tuple[int, Literal["+", "-"]]:
             - str: Direction ("+" for max, "-" for min)
 
     Raises:
-        Exception: If kind does not contain valid axis identifier
-        Exception: If kind does not contain valid direction identifier
+        Exception: If kind does not contain valid axis or direction identifier
     """
     axis = -1
     if "_x" in kind:

--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -29,29 +29,29 @@ class Detector(SimulationObject, ABC):
     and visualization of results.
 
     Attributes:
-        name (str): Unique identifier for the detector.
-        dtype (jnp.dtype): Data type for detector arrays, defaults to float32.
-        exact_interpolation (bool): Whether to use exact field interpolation.
-        inverse (bool): Whether to record fields in inverse time order.
-        interval (int): Number of time steps between recordings.
-        start_after_periods (float, optional): When to start recording, in periods.
-        end_after_periods (float, optional): When to stop recording, in periods.
-        period_length (float, optional): Length of one period in simulation time.
-        start_time (float, optional): Absolute start time for recording.
-        end_time (float, optional): Absolute end time for recording.
-        on_for_time (float, optional): Duration to record for, in simulation time.
-        on_for_periods (float, optional): Duration to record for, in periods.
-        time_steps (list[int], optional): Specific time steps to record at.
-        plot (bool): Whether to generate plots of recorded data.
-        if_inverse_plot_backwards (bool): Plot inverse data in reverse time order.
-        num_video_workers (int): Number of workers for video generation.
-        color (tuple[float, float, float]): RGB color for plotting.
-        plot_interpolation (str): Interpolation method for plots.
-        plot_dpi (int, optional): DPI resolution for plots.
+        name: Unique identifier for the detector.
+        dtype: Data type for detector arrays, defaults to float32.
+        exact_interpolation: Whether to use exact field interpolation.
+        inverse: Whether to record fields in inverse time order.
+        interval: Number of time steps between recordings.
+        start_after_periods: When to start recording, in periods.
+        end_after_periods: When to stop recording, in periods.
+        period_length: Length of one period in simulation time.
+        start_time: Absolute start time for recording.
+        end_time: Absolute end time for recording.
+        on_for_time: Duration to record for, in simulation time.
+        on_for_periods: Duration to record for, in periods.
+        time_steps: Specific time steps to record at.
+        plot: Whether to generate plots of recorded data.
+        if_inverse_plot_backwards: Plot inverse data in reverse time order.
+        num_video_workers: Number of workers for video generation.
+        color: RGB color for plotting.
+        plot_interpolation: Interpolation method for plots.
+        plot_dpi: DPI resolution for plots.
     """
 
-    name: str = frozen_field(kind="KW_ONLY")  # type: ignore
-    dtype: jnp.dtype = frozen_field(kind="KW_ONLY", default=jnp.float32)  # type: ignore
+    name: str = frozen_field(kind="KW_ONLY")
+    dtype: jnp.dtype = frozen_field(kind="KW_ONLY", default=jnp.float32)
     exact_interpolation: bool = False
     inverse: bool = False
     interval: int = 1
@@ -62,13 +62,13 @@ class Detector(SimulationObject, ABC):
     end_time: float | None = None
     on_for_time: float | None = None
     on_for_periods: float | None = None
-    time_steps: list[int] = field(default=None)  # type: ignore
+    time_steps: list[int] = field(default=None)
     plot: bool = True
     if_inverse_plot_backwards: bool = True
     num_video_workers: int = 8  # only used when generating video
-    _is_on_at_time_step_arr: jax.Array = field(default=None, init=False)  # type: ignore
-    _time_step_to_arr_idx: jax.Array = field(default=None, init=False)  # type: ignore
-    _num_time_steps_on: int = field(default=None, init=False)  # type: ignore
+    _is_on_at_time_step_arr: jax.Array = field(default=None, init=False)
+    _time_step_to_arr_idx: jax.Array = field(default=None, init=False)
+    _num_time_steps_on: int = field(default=None, init=False)
     color: tuple[float, float, float] = LIGHT_GREEN
     plot_interpolation: str = frozen_field(kind="KW_ONLY", default="gaussian")
     plot_dpi: int | None = frozen_field(kind="KW_ONLY", default=None)

--- a/src/fdtdx/objects/detectors/diffractive.py
+++ b/src/fdtdx/objects/detectors/diffractive.py
@@ -20,6 +20,7 @@ class DiffractiveDetector(Detector):
         frequencies: List of frequencies to analyze (in Hz)
         orders: Tuple of (nx, ny) pairs specifying diffraction orders to compute
         direction: Direction of diffraction analysis ("+" or "-") along propagation axis
+        dtype: Data type for detector computations (must be complex)
     """
 
     frequencies: Sequence[float] = field(kind="KW_ONLY")  # type: ignore

--- a/src/fdtdx/objects/detectors/phasor.py
+++ b/src/fdtdx/objects/detectors/phasor.py
@@ -20,6 +20,7 @@ class PhasorDetector(Detector):
         reduce_volume: If True, reduces the volume of recorded data.
         components: Sequence of field components to measure. Can include any of:
             "Ex", "Ey", "Ez", "Hx", "Hy", "Hz".
+        dtype: Complex numeric data type for phasor calculations. Can be either jnp.complex64 or jnp.complex128. Defaults to jnp.complex64.
     """
 
     frequencies: Sequence[float] = (None,)  # type: ignore

--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -69,12 +69,12 @@ def plot_from_slices(
     return data
 
 
-def _make_animation_frame(t: float | int, precomputed_figs, fps):
+def _make_animation_frame(t: float | int, precomputed_figs: list[plt.figure], fps: int):
     """Creates a single frame for the video animation.
 
     Args:
         t: Time point in seconds
-        precomputed_figs: List of precomputed figure arrays
+        precomputed_figs: List of precomputed figures
         fps: Frames per second of the video
 
     Returns:

--- a/src/fdtdx/objects/device/parameters/utils.py
+++ b/src/fdtdx/objects/device/parameters/utils.py
@@ -137,9 +137,7 @@ def nearest_index(
             Tuple[jax.Array, jax.Array]: (indices, distances)
 
     Raises:
-        Exception: If axis not provided when using allowed_indices option.
-        Exception: If values array is not 3D when using allowed_indices.
-        Exception: If invalid axis specified.
+        Exception: If axis is not provided when using allowed_indices, if values array is not 3D when using allowed_indices, or if an invalid axis is specified.
         ValueError: If unknown distance metric specified.
     """
     if allowed_indices is None:

--- a/src/fdtdx/objects/object.py
+++ b/src/fdtdx/objects/object.py
@@ -259,6 +259,9 @@ class SimulationObject(ExtendedTreeClass, ABC):
 
         Returns:
             PositionConstraint: Positional constraint between this object and the other
+
+        Raises:
+            Exception: If input arrays don't have the same length
         """
         if isinstance(axes, int):
             axes = (axes,)
@@ -318,6 +321,9 @@ class SimulationObject(ExtendedTreeClass, ABC):
 
         Returns:
             SizeConstraint: Size constraint between this object and the other
+
+        Raises:
+            Exception: If input arrays don't have the same length
         """
         if isinstance(axes, int):
             axes = (axes,)
@@ -592,6 +598,9 @@ class SimulationObject(ExtendedTreeClass, ABC):
 
         Returns:
             GridCoordinateConstraint: Constraint forcing alignment with specific grid coordinates
+
+        Raises:
+            Exception: If input arrays don't have the same length
         """
         if isinstance(axes, int):
             axes = (axes,)
@@ -626,6 +635,9 @@ class SimulationObject(ExtendedTreeClass, ABC):
 
         Returns:
             RealCoordinateConstraint: Constraint forcing alignment with specific real-space coordinates
+
+        Raises:
+            Exception: If input arrays don't have the same length
         """
         if isinstance(axes, int):
             axes = (axes,)
@@ -668,6 +680,9 @@ class SimulationObject(ExtendedTreeClass, ABC):
 
         Returns:
             SizeExtensionConstraint: Constraint defining how the object extends
+
+        Raises:
+            Exception: If offset or grid_offset is used when extending to simulation boundary
         """
         # default: extend to corresponding side
         if other_position is None:

--- a/src/fdtdx/objects/sources/profile.py
+++ b/src/fdtdx/objects/sources/profile.py
@@ -29,6 +29,9 @@ class TemporalProfile(ABC):
 
         Returns:
             Amplitude values at the given time points
+
+        Raises:
+            NotImplementedError: This is an abstract method that must be implemented by subclasses
         """
         raise NotImplementedError()
 

--- a/src/fdtdx/objects/sources/source.py
+++ b/src/fdtdx/objects/sources/source.py
@@ -39,6 +39,9 @@ class Source(SimulationObject, ABC):
 
         Returns:
             Updated electric field array.
+
+        Raises:
+            NotImplementedError: This is an abstract method that must be implemented by subclasses.
         """
         raise NotImplementedError()
 
@@ -62,6 +65,9 @@ class Source(SimulationObject, ABC):
 
         Returns:
             Updated magnetic field array.
+
+        Raises:
+            NotImplementedError: This is an abstract method that must be implemented by subclasses.
         """
         raise NotImplementedError()
 
@@ -81,6 +87,9 @@ class Source(SimulationObject, ABC):
 
         Returns:
             Initialized source instance.
+
+        Raises:
+            NotImplementedError: This is an abstract method that must be implemented by subclasses.
         """
         raise NotImplementedError()
 

--- a/src/fdtdx/objects/static_material/multi_material.py
+++ b/src/fdtdx/objects/static_material/multi_material.py
@@ -19,6 +19,9 @@ class StaticMultiMaterialObject(StaticMaterialObject, ABC):
 
         Returns:
             jax.Array: Binary mask representing the voxels occupied by the object
+
+        Raises:
+            NotImplementedError: This is an abstract method that must be implemented by subclasses
         """
         raise NotImplementedError()
 
@@ -31,5 +34,8 @@ class StaticMultiMaterialObject(StaticMaterialObject, ABC):
 
         Returns:
             jax.Array: Index array
+
+        Raises:
+            NotImplementedError: This is an abstract method that must be implemented by subclasses
         """
         raise NotImplementedError()

--- a/src/fdtdx/objects/static_material/uniform.py
+++ b/src/fdtdx/objects/static_material/uniform.py
@@ -48,7 +48,6 @@ class Waveguide(UniformMaterialObject):
     Visualized in light blue color by default.
 
     Attributes:
-        permittivity: Required relative permittivity of the waveguide material
         color: RGB tuple for visualization, defaults to light blue
     """
 

--- a/src/fdtdx/utils/logger.py
+++ b/src/fdtdx/utils/logger.py
@@ -177,6 +177,9 @@ class Logger:
         Args:
             stats: Dictionary of statistics to record
             do_print: Whether to print stats to console
+
+        Raises:
+            AssertionError: If attempting to write before the writer is initialized
         """
         stats = {
             k: v.item() if isinstance(v, jax.Array) else v
@@ -214,6 +217,9 @@ class Logger:
             objects: Container with simulation objects
             detector_states: Dictionary mapping detector names to their states
             exclude: List of detector names to exclude from logging
+
+        Raises:
+            Exception: If a detector returns an output format that is neither Figure nor string
         """
         for detector in [d for d in objects.detectors if d.name not in exclude]:
             cur_state = jax.device_get(detector_states[detector.name])

--- a/src/fdtdx/utils/plot_setup.py
+++ b/src/fdtdx/utils/plot_setup.py
@@ -43,6 +43,9 @@ def plot_setup(
     Returns:
         matplotlib.figure.Figure: The generated figure object
 
+    Raises:
+        AssertionError: If `axs` is provided but is None. This should not happen in normal operation as the function creates new axes when `axs` is None.
+
     Note:
         The plots show object positions in micrometers, converting from simulation units.
         PML objects are automatically excluded from their respective boundary planes.

--- a/src/fdtdx/utils/plot_setup.py
+++ b/src/fdtdx/utils/plot_setup.py
@@ -30,21 +30,18 @@ def plot_setup(
     helps verify the correct positioning and sizing of objects in the simulation setup.
 
     Args:
-        config (SimulationConfig): Configuration object containing simulation parameters like resolution
-        objects (ObjectContainer): Container holding all simulation objects to be plotted
-        exclude_object_list (list[SimulationObject]): List of objects to exclude from all plots
-        filename (str | Path | None): If provided, saves the plot to this file instead of displaying
-        axs (Sequence[Any] | None): Optional matplotlib axes to plot on. If None, creates new figure
-        plot_legend (bool): Whether to add a legend showing object names/types
-        exclude_xy_plane_object_list (list[SimulationObject]): Objects to exclude from XY plane plot
-        exclude_yz_plane_object_list (list[SimulationObject]): Objects to exclude from YZ plane plot
-        exclude_xz_plane_object_list (list[SimulationObject]): Objects to exclude from XZ plane plot
+        config: Configuration object containing simulation parameters like resolution
+        objects: Container holding all simulation objects to be plotted
+        exclude_object_list: List of objects to exclude from all plots
+        filename: If provided, saves the plot to this file instead of displaying
+        axs: Optional matplotlib axes to plot on. If None, creates new figure
+        plot_legend: Whether to add a legend showing object names/types
+        exclude_xy_plane_object_list: Objects to exclude from XY plane plot
+        exclude_yz_plane_object_list: Objects to exclude from YZ plane plot
+        exclude_xz_plane_object_list: Objects to exclude from XZ plane plot
 
     Returns:
         matplotlib.figure.Figure: The generated figure object
-
-    Raises:
-        AssertionError: If provided axes are None after initialization attempt
 
     Note:
         The plots show object positions in micrometers, converting from simulation units.

--- a/src/fdtdx/utils/plot_setup.py
+++ b/src/fdtdx/utils/plot_setup.py
@@ -30,18 +30,21 @@ def plot_setup(
     helps verify the correct positioning and sizing of objects in the simulation setup.
 
     Args:
-        config: Configuration object containing simulation parameters like resolution
-        objects: Container holding all simulation objects to be plotted
-        exclude_object_list: List of objects to exclude from all plots
-        filename: If provided, saves the plot to this file instead of displaying
-        axs: Optional matplotlib axes to plot on. If None, creates new figure
-        plot_legend: Whether to add a legend showing object names/types
-        exclude_xy_plane_object_list: Objects to exclude from XY plane plot
-        exclude_yz_plane_object_list: Objects to exclude from YZ plane plot
-        exclude_xz_plane_object_list: Objects to exclude from XZ plane plot
+        config (SimulationConfig): Configuration object containing simulation parameters like resolution
+        objects (ObjectContainer): Container holding all simulation objects to be plotted
+        exclude_object_list (list[SimulationObject]): List of objects to exclude from all plots
+        filename (str | Path | None): If provided, saves the plot to this file instead of displaying
+        axs (Sequence[Any] | None): Optional matplotlib axes to plot on. If None, creates new figure
+        plot_legend (bool): Whether to add a legend showing object names/types
+        exclude_xy_plane_object_list (list[SimulationObject]): Objects to exclude from XY plane plot
+        exclude_yz_plane_object_list (list[SimulationObject]): Objects to exclude from YZ plane plot
+        exclude_xz_plane_object_list (list[SimulationObject]): Objects to exclude from XZ plane plot
 
     Returns:
         matplotlib.figure.Figure: The generated figure object
+
+    Raises:
+        AssertionError: If provided axes are None after initialization attempt
 
     Note:
         The plots show object positions in micrometers, converting from simulation units.


### PR DESCRIPTION
Resolves #34 

This is currently not fully ready for merge, as changes from main need to be incorporated.

Further discussion is also needed as almost the whole codebase uses @extended_autoinit which hides the \_\_init__ method from mkdocs leading to fragmented definition and docstrings of classes.

Possible Solutions:

- keep on writing the docstrings (args part) manually and hope for the best 
- somewhat absolve the usage of __init__ generators for better discoverability

The first option resulted in the current fragmentation.

Concerning the invisibility of superclass variables it seems that mkdocs is somewhat unable to achieve this without a lot of heavy lifting.

The only combination of options that starts displaying inherited members result in massive duplicate listings in even the simplest configurations:

<img width="717" alt="Bildschirmfoto 2025-04-13 um 19 47 42" src="https://github.com/user-attachments/assets/2b511aec-985c-4d0c-8793-84836e7bb95e" />

Other options for documentation include heavyweights like Sphinx, or lightweights like pdoc are possible but a detailed feature parity check is needed.