### PR TITLE
restricted python version smaller than 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Yannik Mahlau", email = "mahlau@tnt.uni-hannover.de" },
     { name = "Frederik Schubert", email = "schubert@tnt.uni-hannover.de" },
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.11, <3.14"
 dependencies = [
     "loguru>=0.7.3",
     "pytreeclass>=0.11",


### PR DESCRIPTION
resolves #239 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restrict supported Python versions to >=3.11 and <3.14 to prevent installs on Python 3.14+ where we have known incompatibilities. Updated requires-python in pyproject.toml accordingly.

<sup>Written for commit 1500b02be36abe5eab96b0df6e9daf6b6312b95e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

