### PR TITLE
Stopping simulation according to a user-specified condition

### DIFF
--- a/src/fdtdx/fdtd/fdtd.py
+++ b/src/fdtdx/fdtd/fdtd.py
@@ -8,6 +8,7 @@ from fdtdx.config import SimulationConfig
 from fdtdx.fdtd.backward import backward
 from fdtdx.fdtd.container import ArrayContainer, ObjectContainer, SimulationState, reset_array_container
 from fdtdx.fdtd.forward import forward, forward_single_args_wrapper
+from fdtdx.fdtd.stop_conditions import StoppingCondition, TimeStepCondition
 from fdtdx.interfaces.state import RecordingState
 from fdtdx.objects.boundaries.boundary import BaseBoundaryState
 from fdtdx.objects.detectors.detector import DetectorState
@@ -285,6 +286,7 @@ def checkpointed_fdtd(
     objects: ObjectContainer,
     config: SimulationConfig,
     key: jax.Array,
+    stopping_condition: StoppingCondition | None = None,
 ) -> SimulationState:
     """Run an FDTD simulation with gradient checkpointing for memory efficiency.
 
@@ -297,6 +299,8 @@ def checkpointed_fdtd(
         objects (ObjectContainer): Collection of physical objects in the simulation
         config (SimulationConfig): Simulation parameters including checkpointing settings
         key (jax.Array): JAX PRNGKey for any stochastic operations
+        stopping_condition (StoppingCondition, optional): Custom stopping condition on which simulation is halted.
+            If none is provided, we default to TimeStepCondition (simulation progresses until max time is reached)
 
     Returns:
         SimulationState: Tuple containing final time step and ArrayContainer with final state
@@ -307,9 +311,17 @@ def checkpointed_fdtd(
     """
     arrays = reset_array_container(arrays, objects)
     state = (jnp.asarray(0, dtype=jnp.int32), arrays)
