### PR TITLE
feat: warning for python v14

### DIFF
--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -1,3 +1,14 @@
+import sys
+import warnings
+
+if sys.version_info >= (3, 14):
+    warnings.warn(
+        "Python 3.14+ is not supported by fdtdx. Expect crashes and unknown errors. "
+        "Support for Python 3.14 will be added in the coming months.",
+        UserWarning,
+        stacklevel=2,
+    )
+
 from fdtdx import constants
 from fdtdx.colors import Color
 from fdtdx.config import GradientConfig, SimulationConfig


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Users running Python 3.14+ will now receive a warning indicating that this version is unsupported and may cause instability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->