### PR TITLE
fix: dependabot config missing cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      minimum-interval-days: 7
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"
@@ -17,6 +19,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      minimum-interval-days: 7
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"
@@ -30,6 +34,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      minimum-interval-days: 7
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      minimum-interval-days: 7
+      default-days: 7
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"
@@ -20,7 +20,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      minimum-interval-days: 7
+      default-days: 7
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"
@@ -35,7 +35,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      minimum-interval-days: 7
+      default-days: 7
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted dependency update configuration to add a 7-day cooldown between automated update attempts for GitHub Actions, pip, and pre-commit ecosystems while preserving the existing weekly schedule, PR limits, and ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->