+    if stopping_condition is not None:
+        stopping_condition = stopping_condition.setup(state, config, objects)
+    else:
+        stopping_condition = TimeStepCondition().setup(state, config, objects)
     state = eqxi.while_loop(
         max_steps=config.time_steps_total,
-        cond_fun=lambda s: config.time_steps_total > s[0],
+        cond_fun=partial(
+            stopping_condition,
+            config=config,
+            objects=objects,
+        ),
         body_fun=partial(
             forward,
             config=config,

--- a/src/fdtdx/fdtd/stop_conditions.py
+++ b/src/fdtdx/fdtd/stop_conditions.py
@@ -1,0 +1,315 @@
+from abc import ABC, abstractmethod
+from typing import Self
+
+import jax
+import jax.numpy as jnp
+
+from fdtdx.config import SimulationConfig
+from fdtdx.core.jax.pytrees import TreeClass, autoinit, frozen_field, frozen_private_field
+from fdtdx.core.physics.metrics import compute_energy
+from fdtdx.core.wavelength import WaveCharacter
+from fdtdx.fdtd.container import DetectorState, ObjectContainer, SimulationState
+
+
+@autoinit
+class StoppingCondition(TreeClass, ABC):
+    """Abstract base class for defining custom stopping conditions in simulations.
+
+    This class provides the interface for implementing custom termination criteria
+    that can depend on simulation state, detector readings, field values, etc.
+    """
+
+    @abstractmethod
+    def setup(self, state: SimulationState, config: SimulationConfig, objects: ObjectContainer) -> Self:
+        """Preparing condition for its use in the simulation."""
+        return self
+
+    @abstractmethod
+    def _validate(self, state: SimulationState, config: SimulationConfig, objects: ObjectContainer) -> None:
+        """Pre-run validation; override in subclasses."""
+        pass
+
+    @abstractmethod
+    def __call__(self, state: SimulationState, config: SimulationConfig, objects: ObjectContainer) -> jax.Array:
+        """Evaluate the stopping condition.
+
+        Args:
+            state (SimulationState): Current simulation state
+            config (SimulationConfig): Configuration of the simulation
+            objects (ObjectContainer): Objects in simulation
+
+        Returns:
+            jax.Array: Boolean scalar - True if simulation should continue, False if it should stop
+
+        Raises:
+            NotImplementedError: Must be implemented by subclasses.
+        """
+        raise NotImplementedError()
+
+
+@autoinit
+class TimeStepCondition(StoppingCondition):
+    """Default stopping condition based on maximum time steps.
+
+    This recreates the original behavior where simulation continues until
+    a specified end time is reached.
+    """
+
+    def setup(self, state: SimulationState, config: SimulationConfig, objects: ObjectContainer) -> Self:
+        self._validate(state, config, objects)
+        return self
+
+    def _validate(self, state: SimulationState, config: SimulationConfig, objects: ObjectContainer) -> None:
+        pass
+
+    def __call__(self, state: SimulationState, config: SimulationConfig, objects: ObjectContainer) -> jax.Array:
+        """Check if simulation should continue based on time step.
+
+        Args:
+            state (SimulationState): Current simulation state.
+            config (SimulationConfig): Configuration of the simulation.
+            objects (ObjectContainer): Objects in simulation.
+
+        Returns:
+            jax.Array: Boolean scalar - True if current time < end_time, False otherwise
+        """
+        curr_time_step, _ = state
+        return config.time_steps_total > curr_time_step
+
+
+@autoinit
+class EnergyThresholdCondition(StoppingCondition):
+    """This condition stops a simulation when the total energy in the simulation volume
+    falls below a specified threshold. A minimum number of steps can be enforced
+    before convergence checks are applied, and a hard cutoff is imposed at
+    ``SimulationConfig.time_steps_total``. This condition is intended to be used with
+    pulsed sources, where the total amount of energy input in the volume is
+    finite, therefore total energy in the system is expected to converge towards zero eventually.
+
+    Attributes:
+        threshold (float, optional): Lower energy threshold for determining
+            simulation termination. Defaults to ``1e-6``.
+        min_steps (int, optional): The minimum number of time steps that must be
+            completed before convergence checking begins. Defaults to
+            ``0.1 * SimulationConfig.time_steps_total``.
+        max_steps (int, optional): The maximum number of time steps in a
+            simulation, regardless of the condition being fulfilled. Defaults to
+            ``SimulationConfig.time_steps_total``.
+    """
+
+    threshold: float = frozen_field(default=1e-6)
+    min_steps: int | None = frozen_field(default=None)
+    max_steps: int | None = frozen_field(default=None)
+
+    def setup(self, state: SimulationState, config: SimulationConfig, objects: ObjectContainer) -> Self:
+        self = self.aset(
+            "max_steps", config.time_steps_total if self.max_steps is None else self.max_steps, create_new_ok=True
+        )
+        self = self.aset(
+            "min_steps",
+            int(round(config.time_steps_total * 0.1)) if self.min_steps is None else self.min_steps,
+            create_new_ok=True,
+        )
+        self._validate(state, config, objects)
+
+        return self
+
+    def _validate(self, state: SimulationState, config: SimulationConfig, objects: ObjectContainer) -> None:
+        if self.threshold <= 0:
+            raise ValueError(f"Energy threshold must be positive, got {self.threshold}.")
+
+        if self.min_steps is not None and self.min_steps < 0:
+            raise ValueError(f"Minimum steps must be non-negative, got {self.min_steps}.")
+
+    def __call__(self, state: SimulationState, config: SimulationConfig, objects: ObjectContainer) -> jax.Array:
+        """Check if simulation should continue based on energy reaching a lower threshold.
+        Energy checks are only able to terminate the simulation after the time step is larger than ``min_steps``.
+
+        Args:
+            state (SimulationState): Current simulation state.
+            config (SimulationConfig): Configuration of the simulation.
+            objects (ObjectContainer): Objects in simulation.
+
+        Returns:
+            jax.Array: Boolean scalar - True if condition not met and curr_time_step < max_steps.
+        """
+        curr_time_step, arrays = state
+        time_condition = curr_time_step < self.max_steps
+        min_steps_condition = curr_time_step < self.min_steps
+        total_energy = jnp.sum(compute_energy(arrays.E, arrays.H, arrays.inv_permittivities, arrays.inv_permeabilities))
+        converged = total_energy < self.threshold
+
+        return time_condition & (min_steps_condition | ~converged)
+
+
+@autoinit
+class DetectorConvergenceCondition(StoppingCondition):
+    """Stopping condition based on convergence of values read off by a
+    Detector with ``reduce_volume=True`` and number of readings equal to
+    number of time steps (with ``switch=OnOffSwitch()``).
+
+    This stopping condition starts off estimating convergence of values read off by a
+    user-specified Detector by considering two subsets of its readings:
+      (i) a number of previous periods [t - (prev_periods + 1)*spp, t - spp), and
+      (ii) the last full period [t - spp, t),
+    where t is the current time step, spp is the number of samples of the period
+    over which the reading changes (it's usually half the period of the CW
+    source in the case of PoyntingFluxDetector and EnergyDetector).
+    Once it has them, it computes the mean over all periods of (i) such that the
+    result has the same shape as (ii). After this, their Fourier transform is
+    computed, and then the L2 norm of these two transforms, and stops the
+    simulation once this norm falls below a specified threshold.
+    A minimum number of steps are enforced before convergence checks are
+    applied, and a hard cutoff of the simulation is imposed when the time step
+    is equal to ``max_steps``.
+
+    Attributes:
+        detector_name (str): The name of the Detector from which
+            readings will be obtained in order to determine when to
+            halt the simulation.
+        wave_character (WaveCharacter): The WaveCharacter fed to the source in the simulation.
+            This is used to calculate the period over which the detector reading changes.
+            For PoyntingFluxDetector and EnergyDetector, this is typically half
+            the period of the CW source specified in this WaveCharacter.
+        prev_periods (int, optional): Number of previous full periods used as a reference (>=1).
+        threshold (float, optional): Relative change threshold for determining
+            convergence. Defaults to ``1e-6``.
+        min_steps (int, optional): The minimum number of time steps that the
+            simulation must go on for before convergence checking begins. Defaults
+            to ``(prev_periods + 1) * spp``, where ``spp`` is samples per period of
+            the source. This ensures that there are enough readings to compute the
+            Fourier transforms.
+        max_steps (int, optional): The maximum number of time steps before the
+            simulation is stopped, regardless of convergence.
+            Defaults to ``SimulationConfig.time_steps_total``.
+    """
+
+    detector_name: str = frozen_field()
+    wave_character: WaveCharacter = frozen_field()
+    prev_periods: int = frozen_field(default=4)
+    threshold: float = frozen_field(default=1e-6)
+    min_steps: int | None = frozen_field(default=None)
+    max_steps: int | None = frozen_field(default=None)
+    _spp: int | None = frozen_private_field(default=None)  # type: ignore
+
+    def setup(self, state: SimulationState, config: SimulationConfig, objects: ObjectContainer) -> Self:
+        """Setting up internal attributes and validating inputs."""
+        spp = int(round(self.wave_character.get_period() / config.time_step_duration))
+        self = self.aset("_spp", spp, create_new_ok=True)
+        self = self.aset(
+            "max_steps", config.time_steps_total if self.max_steps is None else self.max_steps, create_new_ok=True
+        )
+        self = self.aset(
+            "min_steps",
+            int(round((self.prev_periods + 1) * spp)) if self.min_steps is None else self.min_steps,
+            create_new_ok=True,
+        )
+        self._validate(state, config, objects)
+
+        return self
+
+    def _validate(self, state: SimulationState, config: SimulationConfig, objects: ObjectContainer) -> None:
+        _, arrays = state
+
+        if (self.prev_periods + 1) * self._spp > config.time_steps_total:
+            raise ValueError(
+                "Number of samples over which DetectorConvergenceCondition computes is "
+                "greater than the number of time steps in the simulation. "
+                "Increase the time over which the simulation runs in SimulationConfig, "
+                "decrease prev_periods, or use a source with a shorter period."
+            )
+
+        if self.detector_name not in arrays.detector_states:
+            available = tuple(arrays.detector_states.keys())
+            raise KeyError(f"Detector '{self.detector_name}' not found. Available detectors: {available}")
+        det_state: DetectorState = arrays.detector_states[self.detector_name]
+
+        if all(k not in det_state for k in ("energy", "poynting_flux", "fields")):
+            available = tuple(det_state.keys())
+            raise KeyError(
+                f"Chosen detector does not seem to be an EnergyDetector, PoyntingFluxDetector, FieldDetector.\n "
+                f"Available keys: {available}"
+            )
+        readings = next(iter(det_state.values()))
+
+        if readings.ndim != 2:
+            raise ValueError(
+                f"The selected detector must have reduce_volume=True. Therefore, "
+                f"the DetectorState('{self.detector_name}') array must have two "
+                f"dimensions; got ndim={readings.ndim}.\n"
+            )
+
+        if readings.shape[0] != config.time_steps_total:
+            raise ValueError(
+                f"The number of detector readings must be exactly the same as the number of time steps in the simulation. "
+                f"Number of detector readings: {readings.shape[0]}, time steps: {config.time_steps_total}.\n"
+            )
+
+        if self.prev_periods < 1:
+            raise ValueError(f"prev_periods must be >= 1; got {self.prev_periods}.")
+
+        if self.threshold < 0:
+            raise ValueError(f"Detector convergence threshold must be non-negative, got {self.threshold}.")
+
+        if self.min_steps is not None and self.min_steps < (self.prev_periods + 1) * self._spp:
+            raise ValueError(
+                "min_steps must be larger than the number of steps used to compute convergence, "
+                f"got {self.min_steps}, need more than {(self.prev_periods + 1) * self._spp}. "
+                "You can also decrease prev_periods to match min_steps, or you can leave min_steps unset, "
+                "as a suitable default will be used."
+            )
+
+    def __call__(self, state: SimulationState, config: SimulationConfig, objects: ObjectContainer) -> jax.Array:
+        """Check if simulation should continue based on the L2 norm between Fourier
+        transforms of the last period and an average over a number of previous
+        periods ``prev_periods``.
+
+        Args:
+            state (SimulationState): Current simulation state.
+            config (SimulationConfig): Configuration of the simulation.
+            objects (ObjectContainer): Objects in simulation.
+
+        Returns:
+            jax.Array: Boolean scalar - True if condition not met and curr_time_step < max_steps.
+        """
+        curr_time_step, arrays = state
+        converged: jnp.ndarray = jnp.array(False, dtype=bool)
+        readings: jax.Array = next(iter(arrays.detector_states[self.detector_name].values()))
+
+        # Always continue if below minimum steps, always stop if at end_step
+        time_condition = curr_time_step < config.time_steps_total
+        min_steps_condition = curr_time_step >= self.min_steps
+
+        # Wrapping this in a func so we don't compute it until min_steps_condition == True
+        def _compute_converged(_):
+            start_ref = curr_time_step - (self.prev_periods + 1) * self._spp
+            start_last = curr_time_step - self._spp
+
+            # Clamp to valid bounds to avoid OOB under JIT (it doesn't like that)
+            start_ref = jnp.clip(start_ref, 0, config.time_steps_total - self.prev_periods * self._spp)
+            start_last = jnp.clip(start_last, 0, config.time_steps_total - self._spp)
+
+            ref_2d = jax.lax.dynamic_slice(readings, (start_ref, 0), (self.prev_periods * self._spp, 1))
+            last_2d = jax.lax.dynamic_slice(readings, (start_last, 0), (self._spp, 1))
+
+            readings_ref = jnp.squeeze(ref_2d, axis=1)  # (k*spp,)
+            readings_last = jnp.squeeze(last_2d, axis=1)  # (spp,)
+
+            # Take the reference readings and average all prev_periods together (prev_periods*spp,) -> (spp,)
+            ref_periods = readings_ref.reshape(self.prev_periods, self._spp)  # (prev_periods, spp)
+            ref_mean = jnp.mean(ref_periods, axis=0)  # (spp,)
+
+            fft_ref = jnp.fft.rfft(ref_mean, n=self._spp)  # (spp//2 + 1,)
+            fft_last = jnp.fft.rfft(readings_last, n=self._spp)  # (spp//2 + 1,)
+
+            spectra_distance = jnp.linalg.norm(jnp.abs(fft_ref) - jnp.abs(fft_last))
+            return spectra_distance < self.threshold
+
+        converged = jax.lax.cond(
+            min_steps_condition,
+            _compute_converged,
+            lambda _: jnp.array(False, dtype=bool),
+            operand=None,
+        )
+
+        return (~min_steps_condition) | (time_condition & (~converged))

--- a/src/fdtdx/fdtd/wrapper.py
+++ b/src/fdtdx/fdtd/wrapper.py
@@ -3,6 +3,7 @@ import jax
 from fdtdx.config import SimulationConfig
 from fdtdx.fdtd.container import ArrayContainer, ObjectContainer, SimulationState
 from fdtdx.fdtd.fdtd import checkpointed_fdtd, reversible_fdtd
+from fdtdx.fdtd.stop_conditions import StoppingCondition
 
 
 def run_fdtd(
@@ -10,7 +11,16 @@ def run_fdtd(
     objects: ObjectContainer,
     config: SimulationConfig,
     key: jax.Array,
+    stopping_condition: StoppingCondition | None = None,
 ) -> SimulationState:
+    if stopping_condition is not None:
+        if config.gradient_config is not None:
+            raise NotImplementedError(
+                "Custom stopping conditions are not yet compatible with gradient computation. "
+                "Set config.gradient_config to None or use default time-based stopping by "
+                "setting stopping_condition=None."
+            )
+
     if config.gradient_config is None:
         # only forward simulation, use standard while loop of checkpointed fdtd
         return checkpointed_fdtd(
@@ -18,6 +28,7 @@ def run_fdtd(
             objects=objects,
             config=config,
             key=key,
+            stopping_condition=stopping_condition,
         )
     if config.gradient_config.method == "reversible":
         return reversible_fdtd(
@@ -32,6 +43,7 @@ def run_fdtd(
             objects=objects,
             config=config,
             key=key,
+            stopping_condition=stopping_condition,
         )
     else:
         raise Exception(f"Unknown gradient computation method: {config.gradient_config.method}")

--- a/tests/fdtd/test_condition.py
+++ b/tests/fdtd/test_condition.py
@@ -1,0 +1,356 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+from fdtdx.config import SimulationConfig
+from fdtdx.core.wavelength import WaveCharacter
+from fdtdx.fdtd.container import ArrayContainer
+from fdtdx.fdtd.initialization import place_objects
+
+# Import the module to test
+from fdtdx.fdtd.stop_conditions import DetectorConvergenceCondition, EnergyThresholdCondition, TimeStepCondition
+from fdtdx.objects.boundaries.boundary import BaseBoundaryState
+from fdtdx.objects.detectors.detector import DetectorState
+from fdtdx.objects.detectors.energy import EnergyDetector
+from fdtdx.objects.static_material.static import SimulationVolume
+
+
+class TestCondition:
+    @pytest.fixture
+    def setup_simulation_state(self):
+        """Set up a basic simulation state for testing."""
+        # Create dummy arrays with appropriate shapes
+        E = jnp.ones((3, 10, 10, 10))  # 3D electric field
+        H = jnp.ones((3, 10, 10, 10))  # 3D magnetic field
+        inv_permittivities = jnp.ones((10, 10, 10))
+        inv_permeabilities = jnp.ones((10, 10, 10))
+
+        # Create mock boundary and detector states
+        boundary_states = {"pml": BaseBoundaryState()}
+        detector_states = {"detector1": DetectorState()}
+
+        # Create array container
+        arrays = ArrayContainer(
+            E=E,
+            H=H,
+            inv_permittivities=inv_permittivities,
+            inv_permeabilities=inv_permeabilities,
+            boundary_states=boundary_states,
+            detector_states=detector_states,
+            recording_state=None,
+            electric_conductivity=None,
+            magnetic_conductivity=None,
+        )
+
+        # Create simulation state
+        time_step = jnp.array(0)
+        state = (time_step, arrays)
+
+        config = SimulationConfig(
+            time=100e-11,
+            resolution=1e-4,
+            courant_factor=0.99,
+        )
+        detector_name = "test_detector"
+        detector = EnergyDetector(name=detector_name)
+        volume = SimulationVolume(partial_real_shape=(1e-3, 1e-3, 1e-3))
+        position_constraints = []
+        position_constraints.extend(detector.same_position_and_size(volume))
+        key = jax.random.PRNGKey(0)
+        objects, arrays, _, config, _ = place_objects(
+            volume=volume,
+            config=config,
+            constraints=position_constraints,
+            key=key,
+        )
+
+        return {"state": state, "config": config, "objects": objects, "dn": detector_name}
+
+    def test_condition_function_signature(self, setup_simulation_state):
+        """Test that stopping condition function has the correct signature and returns expected types."""
+        state = setup_simulation_state["state"]
+        config = setup_simulation_state["config"]
+        objects = setup_simulation_state["objects"]
+        detector_name = setup_simulation_state["dn"]
+        arrays = state[1]
+        cw_source_period = 5e-11  # 20 GHz
+        wave_character = WaveCharacter(period=cw_source_period)
+        threshold = 1e-6
+        min_steps = 1572  # Approximately 5 periods at 20 GHz with dt ~ 1.906e-13 s.
+        # This value ensures min_steps > spp * (prev_periods+1),
+        # otherwise a ValueError is raised
+
+        arrays.detector_states[detector_name] = {"energy": jnp.zeros((config.time_steps_total, 1))}
+
+        # TimeStepCondition
+        time_step_cond = TimeStepCondition()
+        ts_result = time_step_cond(state, config, objects)
+
+        assert isinstance(ts_result, jax.Array)
+        assert ts_result.dtype == jnp.bool_
+        assert ts_result.shape == ()
+
+        # EnergyThresholdCondition
+        energy_thresh_cond = EnergyThresholdCondition(
+            threshold=threshold,
+            min_steps=min_steps,
+        )
+        energy_thresh_cond = energy_thresh_cond.setup(state, config, objects)
+        et_result = energy_thresh_cond(state, config, objects)
+
+        assert isinstance(et_result, jax.Array)
+        assert et_result.dtype == jnp.bool_
+        assert et_result.shape == ()
+
+        detector_cond = DetectorConvergenceCondition(
+            detector_name=detector_name,
+            wave_character=wave_character,
+            prev_periods=5,
+            threshold=threshold,
+            min_steps=min_steps,
+        )
+        detector_cond = detector_cond.setup(state, config, objects)
+        dc_result = detector_cond(state, config, objects)
+
+        assert isinstance(dc_result, jax.Array)
+        assert dc_result.dtype == jnp.bool_
+        assert dc_result.shape == ()
+
+    def test_time_step_condition(self, setup_simulation_state):
+        state = setup_simulation_state["state"]
+        config = setup_simulation_state["config"]
+        objects = setup_simulation_state["objects"]
+
+        cond_fun = TimeStepCondition()
+        cond_fun = cond_fun.setup(state, config, objects)
+
+        # Test when time_step < config.time_steps_total
+        assert cond_fun(state, config, objects)
+
+        # Test when time_step == config.time_steps_total
+        state = (jnp.array(config.time_steps_total), state[1])
+        assert not cond_fun(state, config, objects)
+
+        # Test when time_step > config.time_steps_total
+        state = (jnp.array(config.time_steps_total + 1), state[1])
+        assert not cond_fun(state, config, objects)
+
+    def test_energy_threshold_condition(self, setup_simulation_state):
+        state = setup_simulation_state["state"]
+        config = setup_simulation_state["config"]
+        objects = setup_simulation_state["objects"]
+        arrays = state[1]
+        min_steps = 10
+
+        # Test threshold being negative -> should raise ValueError
+        threshold = -1e-5
+        with pytest.raises(ValueError, match="must be positive"):
+            EnergyThresholdCondition(
+                threshold=threshold,
+                min_steps=min_steps,
+            ).setup(state, config, objects)
+
+        # Test threshold being zero -> should raise ValueError
+        threshold = 0.0
+        with pytest.raises(ValueError, match="must be positive"):
+            EnergyThresholdCondition(
+                threshold=threshold,
+                min_steps=min_steps,
+            ).setup(state, config, objects)
+
+        # Test min_steps being negative -> should raise ValueError
+        threshold = 1e-5
+        min_steps = -1
+        with pytest.raises(ValueError, match="must be non-negative"):
+            EnergyThresholdCondition(
+                threshold=threshold,
+                min_steps=min_steps,
+            ).setup(state, config, objects)
+
+        # Test before min_steps -> should continue
+        threshold = 1e-5
+        min_steps = 10
+        cond_fun = EnergyThresholdCondition(
+            threshold=threshold,
+            min_steps=min_steps,
+        )
+        state_before_min = (jnp.array(min_steps - 2), arrays)
+        cond_fun = cond_fun.setup(state_before_min, config, objects)
+        assert cond_fun(state_before_min, config, objects)
+
+        # Test after min_steps, above threshold -> should continue
+        state_above_thresh = (jnp.array(min_steps + 1), arrays)
+        cond_fun = cond_fun.setup(state_above_thresh, config, objects)
+        assert cond_fun(state_above_thresh, config, objects)
+
+        # Test after min_steps, under threshold -> should stop
+        # To simulate having a lower energy than the threshold, we'll manually
+        # create a state where the energy is below the threshold,
+        # by setting its attributes, E and H, to a small value
+        nE = arrays.E.size
+        nH = arrays.H.size
+        v = jnp.sqrt(threshold / float(nE + nH)) * 0.9
+        v = jnp.asarray(v, dtype=arrays.E.dtype)
+        E_new = jnp.full_like(arrays.E, v)
+        H_new = jnp.full_like(arrays.H, v)
+        arrays_new = arrays.aset("E", E_new).aset("H", H_new)
+        state_below_thresh = (jnp.array(min_steps + 1), arrays_new)
+        cond_fun = cond_fun.setup(state_below_thresh, config, objects)
+        assert not cond_fun(state_below_thresh, config, objects)
+
+        # Test at config.time_steps_total -> should stop regardless
+        # of total energy value
+        state_at_end = (jnp.array(config.time_steps_total), arrays)
+        cond_fun = cond_fun.setup(state_at_end, config, objects)
+        assert not cond_fun(state_at_end, config, objects)
+
+    def test_detector_convergence_condition(self, setup_simulation_state):
+        state = setup_simulation_state["state"]
+        config = setup_simulation_state["config"]
+        objects = setup_simulation_state["objects"]
+        arrays = state[1]
+        # If courant_factor=0.99 and resolution=1e-4, then time_step_duration ≈ 1.906e-13 s
+        # Therefore we have time / time_step_duration ≈ 524.5, which is rounded up to 525.
+        # This is the number of time steps. Remember that min_steps cannot be larger than this
+        detector_name = setup_simulation_state["dn"]
+        cw_source_period = 5e-11  # 20 GHz
+        wave_character = WaveCharacter(frequency=1 / cw_source_period)
+        prev_periods = 2
+        min_steps = 786
+        threshold = 1e-5
+
+        # Make dummy energy detector readings
+        energy_readings = jnp.linspace(1.0, 0.0, config.time_steps_total).reshape(-1, 1)
+        detector_state = {"energy": energy_readings}
+        arrays.detector_states[detector_name] = detector_state
+
+        # Test (prev_periods + 1)*spp exceeding total steps
+        large_period = config.time_step_duration * config.time_steps_total
+        with pytest.raises(ValueError, match="Number of samples over which"):
+            DetectorConvergenceCondition(
+                detector_name=detector_name,
+                wave_character=WaveCharacter(period=large_period),
+                prev_periods=4,
+                threshold=1e-6,
+            ).setup(state, config, objects)
+
+        # Test detector readings must be 2D (ndim == 2)
+        with pytest.raises(ValueError, match="must have two *dimensions*|must have reduce_volume"):
+            arrays.detector_states["bad_detector"] = {"energy": jnp.zeros((config.time_steps_total,))}
+            DetectorConvergenceCondition(
+                detector_name="bad_detector",
+                wave_character=WaveCharacter(period=5e-11),
+                prev_periods=2,
+                threshold=1e-6,
+            ).setup(state, config, objects)
+
+        # Detector readings' first dimension must equal total time steps
+        with pytest.raises(ValueError, match="number of detector readings must be exactly"):
+            arrays.detector_states["bad_detector"] = {"energy": jnp.zeros((config.time_steps_total - 1, 1))}
+            DetectorConvergenceCondition(
+                detector_name="bad_detector",
+                wave_character=WaveCharacter(period=5e-11),
+                prev_periods=2,
+                threshold=1e-6,
+            ).setup(state, config, objects)
+
+        # Test prev_periods being less than 1
+        with pytest.raises(ValueError, match="prev_periods must be >= 1"):
+            DetectorConvergenceCondition(
+                detector_name=detector_name,
+                wave_character=WaveCharacter(period=5e-11),
+                prev_periods=0,
+                threshold=1e-6,
+            ).setup(state, config, objects)
+
+        # Test (prev_periods + 1) * spp being larger than min_steps
+        with pytest.raises(ValueError, match="must be larger"):
+            DetectorConvergenceCondition(
+                detector_name=detector_name,
+                wave_character=WaveCharacter(period=1e-12),
+                prev_periods=5,
+                threshold=1e-6,
+                min_steps=3,
+            ).setup(state, config, objects)
+
+        # Test threshold being negative
+        with pytest.raises(ValueError, match="must be non-negative"):
+            DetectorConvergenceCondition(
+                detector_name=detector_name,
+                wave_character=WaveCharacter(period=5e-11),
+                prev_periods=2,
+                threshold=-1e-6,
+            ).setup(state, config, objects)
+
+        # Test before min_steps -> should continue
+        cond_fun = DetectorConvergenceCondition(
+            detector_name=detector_name,
+            wave_character=wave_character,
+            prev_periods=prev_periods,
+            threshold=threshold,
+            min_steps=min_steps,
+        )
+        state_before_min = (jnp.array(min_steps - 10), arrays)
+        cond_fun = cond_fun.setup(state_before_min, config, objects)
+        assert cond_fun(state_before_min, config, objects)
+
+        # Test after min_steps, but not converged -> should continue
+        # Energy difference is larger than threshold
+        state_not_converged = (jnp.array(min_steps + 1), arrays)
+        cond_fun = cond_fun.setup(state_not_converged, config, objects)
+        assert cond_fun(state_not_converged, config, objects)
+
+        # Test after min_steps and converged -> should stop
+        # To simulate convergence, we'll manually create a state where the
+        # energy difference is below the threshold
+        converged_energy_readings = jnp.ones(config.time_steps_total).reshape(-1, 1)
+        converged_energy_readings = converged_energy_readings.at[min_steps + 1].set(
+            converged_energy_readings[min_steps] + threshold / 10
+        )
+        arrays.detector_states[detector_name]["energy"] = converged_energy_readings
+        state_converged = (jnp.array(min_steps + 2), arrays)
+        cond_fun = cond_fun.setup(state_converged, config, objects)
+        assert not cond_fun(state_converged, config, objects)
+
+        # Test at end_step -> should stop regardless of convergence
+        state_at_end = (jnp.array(config.time_steps_total), arrays)
+        cond_fun = cond_fun.setup(state_at_end, config, objects)
+        assert not cond_fun(state_at_end, config, objects)
+
+    def test_jit_compatibility(self, setup_simulation_state):
+        state = setup_simulation_state["state"]
+        config = setup_simulation_state["config"]
+        objects = setup_simulation_state["objects"]
+        arrays = state[1]
+        detector_name = setup_simulation_state["dn"]
+
+        ts_cond_fun = TimeStepCondition()
+        ts_cond_fun = ts_cond_fun.setup(state, config, objects)
+        jitted_ts_cond_fun = jax.jit(ts_cond_fun)
+        result = jitted_ts_cond_fun(state, config, objects)
+        assert isinstance(result, jax.Array)
+
+        ec_cond_fun = EnergyThresholdCondition(
+            threshold=1e-5,
+            min_steps=10,
+        )
+        ec_cond_fun = ec_cond_fun.setup(state, config, objects)
+        jitted_ec_cond_fun = jax.jit(ec_cond_fun)
+        result = jitted_ec_cond_fun(state, config, objects)
+        assert isinstance(result, jax.Array)
+
+        arrays.detector_states[detector_name] = {"energy": jnp.zeros((config.time_steps_total, 1))}
+        # Choose a small period so spp is small and feasible for this config:
+        # e.g., period = 2 * dt -> spp ~= 2, prev_periods=1 => (k+1)*spp = 4 << T
+        wave_character = WaveCharacter(period=2 * config.time_step_duration)
+        dc_cond_fun = DetectorConvergenceCondition(
+            detector_name=detector_name,
+            wave_character=wave_character,
+            prev_periods=1,
+            threshold=1e-5,
+            min_steps=None,
+        )
+        dc_cond_fun = dc_cond_fun.setup(state, config, objects)
+        jitted_dc_cond_fun = jax.jit(dc_cond_fun)
+        result = jitted_dc_cond_fun(state, config, objects)
+        assert isinstance(result, jax.Array)

--- a/tests/fdtd/test_wrapper.py
+++ b/tests/fdtd/test_wrapper.py
@@ -39,10 +39,12 @@ class TestRunFdtd:
             mock_result = Mock(spec=SimulationState)
             mock_checkpointed.return_value = mock_result
 
-            result = run_fdtd(arrays, objects, config, key)
+            result = run_fdtd(arrays, objects, config, key, stopping_condition=None)
 
             # Verify checkpointed_fdtd was called
-            mock_checkpointed.assert_called_once_with(arrays=arrays, objects=objects, config=config, key=key)
+            mock_checkpointed.assert_called_once_with(
+                arrays=arrays, objects=objects, config=config, key=key, stopping_condition=None
+            )
 
             # Verify the result is returned
             assert result == mock_result
@@ -83,10 +85,12 @@ class TestRunFdtd:
             mock_result = Mock(spec=SimulationState)
             mock_checkpointed.return_value = mock_result
 
-            result = run_fdtd(arrays, objects, config, key)
+            result = run_fdtd(arrays, objects, config, key, stopping_condition=None)
 
             # Verify checkpointed_fdtd was called
-            mock_checkpointed.assert_called_once_with(arrays=arrays, objects=objects, config=config, key=key)
+            mock_checkpointed.assert_called_once_with(
+                arrays=arrays, objects=objects, config=config, key=key, stopping_condition=None
+            )
 
             # Verify the result is returned
             assert result == mock_result
@@ -116,10 +120,12 @@ class TestRunFdtd:
             mock_result = Mock(spec=SimulationState)
             mock_checkpointed.return_value = mock_result
 
-            run_fdtd(arrays, objects, config, key)
+            run_fdtd(arrays, objects, config, key, stopping_condition=None)
 
             # Verify checkpointed_fdtd was called
-            mock_checkpointed.assert_called_once_with(arrays=arrays, objects=objects, config=config, key=key)
+            mock_checkpointed.assert_called_once_with(
+                arrays=arrays, objects=objects, config=config, key=key, stopping_condition=None
+            )
 
     def test_gradient_config_with_none_method(self, setup):
         """Test edge case where gradient_config exists but method is None"""


### PR DESCRIPTION
This PR attempts to solve issue #103. As suggested there, this here is a bit of a draft to obtain feedback on how this should be implemented. This is my first time when writing code using JAX that compiles to XLA, so said feedback is more than welcome.

On that note, I was wondering; Objects which are of class `DetectorState`, accessed by doing `arrays.detector_states["detector_name"]` are (so far) a dictionary with a key being the detector type name (`poynting_flux`, `phasor`, and so on) and the value being a `jax.Array`. As far as I understand, this array's shape changes with each time step, and I read that this may make it necessary to recompile functions/methods that might use it. I imagine recompiling this logic on every time step would be slow. But, is this true? Would I need to use arrays with a fixed shape to avoid recompilations? FDTDX already uses such arrays that vary their shape in time (detectors themselves) so I'm a bit confused on what to do in order to avoid recompilation and ensure good performance.

I also am throwing exceptions to indicate no compatibility with gradient computation, but I read that you can't do that inside JIT compiled code, and `custom_fdtd_forward` is supposedly compiled.