### PR TITLE
Initial Polygon from GDS implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "matplotlib>=3.9.4",
     "rich>=13.9.4",
     "typing-extensions>=4.14.1",
+    "gdstk>=0.9",
 ]
 
 [project.urls]

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -84,7 +84,11 @@ from fdtdx.objects.sources.linear_polarization import GaussianPlaneSource, Unifo
 from fdtdx.objects.sources.mode import ModePlaneSource
 from fdtdx.objects.sources.profile import GaussianPulseProfile, SingleFrequencyProfile
 from fdtdx.objects.static_material.cylinder import Cylinder
-from fdtdx.objects.static_material.polygon import ExtrudedPolygon, extruded_polygon_from_gds
+from fdtdx.objects.static_material.polygon import (
+    ExtrudedPolygon,
+    extruded_polygon_from_gds,
+    extruded_polygon_from_gds_path,
+)
 from fdtdx.objects.static_material.sphere import Sphere
 from fdtdx.objects.static_material.static import SimulationVolume, UniformMaterialObject
 from fdtdx.utils.logger import Logger
@@ -191,6 +195,7 @@ __all__ = [
     "Sphere",
     "ExtrudedPolygon",
     "extruded_polygon_from_gds",
+    "extruded_polygon_from_gds_path",
     "UniformMaterialObject",
     "SimulationVolume",
     # utils

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -84,7 +84,7 @@ from fdtdx.objects.sources.linear_polarization import GaussianPlaneSource, Unifo
 from fdtdx.objects.sources.mode import ModePlaneSource
 from fdtdx.objects.sources.profile import GaussianPulseProfile, SingleFrequencyProfile
 from fdtdx.objects.static_material.cylinder import Cylinder
-from fdtdx.objects.static_material.polygon import ExtrudedPolygon
+from fdtdx.objects.static_material.polygon import ExtrudedPolygon, extruded_polygon_from_gds
 from fdtdx.objects.static_material.sphere import Sphere
 from fdtdx.objects.static_material.static import SimulationVolume, UniformMaterialObject
 from fdtdx.utils.logger import Logger
@@ -190,6 +190,7 @@ __all__ = [
     "Cylinder",
     "Sphere",
     "ExtrudedPolygon",
+    "extruded_polygon_from_gds",
     "UniformMaterialObject",
     "SimulationVolume",
     # utils

--- a/src/fdtdx/objects/static_material/polygon.py
+++ b/src/fdtdx/objects/static_material/polygon.py
@@ -85,6 +85,53 @@ class ExtrudedPolygon(StaticMultiMaterialObject):
 
 
 def extruded_polygon_from_gds(
+    lib: gdstk.Library,
+    cell_name: str,
+    layer: int,
+    datatype: int = 0,
+    polygon_index: int = 0,
+    **kwargs,
+) -> ExtrudedPolygon:
+    """Create an ExtrudedPolygon from a polygon in an already-loaded gdstk Library.
+
+    Args:
+        lib: An already-loaded gdstk Library.
+        cell_name: Name of the GDS cell containing the polygon.
+        layer: GDS layer number to read.
+        datatype: GDS datatype (default 0).
+        polygon_index: Which polygon to use when multiple exist on the layer (default 0).
+        **kwargs: Forwarded to ExtrudedPolygon (axis, material_name, materials, …).
+
+    Returns:
+        ExtrudedPolygon with vertices centered around the origin in metres.
+
+    Raises:
+        ValueError: If the cell or layer/datatype combination is not found.
+        IndexError: If polygon_index is out of range.
+    """
+    cell = next((c for c in lib.cells if isinstance(c, gdstk.Cell) and c.name == cell_name), None)
+    if cell is None:
+        raise ValueError(f"Cell '{cell_name}' not found in library")
+
+    matching = [p for p in cell.polygons if p.layer == layer and p.datatype == datatype]
+    if not matching:
+        raise ValueError(f"No polygons on layer={layer}, datatype={datatype} in cell '{cell_name}'")
+    if polygon_index >= len(matching):
+        raise IndexError(
+            f"polygon_index={polygon_index} out of range; found {len(matching)} polygon(s) on layer={layer}"
+        )
+
+    polygon = matching[polygon_index]
+    vertices_m = np.array(polygon.points) * lib.unit  # library units → metres
+
+    # centre vertices around origin (ExtrudedPolygon convention)
+    centre = 0.5 * (vertices_m.min(axis=0) + vertices_m.max(axis=0))
+    centred = vertices_m - centre
+
+    return ExtrudedPolygon(vertices=centred, **kwargs)
+
+
+def extruded_polygon_from_gds_path(
     gds_file: str | pathlib.Path,
     cell_name: str,
     layer: int,
@@ -110,24 +157,4 @@ def extruded_polygon_from_gds(
         IndexError: If polygon_index is out of range.
     """
     lib = gdstk.read_gds(str(gds_file))
-
-    cell = next((c for c in lib.cells if isinstance(c, gdstk.Cell) and c.name == cell_name), None)
-    if cell is None:
-        raise ValueError(f"Cell '{cell_name}' not found in '{gds_file}'")
-
-    matching = [p for p in cell.polygons if p.layer == layer and p.datatype == datatype]
-    if not matching:
-        raise ValueError(f"No polygons on layer={layer}, datatype={datatype} in cell '{cell_name}'")
-    if polygon_index >= len(matching):
-        raise IndexError(
-            f"polygon_index={polygon_index} out of range; found {len(matching)} polygon(s) on layer={layer}"
-        )
-
-    polygon = matching[polygon_index]
-    vertices_m = np.array(polygon.points) * lib.unit  # library units → metres
-
-    # centre vertices around origin (ExtrudedPolygon convention)
-    centre = 0.5 * (vertices_m.min(axis=0) + vertices_m.max(axis=0))
-    centred = vertices_m - centre
-
-    return ExtrudedPolygon(vertices=centred, **kwargs)
+    return extruded_polygon_from_gds(lib, cell_name, layer, datatype, polygon_index, **kwargs)

--- a/src/fdtdx/objects/static_material/polygon.py
+++ b/src/fdtdx/objects/static_material/polygon.py
@@ -1,3 +1,6 @@
+import pathlib
+
+import gdstk
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -79,3 +82,52 @@ class ExtrudedPolygon(StaticMultiMaterialObject):
         idx = all_names.index(self.material_name)
         arr = jnp.ones(self.grid_shape, dtype=jnp.int32) * idx
         return arr
+
+
+def extruded_polygon_from_gds(
+    gds_file: str | pathlib.Path,
+    cell_name: str,
+    layer: int,
+    datatype: int = 0,
+    polygon_index: int = 0,
+    **kwargs,
+) -> ExtrudedPolygon:
+    """Create an ExtrudedPolygon from a polygon in a GDS file.
+
+    Args:
+        gds_file: Path to the .gds file.
+        cell_name: Name of the GDS cell containing the polygon.
+        layer: GDS layer number to read.
+        datatype: GDS datatype (default 0).
+        polygon_index: Which polygon to use when multiple exist on the layer (default 0).
+        **kwargs: Forwarded to ExtrudedPolygon (axis, material_name, materials, …).
+
+    Returns:
+        ExtrudedPolygon with vertices centered around the origin in metres.
+
+    Raises:
+        ValueError: If the cell or layer/datatype combination is not found.
+        IndexError: If polygon_index is out of range.
+    """
+    lib = gdstk.read_gds(str(gds_file))
+
+    cell = next((c for c in lib.cells if isinstance(c, gdstk.Cell) and c.name == cell_name), None)
+    if cell is None:
+        raise ValueError(f"Cell '{cell_name}' not found in '{gds_file}'")
+
+    matching = [p for p in cell.polygons if p.layer == layer and p.datatype == datatype]
+    if not matching:
+        raise ValueError(f"No polygons on layer={layer}, datatype={datatype} in cell '{cell_name}'")
+    if polygon_index >= len(matching):
+        raise IndexError(
+            f"polygon_index={polygon_index} out of range; found {len(matching)} polygon(s) on layer={layer}"
+        )
+
+    polygon = matching[polygon_index]
+    vertices_m = np.array(polygon.points) * lib.unit  # library units → metres
+
+    # centre vertices around origin (ExtrudedPolygon convention)
+    centre = 0.5 * (vertices_m.min(axis=0) + vertices_m.max(axis=0))
+    centred = vertices_m - centre
+
+    return ExtrudedPolygon(vertices=centred, **kwargs)

--- a/tests/unit/objects/static_material/test_polygon.py
+++ b/tests/unit/objects/static_material/test_polygon.py
@@ -11,7 +11,11 @@ import pytest
 
 from fdtdx.config import SimulationConfig
 from fdtdx.materials import Material
-from fdtdx.objects.static_material.polygon import ExtrudedPolygon, extruded_polygon_from_gds
+from fdtdx.objects.static_material.polygon import (
+    ExtrudedPolygon,
+    extruded_polygon_from_gds,
+    extruded_polygon_from_gds_path,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -222,14 +226,14 @@ class TestGetMaterialMapping:
 
 
 # ---------------------------------------------------------------------------
-# extruded_polygon_from_gds
+# extruded_polygon_from_gds / extruded_polygon_from_gds_path
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture
-def square_gds(tmp_path):
-    """Write a GDS file with a 200nm square on layer 1 and return its path."""
-    half = 0.1  # 0.1 µm = 100 nm in GDS library units (1e-6 m)
+def square_lib():
+    """In-memory gdstk Library with a 200nm square on layer 1."""
+    half = 0.1  # 0.1 µm = 100 nm
     lib = gdstk.Library(unit=1e-6, precision=1e-9)
     cell = lib.new_cell("TOP")
     cell.add(
@@ -239,46 +243,78 @@ def square_gds(tmp_path):
             datatype=0,
         )
     )
+    return lib
+
+
+@pytest.fixture
+def square_gds(square_lib, tmp_path):
+    """Write the square library to a .gds file and return its path."""
     path = tmp_path / "test.gds"
-    lib.write_gds(str(path))
+    square_lib.write_gds(str(path))
     return path
 
 
 @pytest.mark.unit
 class TestExtrudedPolygonFromGds:
-    def test_returns_extruded_polygon(self, square_gds, two_materials):
+    """Tests for extruded_polygon_from_gds (accepts a gdstk.Library)."""
+
+    def test_returns_extruded_polygon(self, square_lib, two_materials):
         result = extruded_polygon_from_gds(
-            square_gds, "TOP", layer=1, axis=2, material_name="si", materials=two_materials
+            square_lib, "TOP", layer=1, axis=2, material_name="si", materials=two_materials
         )
         assert isinstance(result, ExtrudedPolygon)
 
-    def test_vertices_shape(self, square_gds, two_materials):
+    def test_vertices_shape(self, square_lib, two_materials):
         result = extruded_polygon_from_gds(
-            square_gds, "TOP", layer=1, axis=2, material_name="si", materials=two_materials
+            square_lib, "TOP", layer=1, axis=2, material_name="si", materials=two_materials
         )
         assert result.vertices.shape == (4, 2)
 
-    def test_vertices_centred_around_origin(self, square_gds, two_materials):
+    def test_vertices_centred_around_origin(self, square_lib, two_materials):
         """Vertices should be symmetric: max ≈ +100 nm, min ≈ -100 nm."""
         result = extruded_polygon_from_gds(
-            square_gds, "TOP", layer=1, axis=2, material_name="si", materials=two_materials
+            square_lib, "TOP", layer=1, axis=2, material_name="si", materials=two_materials
         )
         expected_half = 100e-9
         assert np.allclose(result.vertices.max(axis=0), [expected_half, expected_half])
         assert np.allclose(result.vertices.min(axis=0), [-expected_half, -expected_half])
 
-    def test_bad_cell_name_raises(self, square_gds, two_materials):
+    def test_bad_cell_name_raises(self, square_lib, two_materials):
         with pytest.raises(ValueError, match="Cell 'MISSING'"):
             extruded_polygon_from_gds(
-                square_gds, "MISSING", layer=1, axis=2, material_name="si", materials=two_materials
+                square_lib, "MISSING", layer=1, axis=2, material_name="si", materials=two_materials
             )
 
-    def test_bad_layer_raises(self, square_gds, two_materials):
+    def test_bad_layer_raises(self, square_lib, two_materials):
         with pytest.raises(ValueError, match="layer=99"):
-            extruded_polygon_from_gds(square_gds, "TOP", layer=99, axis=2, material_name="si", materials=two_materials)
+            extruded_polygon_from_gds(square_lib, "TOP", layer=99, axis=2, material_name="si", materials=two_materials)
 
-    def test_polygon_index_out_of_range_raises(self, square_gds, two_materials):
+    def test_polygon_index_out_of_range_raises(self, square_lib, two_materials):
         with pytest.raises(IndexError, match="polygon_index=5"):
             extruded_polygon_from_gds(
-                square_gds, "TOP", layer=1, polygon_index=5, axis=2, material_name="si", materials=two_materials
+                square_lib, "TOP", layer=1, polygon_index=5, axis=2, material_name="si", materials=two_materials
+            )
+
+
+@pytest.mark.unit
+class TestExtrudedPolygonFromGdsPath:
+    """Tests for extruded_polygon_from_gds_path (accepts a file path)."""
+
+    def test_returns_extruded_polygon(self, square_gds, two_materials):
+        result = extruded_polygon_from_gds_path(
+            square_gds, "TOP", layer=1, axis=2, material_name="si", materials=two_materials
+        )
+        assert isinstance(result, ExtrudedPolygon)
+
+    def test_vertices_match_library_function(self, square_lib, square_gds, two_materials):
+        """Path variant must produce the same vertices as the library variant."""
+        kwargs = {"layer": 1, "axis": 2, "material_name": "si", "materials": two_materials}
+        from_lib = extruded_polygon_from_gds(square_lib, "TOP", **kwargs)
+        from_path = extruded_polygon_from_gds_path(square_gds, "TOP", **kwargs)
+        assert np.allclose(from_lib.vertices, from_path.vertices)
+
+    def test_bad_cell_name_raises(self, square_gds, two_materials):
+        with pytest.raises(ValueError, match="Cell 'MISSING'"):
+            extruded_polygon_from_gds_path(
+                square_gds, "MISSING", layer=1, axis=2, material_name="si", materials=two_materials
             )

--- a/tests/unit/objects/static_material/test_polygon.py
+++ b/tests/unit/objects/static_material/test_polygon.py
@@ -3,6 +3,7 @@
 Tests ExtrudedPolygon shape generation, material mapping, and axis properties.
 """
 
+import gdstk
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -10,7 +11,7 @@ import pytest
 
 from fdtdx.config import SimulationConfig
 from fdtdx.materials import Material
-from fdtdx.objects.static_material.polygon import ExtrudedPolygon
+from fdtdx.objects.static_material.polygon import ExtrudedPolygon, extruded_polygon_from_gds
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -218,3 +219,66 @@ class TestGetMaterialMapping:
         placed = _place(poly, config, key)
         mapping = placed.get_material_mapping()
         assert bool(jnp.all(mapping == mapping[0, 0, 0]))
+
+
+# ---------------------------------------------------------------------------
+# extruded_polygon_from_gds
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def square_gds(tmp_path):
+    """Write a GDS file with a 200nm square on layer 1 and return its path."""
+    half = 0.1  # 0.1 µm = 100 nm in GDS library units (1e-6 m)
+    lib = gdstk.Library(unit=1e-6, precision=1e-9)
+    cell = lib.new_cell("TOP")
+    cell.add(
+        gdstk.Polygon(
+            [(-half, -half), (half, -half), (half, half), (-half, half)],
+            layer=1,
+            datatype=0,
+        )
+    )
+    path = tmp_path / "test.gds"
+    lib.write_gds(str(path))
+    return path
+
+
+@pytest.mark.unit
+class TestExtrudedPolygonFromGds:
+    def test_returns_extruded_polygon(self, square_gds, two_materials):
+        result = extruded_polygon_from_gds(
+            square_gds, "TOP", layer=1, axis=2, material_name="si", materials=two_materials
+        )
+        assert isinstance(result, ExtrudedPolygon)
+
+    def test_vertices_shape(self, square_gds, two_materials):
+        result = extruded_polygon_from_gds(
+            square_gds, "TOP", layer=1, axis=2, material_name="si", materials=two_materials
+        )
+        assert result.vertices.shape == (4, 2)
+
+    def test_vertices_centred_around_origin(self, square_gds, two_materials):
+        """Vertices should be symmetric: max ≈ +100 nm, min ≈ -100 nm."""
+        result = extruded_polygon_from_gds(
+            square_gds, "TOP", layer=1, axis=2, material_name="si", materials=two_materials
+        )
+        expected_half = 100e-9
+        assert np.allclose(result.vertices.max(axis=0), [expected_half, expected_half])
+        assert np.allclose(result.vertices.min(axis=0), [-expected_half, -expected_half])
+
+    def test_bad_cell_name_raises(self, square_gds, two_materials):
+        with pytest.raises(ValueError, match="Cell 'MISSING'"):
+            extruded_polygon_from_gds(
+                square_gds, "MISSING", layer=1, axis=2, material_name="si", materials=two_materials
+            )
+
+    def test_bad_layer_raises(self, square_gds, two_materials):
+        with pytest.raises(ValueError, match="layer=99"):
+            extruded_polygon_from_gds(square_gds, "TOP", layer=99, axis=2, material_name="si", materials=two_materials)
+
+    def test_polygon_index_out_of_range_raises(self, square_gds, two_materials):
+        with pytest.raises(IndexError, match="polygon_index=5"):
+            extruded_polygon_from_gds(
+                square_gds, "TOP", layer=1, polygon_index=5, axis=2, material_name="si", materials=two_materials
+            )


### PR DESCRIPTION
Relates to #1 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GDS import for `ExtrudedPolygon` using `gdstk`, enabling shapes to be loaded from a cell and layer and used in simulations. Implements the initial GDS polygon support requested in Linear #1.

- **New Features**
  - `extruded_polygon_from_gds` and `extruded_polygon_from_gds_path` to build `ExtrudedPolygon` from a GDS library or file.
  - Select by `cell_name`, `layer`, `datatype`, and `polygon_index`.
  - Converts vertices to meters using library units and centers them at the origin.
  - Raises clear errors for missing cell/layer or out-of-range polygon index.
  - Exposed in `fdtdx.__init__` and covered by unit tests.

- **Dependencies**
  - Added `gdstk>=0.9`.

<sup>Written for commit f9c644068e810232c0c1bea4aa4f3bbb5f683dad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

