### PR TITLE
feat: add CustomTimeSignalProfile and source signal visualization

### DIFF
--- a/docs/source/07_api.rst
+++ b/docs/source/07_api.rst
@@ -18,6 +18,7 @@ API
     fdtdx.compute_mode
     fdtdx.compute_poynting_flux
     fdtdx.ConnectHolesAndStructures
+    fdtdx.CustomTimeSignalProfile
     fdtdx.Cylinder
     fdtdx.Detector
     fdtdx.Device
@@ -86,6 +87,7 @@ API
     fdtdx.StandardToPlusOneMinusOneRange
     fdtdx.SubpixelSmoothedProjection
     fdtdx.TanhProjection
+    fdtdx.TemporalProfile
     fdtdx.TreeClass
     fdtdx.UniformMaterialObject
     fdtdx.UniformPlaneSource

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -94,7 +94,12 @@ from fdtdx.objects.object import (
 from fdtdx.objects.sources.dipole import PointDipoleSource
 from fdtdx.objects.sources.linear_polarization import GaussianPlaneSource, UniformPlaneSource
 from fdtdx.objects.sources.mode import ModePlaneSource
-from fdtdx.objects.sources.profile import GaussianPulseProfile, SingleFrequencyProfile
+from fdtdx.objects.sources.profile import (
+    CustomTimeSignalProfile,
+    GaussianPulseProfile,
+    SingleFrequencyProfile,
+    TemporalProfile,
+)
 from fdtdx.objects.static_material.cylinder import Cylinder
 from fdtdx.objects.static_material.polygon import (
     ExtrudedPolygon,
@@ -122,6 +127,7 @@ __all__ = [
     "ClosestIndex",
     "Color",
     "ConnectHolesAndStructures",
+    "CustomTimeSignalProfile",
     "Cylinder",
     "Detector",
     "DetectorState",
@@ -178,6 +184,7 @@ __all__ = [
     "StandardToPlusOneMinusOneRange",
     "SubpixelSmoothedProjection",
     "TanhProjection",
+    "TemporalProfile",
     "TreeClass",
     "UniformMaterialObject",
     "UniformPlaneSource",

--- a/src/fdtdx/objects/sources/profile.py
+++ b/src/fdtdx/objects/sources/profile.py
@@ -342,10 +342,17 @@ class CustomTimeSignalProfile(TemporalProfile):
     JIT before constructing this object.
 
     The sampled ``signal`` fully defines the injected time waveform, so the FDTD
-    loop does not apply an additional source-level ``phase_shift``. Optional
-    ``center_wave`` and ``fwidth`` values only describe the signal for reference
-    frequency and spectrum-plotting logic.
+    loop does not apply an additional source-level ``phase_shift``.
 
+    Unlike :class:`GaussianPulseProfile`, this profile does **not** accept a
+    ``center_wave`` or spectral-width parameter.  For an arbitrary waveform the
+    spectral centre is not a free parameter — it is an emergent property of the
+    signal.  Letting the user specify it separately would create a silent
+    inconsistency risk (e.g. labelling a broadband sinc pulse as if it were a
+    narrowband Gaussian).  Instead, :meth:`get_reference_frequency` computes the
+    power-weighted spectral centroid directly from ``signal``, and the frequency
+    axis of any plot is determined automatically from the actual spectrum content
+    via :func:`_auto_range`.
     """
 
     #: Pre-sampled waveform, shape ``(N,)``.  Lives in the pytree so JAX can
@@ -358,12 +365,6 @@ class CustomTimeSignalProfile(TemporalProfile):
     #: Simulation time at which ``signal[0]`` was sampled (seconds).
     start_time: float = frozen_field(default=0.0)
 
-    #: Optional center wavelength / frequency metadata for spectrum plots.
-    center_wave: WaveCharacter | None = frozen_field(default=None)
-
-    #: Optional spectral width metadata for spectrum plots.
-    fwidth: WaveCharacter | None = frozen_field(default=None)
-
     #: Interpolation mode: ``"linear"`` (default) or ``"nearest"``.
     interpolation: Literal["linear", "nearest"] = frozen_field(default="linear")
 
@@ -371,26 +372,20 @@ class CustomTimeSignalProfile(TemporalProfile):
     outside_value: float = frozen_field(default=0.0)
 
     def get_reference_frequency(self, period: float) -> float:
-        if self.center_wave is not None:
-            return self.center_wave.get_frequency()
-        return 1.0 / period
+        """Return the power-weighted spectral centroid of the stored signal.
 
-    def get_frequency_plot_range(
-        self,
-        period: float,
-        frequencies: np.ndarray,
-        spectrum: np.ndarray,
-    ) -> tuple[float, float] | None:
-        if self.center_wave is None or self.fwidth is None:
-            return None
-        del period, spectrum
-        f0 = self.center_wave.get_frequency()
-        df = self.fwidth.get_frequency()
-        lower = max(float(frequencies[0]), f0 - 4 * df)
-        upper = min(float(frequencies[-1]), f0 + 4 * df)
-        if upper <= lower:
-            return None
-        return lower, upper
+        The centroid is well-defined for any spectrum — it equals the peak
+        frequency for unimodal signals and the power-weighted average for
+        multi-band ones.  It is used by :func:`_auto_range` to anchor the
+        frequency axis of spectrum plots.
+        """
+        del period
+        frequencies = np.fft.rfftfreq(len(self.signal), d=self.time_step_duration)
+        spectrum = np.abs(np.fft.rfft(np.asarray(self.signal)))
+        total = float(np.sum(spectrum))
+        if total == 0.0:
+            return 0.0
+        return float(np.sum(frequencies * spectrum) / total)
 
     def get_amplitude(
         self,

--- a/src/fdtdx/objects/sources/profile.py
+++ b/src/fdtdx/objects/sources/profile.py
@@ -1,11 +1,60 @@
 import math
 from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Literal
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
-from fdtdx.core.jax.pytrees import TreeClass, autoinit, frozen_field
+from fdtdx.core.jax.pytrees import TreeClass, autoinit, field, frozen_field
 from fdtdx.core.wavelength import WaveCharacter
+
+
+def _unit_scale(max_abs_value: float, units: tuple[tuple[str, float], ...]) -> tuple[str, float]:
+    for label, scale in units:
+        if max_abs_value * scale >= 0.1:
+            return label, scale
+    return units[-1]
+
+
+def _auto_range(
+    x: np.ndarray,
+    y: np.ndarray,
+    *,
+    relative_threshold: float,
+    pad_fraction: float,
+    center: float | None = None,
+) -> tuple[float, float]:
+    if x.size < 2:
+        return (float(x[0]), float(x[0])) if x.size == 1 else (0.0, 1.0)
+
+    y_abs = np.abs(y)
+    max_y = float(np.max(y_abs)) if y_abs.size else 0.0
+    if max_y == 0.0 or not np.isfinite(max_y):
+        return float(x[0]), float(x[-1])
+
+    idx = np.flatnonzero(y_abs >= relative_threshold * max_y)
+    if idx.size == 0:
+        return float(x[0]), float(x[-1])
+
+    x_min = float(x[idx[0]])
+    x_max = float(x[idx[-1]])
+    if center is not None:
+        x_min = min(x_min, center)
+        x_max = max(x_max, center)
+
+    spacing = float(np.median(np.diff(x)))
+    if x_max <= x_min:
+        half_width = max(20 * spacing, abs(x_min) * 0.05, spacing)
+        x_min -= half_width
+        x_max += half_width
+    else:
+        padding = pad_fraction * (x_max - x_min)
+        x_min -= padding
+        x_max += padding
+
+    return max(float(x[0]), x_min), min(float(x[-1]), x_max)
 
 
 @autoinit
@@ -33,6 +82,160 @@ class TemporalProfile(TreeClass, ABC):
             jax.Array: Amplitude values at the given time points
         """
         raise NotImplementedError()
+
+    def get_reference_frequency(self, period: float) -> float:
+        """Return the frequency expected to dominate the plotted spectrum."""
+        return 1.0 / period
+
+    def get_time_plot_range(self, period: float, total_time: float) -> tuple[float, float] | None:
+        del period, total_time
+        return None
+
+    def get_frequency_plot_range(
+        self,
+        period: float,
+        frequencies: np.ndarray,
+        spectrum: np.ndarray,
+    ) -> tuple[float, float] | None:
+        del period, frequencies, spectrum
+        return None
+
+    def sample_time_signal(
+        self,
+        *,
+        period: float,
+        time_step_duration: float,
+        num_time_steps: int,
+        phase_shift: float = 0.0,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Sample this temporal profile at the same cadence as an FDTD simulation."""
+        if num_time_steps < 2:
+            raise ValueError("num_time_steps must be at least 2 to sample a time signal")
+        if time_step_duration <= 0:
+            raise ValueError("time_step_duration must be positive")
+
+        time = jnp.arange(num_time_steps) * time_step_duration
+        signal = self.get_amplitude(time=time, period=period, phase_shift=phase_shift)
+        return np.asarray(time, dtype=float), np.asarray(signal)
+
+    def frequency_spectrum(
+        self,
+        *,
+        period: float,
+        time_step_duration: float,
+        num_time_steps: int,
+        phase_shift: float = 0.0,
+        normalize: bool = True,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return the one-sided FFT magnitude of the sampled source signal."""
+        _, signal = self.sample_time_signal(
+            period=period,
+            time_step_duration=time_step_duration,
+            num_time_steps=num_time_steps,
+            phase_shift=phase_shift,
+        )
+        frequencies = np.fft.rfftfreq(num_time_steps, d=time_step_duration)
+        spectrum = np.abs(np.fft.rfft(signal))
+        if normalize:
+            max_spectrum = float(np.max(spectrum)) if spectrum.size else 0.0
+            if max_spectrum > 0:
+                spectrum = spectrum / max_spectrum
+        return frequencies, spectrum
+
+    def plot_time_signal_and_spectrum(
+        self,
+        *,
+        period: float,
+        time_step_duration: float,
+        num_time_steps: int,
+        phase_shift: float = 0.0,
+        axs: Any | None = None,
+        filename: str | Path | None = None,
+        time_range: tuple[float, float] | Literal["auto", "full"] = "auto",
+        frequency_range: tuple[float, float] | Literal["auto", "full"] = "auto",
+        relative_threshold: float = 0.01,
+        normalize_spectrum: bool = True,
+    ):
+        """Plot the sampled source time signal and its one-sided frequency spectrum."""
+        from matplotlib import pyplot as plt
+
+        time, signal = self.sample_time_signal(
+            period=period,
+            time_step_duration=time_step_duration,
+            num_time_steps=num_time_steps,
+            phase_shift=phase_shift,
+        )
+        frequencies, spectrum = self.frequency_spectrum(
+            period=period,
+            time_step_duration=time_step_duration,
+            num_time_steps=num_time_steps,
+            phase_shift=phase_shift,
+            normalize=normalize_spectrum,
+        )
+
+        if axs is None:
+            fig, _axs = plt.subplots(1, 2, figsize=(10, 3.5), constrained_layout=True)
+        else:
+            _axs = axs
+            fig = axs[0].figure
+
+        total_time = float(time[-1])
+        if time_range == "auto":
+            suggested_time_range = self.get_time_plot_range(period=period, total_time=total_time)
+            if suggested_time_range is None:
+                suggested_time_range = _auto_range(
+                    time,
+                    signal,
+                    relative_threshold=relative_threshold,
+                    pad_fraction=0.05,
+                )
+            time_range = suggested_time_range
+        elif time_range == "full":
+            time_range = float(time[0]), float(time[-1])
+
+        if frequency_range == "auto":
+            suggested_frequency_range = self.get_frequency_plot_range(
+                period=period,
+                frequencies=frequencies,
+                spectrum=spectrum,
+            )
+            if suggested_frequency_range is None:
+                suggested_frequency_range = _auto_range(
+                    frequencies,
+                    spectrum,
+                    relative_threshold=relative_threshold,
+                    pad_fraction=0.15,
+                    center=self.get_reference_frequency(period),
+                )
+            frequency_range = suggested_frequency_range
+        elif frequency_range == "full":
+            frequency_range = float(frequencies[0]), float(frequencies[-1])
+
+        time_label, time_scale = _unit_scale(
+            max(abs(time_range[0]), abs(time_range[1])),
+            (("fs", 1e15), ("ps", 1e12), ("ns", 1e9), ("s", 1.0)),
+        )
+        frequency_label, frequency_scale = _unit_scale(
+            max(abs(frequency_range[0]), abs(frequency_range[1])),
+            (("THz", 1e-12), ("GHz", 1e-9), ("MHz", 1e-6), ("Hz", 1.0)),
+        )
+
+        signal_to_plot = np.real(signal) if np.iscomplexobj(signal) else signal
+        _axs[0].plot(time * time_scale, signal_to_plot, color="#1f77b4", linewidth=1.6)
+        _axs[0].set_xlim(time_range[0] * time_scale, time_range[1] * time_scale)
+        _axs[0].set_xlabel(f"Time ({time_label})")
+        _axs[0].set_ylabel("Amplitude")
+        _axs[0].grid(True, alpha=0.25)
+
+        _axs[1].plot(frequencies * frequency_scale, spectrum, color="#d55e00", linewidth=1.6)
+        _axs[1].set_xlim(frequency_range[0] * frequency_scale, frequency_range[1] * frequency_scale)
+        _axs[1].set_xlabel(f"Frequency ({frequency_label})")
+        _axs[1].set_ylabel("Normalized |FFT|" if normalize_spectrum else "|FFT|")
+        _axs[1].grid(True, alpha=0.25)
+
+        if filename is not None:
+            fig.savefig(filename, dpi=300, bbox_inches="tight")
+        return fig
 
 
 @autoinit
@@ -79,6 +282,31 @@ class GaussianPulseProfile(TemporalProfile):
                 "spectral_width should not have a phase_shift. Phase shifts should only be applied to center_wave."
             )
 
+    def get_reference_frequency(self, period: float) -> float:
+        del period
+        return self.center_wave.get_frequency()
+
+    def get_time_plot_range(self, period: float, total_time: float) -> tuple[float, float] | None:
+        del period
+        sigma_t = 1.0 / (2 * math.pi * self.spectral_width.get_frequency())
+        t0 = 6 * sigma_t
+        return 0.0, min(total_time, t0 + 5 * sigma_t)
+
+    def get_frequency_plot_range(
+        self,
+        period: float,
+        frequencies: np.ndarray,
+        spectrum: np.ndarray,
+    ) -> tuple[float, float] | None:
+        del period, spectrum
+        center_frequency_hz = self.center_wave.get_frequency()
+        spectral_width_hz = self.spectral_width.get_frequency()
+        lower = max(float(frequencies[0]), center_frequency_hz - 5 * spectral_width_hz)
+        upper = min(float(frequencies[-1]), center_frequency_hz + 5 * spectral_width_hz)
+        if upper <= lower:
+            return None
+        return lower, upper
+
     def get_amplitude(
         self,
         time: jax.Array,
@@ -103,3 +331,92 @@ class GaussianPulseProfile(TemporalProfile):
         carrier = jnp.real(jnp.exp(-1j * carrier_phase))
 
         return envelope * carrier
+
+
+@autoinit
+class CustomTimeSignalProfile(TemporalProfile):
+    """Sampled waveform temporal profile for arbitrary time signals.
+
+    Stores the source waveform as a pre-computed JAX array and interpolates it
+    at each time step inside the FDTD loop.  All signal shaping is done *outside*
+    JIT before constructing this object.
+
+    The sampled ``signal`` fully defines the injected time waveform, so the FDTD
+    loop does not apply an additional source-level ``phase_shift``. Optional
+    ``center_wave`` and ``fwidth`` values only describe the signal for reference
+    frequency and spectrum-plotting logic.
+
+    """
+
+    #: Pre-sampled waveform, shape ``(N,)``.  Lives in the pytree so JAX can
+    #: differentiate through the interpolation if needed.
+    signal: jax.Array = field()
+
+    #: Duration of a single simulation time step (seconds).
+    time_step_duration: float = frozen_field()
+
+    #: Simulation time at which ``signal[0]`` was sampled (seconds).
+    start_time: float = frozen_field(default=0.0)
+
+    #: Optional center wavelength / frequency metadata for spectrum plots.
+    center_wave: WaveCharacter | None = frozen_field(default=None)
+
+    #: Optional spectral width metadata for spectrum plots.
+    fwidth: WaveCharacter | None = frozen_field(default=None)
+
+    #: Interpolation mode: ``"linear"`` (default) or ``"nearest"``.
+    interpolation: Literal["linear", "nearest"] = frozen_field(default="linear")
+
+    #: Value returned for times outside the sampled window.
+    outside_value: float = frozen_field(default=0.0)
+
+    def get_reference_frequency(self, period: float) -> float:
+        if self.center_wave is not None:
+            return self.center_wave.get_frequency()
+        return 1.0 / period
+
+    def get_frequency_plot_range(
+        self,
+        period: float,
+        frequencies: np.ndarray,
+        spectrum: np.ndarray,
+    ) -> tuple[float, float] | None:
+        if self.center_wave is None or self.fwidth is None:
+            return None
+        del period, spectrum
+        f0 = self.center_wave.get_frequency()
+        df = self.fwidth.get_frequency()
+        lower = max(float(frequencies[0]), f0 - 4 * df)
+        upper = min(float(frequencies[-1]), f0 + 4 * df)
+        if upper <= lower:
+            return None
+        return lower, upper
+
+    def get_amplitude(
+        self,
+        time: jax.Array,
+        period: float,
+        phase_shift: float = 0.0,
+    ) -> jax.Array:
+        del period, phase_shift
+
+        idx = (time - self.start_time) / self.time_step_duration
+        floor_idx = jnp.floor(idx)
+        idx0 = floor_idx.astype(jnp.int32)
+        frac = idx - floor_idx
+
+        n = self.signal.shape[0]
+        valid = (idx0 >= 0) & (idx0 < n)
+
+        idx0_clip = jnp.clip(idx0, 0, n - 1)
+        idx1_clip = jnp.clip(idx0_clip + 1, 0, n - 1)
+
+        y0 = self.signal[idx0_clip]
+        y1 = self.signal[idx1_clip]
+
+        if self.interpolation == "nearest":
+            y = jnp.where(frac < 0.5, y0, y1)
+        else:
+            y = (1.0 - frac) * y0 + frac * y1
+
+        return jnp.where(valid, y, self.outside_value)

--- a/src/fdtdx/objects/sources/profile.py
+++ b/src/fdtdx/objects/sources/profile.py
@@ -357,7 +357,7 @@ class CustomTimeSignalProfile(TemporalProfile):
 
     #: Pre-sampled waveform, shape ``(N,)``.  Lives in the pytree so JAX can
     #: differentiate through the interpolation if needed.
-    signal: jax.Array = field()
+    signal: jax.Array = field(on_setattr=[jnp.asarray])
 
     #: Duration of a single simulation time step (seconds).
     time_step_duration: float = frozen_field()
@@ -370,6 +370,16 @@ class CustomTimeSignalProfile(TemporalProfile):
 
     #: Value returned for times outside the sampled window.
     outside_value: float = frozen_field(default=0.0)
+
+    def __post_init__(self):
+        if self.signal.ndim != 1:
+            raise ValueError(f"signal must be one-dimensional, got shape {self.signal.shape}")
+        if self.signal.shape[0] < 2:
+            raise ValueError("signal must contain at least two samples")
+        if self.time_step_duration <= 0:
+            raise ValueError("time_step_duration must be positive")
+        if self.interpolation not in ("linear", "nearest"):
+            raise ValueError(f"interpolation must be 'linear' or 'nearest', got {self.interpolation!r}")
 
     def get_reference_frequency(self, period: float) -> float:
         """Return the power-weighted spectral centroid of the stored signal.

--- a/src/fdtdx/objects/sources/profile.py
+++ b/src/fdtdx/objects/sources/profile.py
@@ -12,6 +12,7 @@ from fdtdx.core.wavelength import WaveCharacter
 
 
 def _unit_scale(max_abs_value: float, units: tuple[tuple[str, float], ...]) -> tuple[str, float]:
+    """Choose a physical display unit that keeps plotted axis values readable."""
     for label, scale in units:
         if max_abs_value * scale >= 0.1:
             return label, scale
@@ -21,11 +22,14 @@ def _unit_scale(max_abs_value: float, units: tuple[tuple[str, float], ...]) -> t
 def _auto_range(
     x: np.ndarray,
     y: np.ndarray,
-    *,
     relative_threshold: float,
     pad_fraction: float,
     center: float | None = None,
 ) -> tuple[float, float]:
+    """Choose a padded plot range around the significant part of an array.
+
+    Examples are the time signal or frequency spectrum.
+    """
     if x.size < 2:
         return (float(x[0]), float(x[0])) if x.size == 1 else (0.0, 1.0)
 
@@ -88,6 +92,11 @@ class TemporalProfile(TreeClass, ABC):
         return 1.0 / period
 
     def get_time_plot_range(self, period: float, total_time: float) -> tuple[float, float] | None:
+        """Return a profile-specific time plot range, or None to use automatic range detection.
+
+        Subclasses may override this hook when the profile has known physical time
+        properties (e.g. a Gaussian pulse).
+        """
         del period, total_time
         return None
 
@@ -97,12 +106,16 @@ class TemporalProfile(TreeClass, ABC):
         frequencies: np.ndarray,
         spectrum: np.ndarray,
     ) -> tuple[float, float] | None:
+        """Return a profile-specific frequency plot range, or None to use automatic range detection.
+
+        Subclasses may override this hook when the profile has known physical frequency
+        properties (e.g. a Gaussian pulse).
+        """
         del period, frequencies, spectrum
         return None
 
     def sample_time_signal(
         self,
-        *,
         period: float,
         time_step_duration: float,
         num_time_steps: int,
@@ -120,7 +133,6 @@ class TemporalProfile(TreeClass, ABC):
 
     def frequency_spectrum(
         self,
-        *,
         period: float,
         time_step_duration: float,
         num_time_steps: int,
@@ -144,7 +156,6 @@ class TemporalProfile(TreeClass, ABC):
 
     def plot_time_signal_and_spectrum(
         self,
-        *,
         period: float,
         time_step_duration: float,
         num_time_steps: int,
@@ -347,17 +358,16 @@ class CustomTimeSignalProfile(TemporalProfile):
     Unlike :class:`GaussianPulseProfile`, this profile does **not** accept a
     ``center_wave`` or spectral-width parameter.  For an arbitrary waveform the
     spectral centre is not a free parameter — it is an emergent property of the
-    signal.  Letting the user specify it separately would create a silent
-    inconsistency risk (e.g. labelling a broadband sinc pulse as if it were a
-    narrowband Gaussian).  Instead, :meth:`get_reference_frequency` computes the
-    power-weighted spectral centroid directly from ``signal``, and the frequency
-    axis of any plot is determined automatically from the actual spectrum content
-    via :func:`_auto_range`.
+    signal (see, e.g., Gedeon et al., IEEE Trans. Antennas Propag. 73(5),
+    2025).  Instead, :meth:`get_reference_frequency` computes the
+    magnitude-weighted spectral centroid directly from ``signal``, and the
+    frequency axis of any plot is determined automatically from the actual
+    spectrum content via :func:`_auto_range`.
     """
 
     #: Pre-sampled waveform, shape ``(N,)``.  Lives in the pytree so JAX can
     #: differentiate through the interpolation if needed.
-    signal: jax.Array = field(on_setattr=[jnp.asarray])
+    signal: jax.Array = field()
 
     #: Duration of a single simulation time step (seconds).
     time_step_duration: float = frozen_field()
@@ -372,6 +382,7 @@ class CustomTimeSignalProfile(TemporalProfile):
     outside_value: float = frozen_field(default=0.0)
 
     def __post_init__(self):
+        object.__setattr__(self, "signal", jnp.asarray(self.signal))
         if self.signal.ndim != 1:
             raise ValueError(f"signal must be one-dimensional, got shape {self.signal.shape}")
         if self.signal.shape[0] < 2:
@@ -382,12 +393,12 @@ class CustomTimeSignalProfile(TemporalProfile):
             raise ValueError(f"interpolation must be 'linear' or 'nearest', got {self.interpolation!r}")
 
     def get_reference_frequency(self, period: float) -> float:
-        """Return the power-weighted spectral centroid of the stored signal.
+        """Return the magnitude-weighted spectral centroid of the stored signal.
 
-        The centroid is well-defined for any spectrum — it equals the peak
-        frequency for unimodal signals and the power-weighted average for
-        multi-band ones.  It is used by :func:`_auto_range` to anchor the
-        frequency axis of spectrum plots.
+        The reference frequency is computed as the weighted mean of the
+        non-negative FFT frequency bins, using the magnitude spectrum as weights
+        (G. Peeters, IRCAM Technical Report, 2004). It is used by
+        :func:`_auto_range` to anchor the frequency axis of spectrum plots.
         """
         del period
         frequencies = np.fft.rfftfreq(len(self.signal), d=self.time_step_duration)

--- a/src/fdtdx/objects/sources/source.py
+++ b/src/fdtdx/objects/sources/source.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Literal, Self
 
 import jax
@@ -89,6 +90,55 @@ class Source(SimulationObject, ABC):
         )
         self = self._update_on_arrays()
         return self
+
+    def sample_time_signal(
+        self,
+        config: SimulationConfig | None = None,
+    ):
+        """Sample the source temporal profile with this source's phase and simulation cadence."""
+        if config is None:
+            config = self._config
+        return self.temporal_profile.sample_time_signal(
+            period=self.wave_character.get_period(),
+            time_step_duration=config.time_step_duration,
+            num_time_steps=config.time_steps_total,
+            phase_shift=self.wave_character.phase_shift,
+        )
+
+    def frequency_spectrum(
+        self,
+        config: SimulationConfig | None = None,
+        normalize: bool = True,
+    ):
+        """Return the one-sided FFT magnitude for this source's sampled time signal."""
+        if config is None:
+            config = self._config
+        return self.temporal_profile.frequency_spectrum(
+            period=self.wave_character.get_period(),
+            time_step_duration=config.time_step_duration,
+            num_time_steps=config.time_steps_total,
+            phase_shift=self.wave_character.phase_shift,
+            normalize=normalize,
+        )
+
+    def plot_time_signal_and_spectrum(
+        self,
+        config: SimulationConfig | None = None,
+        *,
+        filename: str | Path | None = None,
+        **kwargs,
+    ):
+        """Plot this source's selected time signal and associated frequency spectrum."""
+        if config is None:
+            config = self._config
+        return self.temporal_profile.plot_time_signal_and_spectrum(
+            period=self.wave_character.get_period(),
+            time_step_duration=config.time_step_duration,
+            num_time_steps=config.time_steps_total,
+            phase_shift=self.wave_character.phase_shift,
+            filename=filename,
+            **kwargs,
+        )
 
     @abstractmethod
     def update_E(

--- a/src/fdtdx/objects/sources/source.py
+++ b/src/fdtdx/objects/sources/source.py
@@ -9,6 +9,7 @@ from fdtdx.colors import XKCD_DARK_ORANGE, Color
 from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.core.misc import linear_interpolated_indexing, normalize_polarization_for_source
+from fdtdx.core.null import NULL
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.object import SimulationObject
@@ -91,13 +92,27 @@ class Source(SimulationObject, ABC):
         self = self._update_on_arrays()
         return self
 
+    def _resolve_time_signal_config(self, config: SimulationConfig | None) -> SimulationConfig:
+        """Resolve the simulation config used for source time-signal sampling."""
+        if config is not None:
+            return config
+        if self._config is NULL:
+            raise ValueError(
+                "A SimulationConfig is required to sample or plot a source time signal. "
+                "Call place_objects(...) before calling this method, or pass config=... explicitly."
+            )
+        return self._config
+
     def sample_time_signal(
         self,
         config: SimulationConfig | None = None,
     ):
-        """Sample the source temporal profile with this source's phase and simulation cadence."""
-        if config is None:
-            config = self._config
+        """Sample this source's time signal for plotting or analysis.
+
+        The returned signal uses the FDTD time grid from the supplied config, or
+        from self._config if the source has already been placed.
+        """
+        config = self._resolve_time_signal_config(config)
         return self.temporal_profile.sample_time_signal(
             period=self.wave_character.get_period(),
             time_step_duration=config.time_step_duration,
@@ -110,9 +125,11 @@ class Source(SimulationObject, ABC):
         config: SimulationConfig | None = None,
         normalize: bool = True,
     ):
-        """Return the one-sided FFT magnitude for this source's sampled time signal."""
-        if config is None:
-            config = self._config
+        """Return the one-sided FFT magnitude of this source's sampled time signal.
+
+        This is intended for analyzing or visualizing its frequency spectrum.
+        """
+        config = self._resolve_time_signal_config(config)
         return self.temporal_profile.frequency_spectrum(
             period=self.wave_character.get_period(),
             time_step_duration=config.time_step_duration,
@@ -124,13 +141,11 @@ class Source(SimulationObject, ABC):
     def plot_time_signal_and_spectrum(
         self,
         config: SimulationConfig | None = None,
-        *,
         filename: str | Path | None = None,
         **kwargs,
     ):
-        """Plot this source's selected time signal and associated frequency spectrum."""
-        if config is None:
-            config = self._config
+        """Plot this source's sampled time signal and one-sided frequency spectrum."""
+        config = self._resolve_time_signal_config(config)
         return self.temporal_profile.plot_time_signal_and_spectrum(
             period=self.wave_character.get_period(),
             time_step_duration=config.time_step_duration,

--- a/tests/integration/fdtd/test_custom_time_signal_profile.py
+++ b/tests/integration/fdtd/test_custom_time_signal_profile.py
@@ -1,0 +1,83 @@
+"""Integration tests for custom temporal profiles on placed sources."""
+
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+import fdtdx
+
+TEST_OUTPUT_DIR = Path("tests/generated")
+TEST_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _gaussian_windowed_carrier(config: fdtdx.SimulationConfig, wave: fdtdx.WaveCharacter) -> jax.Array:
+    """Return a compact source-like pulse sampled at the simulation cadence."""
+    time = jnp.arange(config.time_steps_total, dtype=config.dtype) * config.time_step_duration
+    pulse_center = 0.5 * time[-1]
+    pulse_width = 8e-15
+    envelope = jnp.exp(-((time - pulse_center) ** 2) / (2 * pulse_width**2))
+    carrier = jnp.cos(2 * jnp.pi * wave.get_frequency() * (time - pulse_center))
+    return (envelope * carrier).astype(config.dtype)
+
+
+def test_custom_time_signal_profile_source_workflow():
+    """CustomTimeSignalProfile works through placement and source wrappers."""
+    config = fdtdx.SimulationConfig(
+        resolution=50e-9,
+        time=500e-15,
+        dtype=jnp.float32,
+    )
+    wave = fdtdx.WaveCharacter(wavelength=1e-6, phase_shift=jnp.pi / 3)
+    signal = _gaussian_windowed_carrier(config, wave)
+
+    volume = fdtdx.SimulationVolume(
+        partial_grid_shape=(8, 8, 8),
+        name="volume",
+    )
+    source = fdtdx.UniformPlaneSource(
+        name="custom_source",
+        partial_grid_shape=(None, None, 1),
+        wave_character=wave,
+        direction="+",
+        fixed_E_polarization_vector=(1, 0, 0),
+        temporal_profile=fdtdx.CustomTimeSignalProfile(
+            signal=signal,
+            time_step_duration=config.time_step_duration,
+            center_wave=wave,
+            fwidth=fdtdx.WaveCharacter(frequency=80e12),
+        ),
+    )
+    constraints = [
+        source.same_size(volume, axes=(0, 1)),
+        source.place_at_center(volume, axes=(0, 1)),
+        source.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(4,)),
+    ]
+
+    object_container, _, _, placed_config, _ = fdtdx.place_objects(
+        object_list=[volume, source],
+        config=config,
+        constraints=constraints,
+        key=jax.random.PRNGKey(0),
+    )
+
+    placed_source = object_container.sources[0]
+    assert isinstance(placed_source.temporal_profile, fdtdx.CustomTimeSignalProfile)
+
+    time, sampled_signal = placed_source.sample_time_signal(placed_config)
+    assert len(time) == placed_config.time_steps_total
+    assert jnp.allclose(jnp.asarray(sampled_signal), signal, atol=1e-4)
+
+    filename = TEST_OUTPUT_DIR / "test_plot_time_signal_custom_source.png"
+    fig = placed_source.plot_time_signal_and_spectrum(
+        config=placed_config,
+        filename=filename,
+    )
+
+    assert fig is not None
+    assert filename.exists()
+    plt.close("all")

--- a/tests/integration/fdtd/test_custom_time_signal_profile.py
+++ b/tests/integration/fdtd/test_custom_time_signal_profile.py
@@ -48,8 +48,6 @@ def test_custom_time_signal_profile_source_workflow():
         temporal_profile=fdtdx.CustomTimeSignalProfile(
             signal=signal,
             time_step_duration=config.time_step_duration,
-            center_wave=wave,
-            fwidth=fdtdx.WaveCharacter(frequency=80e12),
         ),
     )
     constraints = [

--- a/tests/integration/fdtd/test_custom_time_signal_profile.py
+++ b/tests/integration/fdtd/test_custom_time_signal_profile.py
@@ -4,15 +4,9 @@ from pathlib import Path
 
 import jax
 import jax.numpy as jnp
-import matplotlib
-
-matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 import fdtdx
-
-TEST_OUTPUT_DIR = Path("tests/generated")
-TEST_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def _gaussian_windowed_carrier(config: fdtdx.SimulationConfig, wave: fdtdx.WaveCharacter) -> jax.Array:
@@ -65,12 +59,19 @@ def test_custom_time_signal_profile_source_workflow():
 
     placed_source = object_container.sources[0]
     assert isinstance(placed_source.temporal_profile, fdtdx.CustomTimeSignalProfile)
+    assert placed_config.time_step_duration == config.time_step_duration
+    assert placed_config.time_steps_total == config.time_steps_total
 
-    time, sampled_signal = placed_source.sample_time_signal(placed_config)
+    time, sampled_signal = placed_source.sample_time_signal()
     assert len(time) == placed_config.time_steps_total
     assert jnp.allclose(jnp.asarray(sampled_signal), signal, atol=1e-4)
 
-    filename = TEST_OUTPUT_DIR / "test_plot_time_signal_custom_source.png"
+    output_dir = Path("tests/generated")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    filename = output_dir / "test_plot_time_signal_custom_source.png"
+    if filename.exists():
+        filename.unlink()
+
     fig = placed_source.plot_time_signal_and_spectrum(
         config=placed_config,
         filename=filename,
@@ -78,4 +79,5 @@ def test_custom_time_signal_profile_source_workflow():
 
     assert fig is not None
     assert filename.exists()
+    assert filename.stat().st_size > 0
     plt.close("all")

--- a/tests/simulation/physics/sources/test_temporal_profiles.py
+++ b/tests/simulation/physics/sources/test_temporal_profiles.py
@@ -2,6 +2,9 @@
 
   7a. SingleFrequencyProfile reaches steady-state CW with nonzero phasor.
   7b. GaussianPulseProfile excites multiple frequencies within its bandwidth.
+  7c. CustomTimeSignalProfile sampled as an amplitude-scaled, phase-shifted,
+      delayed Gaussian reproduces GaussianPulseProfile physics up to the
+      analytically expected amplitude, phase, and delay factors.
 
 Domain: 1D-like (periodic xy, PML z).
 """
@@ -14,6 +17,7 @@ import fdtdx
 
 # ── Domain constants ─────────────────────────────────────────────────────────
 _WAVELENGTH = 1e-6
+_C = 3e8
 _RESOLUTION = 50e-9
 _PML_CELLS = 10
 _DOMAIN_XY = 3 * _RESOLUTION
@@ -68,6 +72,128 @@ def _run(objects, constraints, config):
     arrays, obj_container, _ = fdtdx.apply_params(arrays, obj_container, params, key)
     _, arrays = fdtdx.run_fdtd(arrays=arrays, objects=obj_container, config=config, key=key)
     return arrays
+
+
+def _phasor_detector_wave_characters():
+    """Return phasor detector WaveCharacters at f_c and f_c ± σ_f."""
+    center_frequency = fdtdx.WaveCharacter(wavelength=_WAVELENGTH).get_frequency()
+    spectral_width_frequency = fdtdx.WaveCharacter(wavelength=3e-6).get_frequency()
+    frequencies = [
+        center_frequency - spectral_width_frequency,
+        center_frequency,
+        center_frequency + spectral_width_frequency,
+    ]
+    return [fdtdx.WaveCharacter(wavelength=_C / freq) for freq in frequencies]
+
+
+def _reference_gaussian_profile():
+    """Return the built-in Gaussian source profile used as the custom-source reference."""
+    center_wave = fdtdx.WaveCharacter(wavelength=_WAVELENGTH)
+    spectral_width = fdtdx.WaveCharacter(wavelength=3e-6)
+    return fdtdx.GaussianPulseProfile(center_wave=center_wave, spectral_width=spectral_width)
+
+
+def _custom_time_signal_profile(config, amplitude: float, delay: float, phase_shift: float):
+    """Sample an amplitude-scaled, phase-shifted, delayed Gaussian pulse."""
+    time = jnp.arange(config.time_steps_total, dtype=config.dtype) * config.time_step_duration
+    delayed_time = time - delay
+
+    center_frequency = fdtdx.WaveCharacter(wavelength=_WAVELENGTH).get_frequency()
+    spectral_width_frequency = fdtdx.WaveCharacter(wavelength=3e-6).get_frequency()
+    sigma_t = 1.0 / (2 * jnp.pi * spectral_width_frequency)
+    t0 = 6 * sigma_t
+    envelope = jnp.exp(-((delayed_time - t0) ** 2) / (2 * sigma_t**2))
+    carrier_phase = 2 * jnp.pi * center_frequency * delayed_time + phase_shift
+    carrier = jnp.real(jnp.exp(-1j * carrier_phase))
+    signal = amplitude * envelope * carrier
+
+    return fdtdx.CustomTimeSignalProfile(
+        signal=signal,
+        time_step_duration=config.time_step_duration,
+        interpolation="linear",
+    )
+
+
+def _build_custom_source_setup(temporal_profile):
+    """Build a small plane-source simulation for custom-profile comparison."""
+    objects, constraints, config, volume = _build_base()
+
+    center_wave = fdtdx.WaveCharacter(wavelength=_WAVELENGTH)
+    source = fdtdx.UniformPlaneSource(
+        partial_grid_shape=(None, None, 1),
+        wave_character=center_wave,
+        temporal_profile=temporal_profile,
+        direction="+",
+        fixed_E_polarization_vector=(1, 0, 0),
+    )
+    constraints.extend(
+        [
+            source.same_size(volume, axes=(0, 1)),
+            source.place_at_center(volume, axes=(0, 1)),
+            source.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_SOURCE_Z,)),
+        ]
+    )
+    objects.append(source)
+
+    phasor_det = fdtdx.PhasorDetector(
+        name="phasor",
+        partial_grid_shape=(None, None, 1),
+        wave_characters=_phasor_detector_wave_characters(),
+        components=("Ex",),
+        reduce_volume=True,
+        scaling_mode="pulse",
+        plot=False,
+    )
+    constraints.extend(
+        [
+            phasor_det.same_size(volume, axes=(0, 1)),
+            phasor_det.place_at_center(volume, axes=(0, 1)),
+            phasor_det.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_DET_Z,)),
+        ]
+    )
+    objects.append(phasor_det)
+
+    field_det = fdtdx.FieldDetector(
+        name="field",
+        partial_grid_shape=(None, None, 1),
+        components=("Ex",),
+        reduce_volume=True,
+        plot=False,
+    )
+    constraints.extend(
+        [
+            field_det.same_size(volume, axes=(0, 1)),
+            field_det.place_at_center(volume, axes=(0, 1)),
+            field_det.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_DET_Z,)),
+        ]
+    )
+    objects.append(field_det)
+
+    return objects, constraints, config
+
+
+def _custom_phasors(arrays):
+    """Return Ex phasors with shape (num_frequencies,)."""
+    return np.asarray(arrays.detector_states["phasor"]["phasor"][0, :, 0])
+
+
+def _custom_field_trace(arrays):
+    """Return the reduced Ex time trace from the field detector."""
+    return np.asarray(arrays.detector_states["field"]["fields"][:, 0])
+
+
+def _analytic_envelope(signal):
+    """Return the Hilbert-transform envelope using an FFT analytic signal."""
+    spectrum = np.fft.fft(signal)
+    weights = np.zeros(signal.shape[0])
+    if signal.shape[0] % 2 == 0:
+        weights[0] = 1
+        weights[signal.shape[0] // 2] = 1
+        weights[1 : signal.shape[0] // 2] = 2
+    else:
+        weights[0] = 1
+        weights[1 : (signal.shape[0] + 1) // 2] = 2
+    return np.abs(np.fft.ifft(spectrum * weights))
 
 
 # ── Tests ────────────────────────────────────────────────────────────────────
@@ -139,7 +265,6 @@ def test_gaussian_pulse_broadband():
     """
     objects, constraints, config, volume = _build_base()
 
-    _C = 3e8  # m/s
     _SIGMA_F = 1e14  # Hz — spectral standard deviation
     _F_CENTER = _C / _WAVELENGTH  # 3e14 Hz
 
@@ -207,7 +332,10 @@ def test_gaussian_pulse_broadband():
 
     arrays = _run(objects, constraints, config)
 
-    amps = {name: abs(complex(arrays.detector_states[name]["phasor"][0, 0].ravel()[0])) for name, _, _ in det_specs}
+    amps = {
+        name: abs(complex(arrays.detector_states[name]["phasor"][0, 0].ravel()[0]))
+        for name, _, _ in det_specs
+    }
 
     assert amps["center"] > 1e-20, "Center phasor is zero — pulse not detected"
 
@@ -220,3 +348,99 @@ def test_gaussian_pulse_broadband():
             f"expected {expected_ratio:.4f} (Gaussian at {log_ratio:+.1f} x σ_f²/2), "
             f"rel_err = {rel_err:.2%}"
         )
+
+
+def test_custom_time_signal_matches_gaussian_pulse_physics():
+    """CustomTimeSignalProfile reproduces GaussianPulseProfile physics up to known factors.
+
+    The custom signal is sampled as an amplitude-scaled, phase-shifted, delayed
+    Gaussian on the FDTD time grid. These transformations have analytical
+    effects: phasor magnitudes scale with amplitude, the center phasor rotates
+    by exp(i 2πfτ - iφ), and the Hilbert-envelope peak arrives delay_steps
+    later.
+    """
+    amplitude = 0.7
+    phase_shift = np.pi / 5
+    delay_steps = 8
+    phasor_mag_tol = 0.01
+    center_complex_phasor_tol = 0.01
+    time_trace_peak_tol = 0.01
+    peak_step_tol = 1
+
+    reference_profile = _reference_gaussian_profile()
+    obj_ref, con_ref, cfg_ref = _build_custom_source_setup(reference_profile)
+    delay = delay_steps * cfg_ref.time_step_duration
+    custom_profile = _custom_time_signal_profile(
+        cfg_ref,
+        amplitude=amplitude,
+        delay=delay,
+        phase_shift=phase_shift,
+    )
+    obj_custom, con_custom, cfg_custom = _build_custom_source_setup(
+        custom_profile,
+    )
+
+    assert cfg_custom.time_step_duration == cfg_ref.time_step_duration
+    assert cfg_custom.time_steps_total == cfg_ref.time_steps_total
+
+    arrays_ref = _run(obj_ref, con_ref, cfg_ref)
+    arrays_custom = _run(obj_custom, con_custom, cfg_custom)
+
+    phasor_ref = _custom_phasors(arrays_ref)
+    phasor_custom = _custom_phasors(arrays_custom)
+    amp_ref = np.abs(phasor_ref)
+    amp_custom = np.abs(phasor_custom)
+    expected_amp = amplitude * amp_ref
+
+    # Amplitude check: all monitored phasor magnitudes should scale by A.
+    assert np.all(amp_ref > 1e-30), f"Reference phasor amplitudes are zero: {amp_ref}"
+    mag_rel_err = np.abs(amp_custom - expected_amp) / expected_amp
+    assert np.all(mag_rel_err < phasor_mag_tol), (
+        f"Phasor magnitude relative errors {mag_rel_err} exceed {phasor_mag_tol}; "
+        f"expected={expected_amp}, custom={amp_custom}"
+    )
+
+    center_idx = 1
+    center_frequency = _phasor_detector_wave_characters()[center_idx].get_frequency()
+    expected_center_phasor = (
+        amplitude
+        * phasor_ref[center_idx]
+        * np.exp(1j * 2 * np.pi * center_frequency * delay - 1j * phase_shift)
+    )
+    # Phase check: with FDTDX's exp(+iωt) phasor convention, delay τ and
+    # carrier phase φ rotate the center phasor by exp(i2πfτ - iφ).
+    center_rel_err = abs(phasor_custom[center_idx] - expected_center_phasor) / abs(expected_center_phasor)
+    assert center_rel_err < center_complex_phasor_tol, (
+        f"Corrected center-frequency phasor relative error {center_rel_err:.3f} "
+        f"exceeds {center_complex_phasor_tol}"
+    )
+
+    trace_ref = _custom_field_trace(arrays_ref)
+    trace_custom = _custom_field_trace(arrays_custom)
+    assert trace_custom.shape == trace_ref.shape
+
+    envelope_ref = _analytic_envelope(trace_ref)
+    envelope_custom = _analytic_envelope(trace_custom)
+    peak_ref = float(np.max(envelope_ref))
+    peak_custom = float(np.max(envelope_custom))
+    expected_peak = amplitude * peak_ref
+    assert peak_ref > 1e-30, "Reference propagated time-domain field is zero"
+
+    # Time-domain amplitude check: the propagated field envelope should scale by A.
+    peak_rel_err = abs(peak_custom - expected_peak) / expected_peak
+    assert peak_rel_err < time_trace_peak_tol, (
+        f"Time-trace peak relative error {peak_rel_err:.3f} exceeds {time_trace_peak_tol}; "
+        f"expected={expected_peak:.4e}, custom={peak_custom:.4e}"
+    )
+
+    # Delay check: the Hilbert envelope removes carrier-phase ambiguity, so its
+    # peak should arrive delay_steps later.
+    peak_step_ref = int(np.argmax(envelope_ref))
+    peak_step_custom = int(np.argmax(envelope_custom))
+    peak_step_err = abs((peak_step_custom - peak_step_ref) - delay_steps)
+    assert peak_step_err <= peak_step_tol, (
+        f"Envelope peak arrival differs from the expected {delay_steps}-step delay "
+        f"by {peak_step_err} time steps, "
+        f"expected <= {peak_step_tol}; "
+        f"reference={peak_step_ref}, custom={peak_step_custom}"
+    )

--- a/tests/simulation/physics/sources/test_temporal_profiles.py
+++ b/tests/simulation/physics/sources/test_temporal_profiles.py
@@ -332,10 +332,7 @@ def test_gaussian_pulse_broadband():
 
     arrays = _run(objects, constraints, config)
 
-    amps = {
-        name: abs(complex(arrays.detector_states[name]["phasor"][0, 0].ravel()[0]))
-        for name, _, _ in det_specs
-    }
+    amps = {name: abs(complex(arrays.detector_states[name]["phasor"][0, 0].ravel()[0])) for name, _, _ in det_specs}
 
     assert amps["center"] > 1e-20, "Center phasor is zero — pulse not detected"
 
@@ -403,16 +400,13 @@ def test_custom_time_signal_matches_gaussian_pulse_physics():
     center_idx = 1
     center_frequency = _phasor_detector_wave_characters()[center_idx].get_frequency()
     expected_center_phasor = (
-        amplitude
-        * phasor_ref[center_idx]
-        * np.exp(1j * 2 * np.pi * center_frequency * delay - 1j * phase_shift)
+        amplitude * phasor_ref[center_idx] * np.exp(1j * 2 * np.pi * center_frequency * delay - 1j * phase_shift)
     )
     # Phase check: with FDTDX's exp(+iωt) phasor convention, delay τ and
     # carrier phase φ rotate the center phasor by exp(i2πfτ - iφ).
     center_rel_err = abs(phasor_custom[center_idx] - expected_center_phasor) / abs(expected_center_phasor)
     assert center_rel_err < center_complex_phasor_tol, (
-        f"Corrected center-frequency phasor relative error {center_rel_err:.3f} "
-        f"exceeds {center_complex_phasor_tol}"
+        f"Corrected center-frequency phasor relative error {center_rel_err:.3f} exceeds {center_complex_phasor_tol}"
     )
 
     trace_ref = _custom_field_trace(arrays_ref)

--- a/tests/unit/objects/sources/test_profile.py
+++ b/tests/unit/objects/sources/test_profile.py
@@ -1,7 +1,10 @@
 """Tests for objects/sources/profile.py - Temporal profiles."""
 
+import math
+
 import jax.numpy as jnp
 import matplotlib
+import numpy as np
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
@@ -224,30 +227,29 @@ class TestCustomTimeSignalProfile:
         assert jnp.allclose(profile.signal, signal)
         assert profile.time_step_duration == 0.25
         assert profile.start_time == 0.0
-        assert profile.center_wave is None
-        assert profile.fwidth is None
         assert profile.interpolation == "linear"
         assert profile.outside_value == 0.0
 
     def test_exact_sample_times(self):
         """Test that exact sample times return exact signal values."""
-        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
-        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=0.25)
+        signal = jnp.array([0.0, 0.0, 1.0, -2.0, 1.0, 0.0, 0.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=1.0)
 
-        times = jnp.array([0.0, 0.25, 0.5, 0.75], dtype=jnp.float32)
+        times = jnp.arange(7, dtype=jnp.float32)
         amplitudes = profile.get_amplitude(time=times, period=1.0)
 
         assert jnp.allclose(amplitudes, signal)
 
     def test_linear_interpolation_between_samples(self):
-        """Test linear interpolation between adjacent signal samples."""
-        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
-        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=0.25)
+        """Test linear interpolation between adjacent signal samples, including sign changes."""
+        signal = jnp.array([0.0, 0.0, 1.0, -2.0, 1.0, 0.0, 0.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=1.0)
 
-        times = jnp.array([0.125, 0.375, 0.625], dtype=jnp.float32)
+        # t=1.5: midpoint(0.0, 1.0)=0.5; t=2.5: midpoint(1.0, -2.0)=-0.5; t=3.5: midpoint(-2.0, 1.0)=-0.5
+        times = jnp.array([1.5, 2.5, 3.5], dtype=jnp.float32)
         amplitudes = profile.get_amplitude(time=times, period=1.0)
 
-        expected = jnp.array([1.0, 3.0, 6.0], dtype=jnp.float32)
+        expected = jnp.array([0.5, -0.5, -0.5], dtype=jnp.float32)
         assert jnp.allclose(amplitudes, expected)
 
     def test_nearest_interpolation(self):
@@ -292,48 +294,37 @@ class TestCustomTimeSignalProfile:
         assert jnp.isclose(amp_no_shift, amp_with_shift)
 
     def test_array_time_input(self):
-        """Test amplitude with vector input times."""
-        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
-        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=0.25)
+        """Test amplitude with vector input: boundary clamping, sign-change interpolation, outside_value."""
+        signal = jnp.array([0.0, 0.0, 1.0, -2.0, 1.0, 0.0, 0.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=1.0)
 
-        times = jnp.array([-0.25, 0.0, 0.125, 0.75, 1.0], dtype=jnp.float32)
+        # pre-boundary, first sample, sign-change midpoint, negative peak, post-boundary
+        times = jnp.array([-0.5, 0.0, 2.5, 3.0, 7.0], dtype=jnp.float32)
         amplitudes = profile.get_amplitude(time=times, period=1.0)
 
-        expected = jnp.array([0.0, 0.0, 1.0, 8.0, 0.0], dtype=jnp.float32)
+        expected = jnp.array([0.0, 0.0, -0.5, -2.0, 0.0], dtype=jnp.float32)
         assert jnp.allclose(amplitudes, expected)
 
-    def test_reference_frequency_uses_center_wave(self):
-        """Test reference frequency metadata fallback and center_wave override."""
-        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
-        profile_without_center = CustomTimeSignalProfile(signal=signal, time_step_duration=0.25)
-        profile_with_center = CustomTimeSignalProfile(
-            signal=signal,
-            time_step_duration=0.25,
-            center_wave=WaveCharacter(frequency=193.4e12),
+    def test_reference_frequency_is_spectral_centroid(self):
+        """Reference frequency is computed as the power-weighted spectral centroid.
+
+        For a Gaussian-windowed carrier the centroid should be very close to the
+        carrier frequency — no user-supplied metadata required.
+        """
+        dt = 1e-15
+        n = 4096
+        f0 = 300e12
+        sigma_t = 30e-15
+        t0 = (n // 2) * dt
+        t = np.arange(n, dtype=np.float64) * dt
+        signal = jnp.asarray(
+            np.exp(-((t - t0) ** 2) / (2 * sigma_t**2)) * np.cos(2 * math.pi * f0 * (t - t0)),
+            dtype=jnp.float32,
         )
+        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=dt)
 
-        assert profile_without_center.get_reference_frequency(period=2e-12) == 0.5e12
-        assert profile_with_center.get_reference_frequency(period=2e-12) == 193.4e12
-
-    def test_frequency_plot_range_uses_center_and_fwidth(self):
-        """Test frequency plot range from center_wave and fwidth metadata."""
-        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
-        profile = CustomTimeSignalProfile(
-            signal=signal,
-            time_step_duration=0.25,
-            center_wave=WaveCharacter(frequency=5.0),
-            fwidth=WaveCharacter(frequency=2.0),
-        )
-        frequencies = jnp.array([0.0, 2.0, 4.0, 6.0, 8.0, 10.0], dtype=jnp.float32)
-        spectrum = jnp.ones_like(frequencies)
-
-        frequency_range = profile.get_frequency_plot_range(
-            period=1.0,
-            frequencies=frequencies,
-            spectrum=spectrum,
-        )
-
-        assert frequency_range == (0.0, 10.0)
+        ref_freq = profile.get_reference_frequency(period=1.0 / f0)
+        assert abs(ref_freq - f0) / f0 < 0.02
 
     def test_plot_time_signal_and_spectrum_custom_writes_file(self, tmp_path):
         """Test that custom time-signal plots can be written to disk."""
@@ -369,6 +360,63 @@ class TestCustomTimeSignalProfile:
         assert len(axs[0].lines) == 1
         assert len(axs[1].lines) == 1
         plt.close("all")
+
+    def test_analytical_fidelity_time_and_frequency_domain(self):
+        """Verify that a Gaussian-windowed carrier is reproduced faithfully in time and frequency.
+
+        Analytical signal: s(t) = exp(-(t-t0)²/(2σ_t²)) · cos(2π f0 (t-t0))
+        Analytical spectrum: |S(f)| ∝ exp(-(f-f0)²/(2σ_f²)),  σ_f = 1/(2π σ_t)
+        """
+        dt = 1e-15  # 1 fs — resolves 300 THz optical carrier
+        n = 4096
+        f0 = 300e12  # 1 µm carrier
+        sigma_t = 30e-15  # 30 fs pulse → σ_f ≈ 5.3 THz
+        t0 = (n // 2) * dt  # center pulse in the window
+
+        time_grid = np.arange(n, dtype=np.float64) * dt
+
+        def analytical(t):
+            return np.exp(-((t - t0) ** 2) / (2 * sigma_t**2)) * np.cos(2 * math.pi * f0 * (t - t0))
+
+        signal = jnp.asarray(analytical(time_grid), dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=dt)
+
+        # --- time-domain fidelity ---
+        # Query at 200 off-grid times (shifted by 0.3 dt so we exercise interpolation)
+        query_times = jnp.asarray(np.arange(100, 300, dtype=np.float64) * dt + 0.3 * dt, dtype=jnp.float32)
+        interpolated = np.asarray(profile.get_amplitude(time=query_times, period=1.0 / f0))
+        expected = analytical(np.asarray(query_times, dtype=np.float64)).astype(np.float32)
+
+        max_error = float(np.max(np.abs(interpolated - expected)))
+        assert max_error < 1e-3, f"time-domain interpolation error {max_error:.2e} exceeds 1e-3"
+
+        # --- frequency-domain fidelity ---
+        frequencies, spectrum = profile.frequency_spectrum(
+            period=1.0 / f0,
+            time_step_duration=dt,
+            num_time_steps=n,
+            normalize=True,
+        )
+
+        # Peak must land within one frequency bin of the carrier
+        df = frequencies[1] - frequencies[0]
+        peak_freq = frequencies[np.argmax(spectrum)]
+        assert abs(peak_freq - f0) < df, (
+            f"spectral peak {peak_freq:.3e} Hz deviates from f0={f0:.3e} Hz by more than df={df:.3e} Hz"
+        )
+
+        # At f0 ± 2σ_f the Gaussian envelope gives exp(-2) ≈ 0.135; allow 15 % tolerance
+        sigma_f = 1.0 / (2 * math.pi * sigma_t)
+        for sign in (-1, +1):
+            target_freq = f0 + sign * 2 * sigma_f
+            idx = int(np.argmin(np.abs(frequencies - target_freq)))
+            assert abs(spectrum[idx] - math.exp(-2)) < 0.15, (
+                f"spectrum at f0{'+' if sign > 0 else '-'}2σ_f = {spectrum[idx]:.3f}, expected ≈ {math.exp(-2):.3f}"
+            )
+
+        # Strong out-of-band suppression at f0 + 5σ_f
+        idx_oob = int(np.argmin(np.abs(frequencies - (f0 + 5 * sigma_f))))
+        assert spectrum[idx_oob] < 0.01, f"out-of-band spectrum at f0+5σ_f = {spectrum[idx_oob]:.4f}, expected < 0.01"
 
 
 class TestTemporalProfilePlotting:

--- a/tests/unit/objects/sources/test_profile.py
+++ b/tests/unit/objects/sources/test_profile.py
@@ -2,9 +2,11 @@
 
 import math
 
+import jax
 import jax.numpy as jnp
 import matplotlib
 import numpy as np
+import pytest
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
@@ -229,6 +231,24 @@ class TestCustomTimeSignalProfile:
         assert profile.start_time == 0.0
         assert profile.interpolation == "linear"
         assert profile.outside_value == 0.0
+
+    def test_accepts_array_like_signal(self):
+        """Test that Python array-likes are converted to JAX arrays."""
+        profile = CustomTimeSignalProfile(signal=[0.0, 1.0, 0.0], time_step_duration=0.25)
+
+        assert isinstance(profile.signal, jax.Array)
+        assert profile.signal.dtype == jnp.float32
+
+    def test_invalid_parameters_raise(self):
+        """Test validation for signal shape, sample cadence, and interpolation mode."""
+        with pytest.raises(ValueError, match="one-dimensional"):
+            CustomTimeSignalProfile(signal=jnp.zeros((2, 2)), time_step_duration=0.25)
+        with pytest.raises(ValueError, match="at least two"):
+            CustomTimeSignalProfile(signal=jnp.zeros((1,)), time_step_duration=0.25)
+        with pytest.raises(ValueError, match="positive"):
+            CustomTimeSignalProfile(signal=jnp.zeros((2,)), time_step_duration=0.0)
+        with pytest.raises(ValueError, match="interpolation"):
+            CustomTimeSignalProfile(signal=jnp.zeros((2,)), time_step_duration=0.25, interpolation="cubic")
 
     def test_exact_sample_times(self):
         """Test that exact sample times return exact signal values."""

--- a/tests/unit/objects/sources/test_profile.py
+++ b/tests/unit/objects/sources/test_profile.py
@@ -1,9 +1,13 @@
 """Tests for objects/sources/profile.py - Temporal profiles."""
 
 import jax.numpy as jnp
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 
 from fdtdx.core.wavelength import WaveCharacter
-from fdtdx.objects.sources.profile import GaussianPulseProfile, SingleFrequencyProfile
+from fdtdx.objects.sources.profile import CustomTimeSignalProfile, GaussianPulseProfile, SingleFrequencyProfile
 
 
 class TestSingleFrequencyProfile:
@@ -207,6 +211,188 @@ class TestGaussianPulseProfile:
 
         # Narrower spectrum (longer pulse) should have higher amplitude far from center
         assert narrow_far > wide_far or jnp.isclose(narrow_far, wide_far, rtol=0.5)
+
+
+class TestCustomTimeSignalProfile:
+    """Tests for CustomTimeSignalProfile class."""
+
+    def test_default_parameters(self):
+        """Test default parameter values."""
+        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=0.25)
+
+        assert jnp.allclose(profile.signal, signal)
+        assert profile.time_step_duration == 0.25
+        assert profile.start_time == 0.0
+        assert profile.center_wave is None
+        assert profile.fwidth is None
+        assert profile.interpolation == "linear"
+        assert profile.outside_value == 0.0
+
+    def test_exact_sample_times(self):
+        """Test that exact sample times return exact signal values."""
+        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=0.25)
+
+        times = jnp.array([0.0, 0.25, 0.5, 0.75], dtype=jnp.float32)
+        amplitudes = profile.get_amplitude(time=times, period=1.0)
+
+        assert jnp.allclose(amplitudes, signal)
+
+    def test_linear_interpolation_between_samples(self):
+        """Test linear interpolation between adjacent signal samples."""
+        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=0.25)
+
+        times = jnp.array([0.125, 0.375, 0.625], dtype=jnp.float32)
+        amplitudes = profile.get_amplitude(time=times, period=1.0)
+
+        expected = jnp.array([1.0, 3.0, 6.0], dtype=jnp.float32)
+        assert jnp.allclose(amplitudes, expected)
+
+    def test_nearest_interpolation(self):
+        """Test nearest-neighbor interpolation around the half-step boundary."""
+        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(
+            signal=signal,
+            time_step_duration=0.25,
+            interpolation="nearest",
+        )
+
+        times = jnp.array([0.10, 0.15, 0.35, 0.40], dtype=jnp.float32)
+        amplitudes = profile.get_amplitude(time=times, period=1.0)
+
+        expected = jnp.array([0.0, 2.0, 2.0, 4.0], dtype=jnp.float32)
+        assert jnp.allclose(amplitudes, expected)
+
+    def test_outside_sample_window_returns_outside_value(self):
+        """Test outside_value before the first sample and after the last sample."""
+        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(
+            signal=signal,
+            time_step_duration=0.25,
+            start_time=1.0,
+            outside_value=-3.0,
+        )
+
+        times = jnp.array([0.75, 1.0, 1.75, 2.0], dtype=jnp.float32)
+        amplitudes = profile.get_amplitude(time=times, period=1.0)
+
+        expected = jnp.array([-3.0, 0.0, 8.0, -3.0], dtype=jnp.float32)
+        assert jnp.allclose(amplitudes, expected)
+
+    def test_phase_shift_is_ignored(self):
+        """Test that pre-sampled custom signals ignore phase_shift."""
+        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=0.25)
+
+        amp_no_shift = profile.get_amplitude(time=0.375, period=1.0, phase_shift=0.0)
+        amp_with_shift = profile.get_amplitude(time=0.375, period=1.0, phase_shift=jnp.pi)
+
+        assert jnp.isclose(amp_no_shift, amp_with_shift)
+
+    def test_array_time_input(self):
+        """Test amplitude with vector input times."""
+        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=0.25)
+
+        times = jnp.array([-0.25, 0.0, 0.125, 0.75, 1.0], dtype=jnp.float32)
+        amplitudes = profile.get_amplitude(time=times, period=1.0)
+
+        expected = jnp.array([0.0, 0.0, 1.0, 8.0, 0.0], dtype=jnp.float32)
+        assert jnp.allclose(amplitudes, expected)
+
+    def test_reference_frequency_uses_center_wave(self):
+        """Test reference frequency metadata fallback and center_wave override."""
+        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
+        profile_without_center = CustomTimeSignalProfile(signal=signal, time_step_duration=0.25)
+        profile_with_center = CustomTimeSignalProfile(
+            signal=signal,
+            time_step_duration=0.25,
+            center_wave=WaveCharacter(frequency=193.4e12),
+        )
+
+        assert profile_without_center.get_reference_frequency(period=2e-12) == 0.5e12
+        assert profile_with_center.get_reference_frequency(period=2e-12) == 193.4e12
+
+    def test_frequency_plot_range_uses_center_and_fwidth(self):
+        """Test frequency plot range from center_wave and fwidth metadata."""
+        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(
+            signal=signal,
+            time_step_duration=0.25,
+            center_wave=WaveCharacter(frequency=5.0),
+            fwidth=WaveCharacter(frequency=2.0),
+        )
+        frequencies = jnp.array([0.0, 2.0, 4.0, 6.0, 8.0, 10.0], dtype=jnp.float32)
+        spectrum = jnp.ones_like(frequencies)
+
+        frequency_range = profile.get_frequency_plot_range(
+            period=1.0,
+            frequencies=frequencies,
+            spectrum=spectrum,
+        )
+
+        assert frequency_range == (0.0, 10.0)
+
+    def test_plot_time_signal_and_spectrum_custom_writes_file(self, tmp_path):
+        """Test that custom time-signal plots can be written to disk."""
+        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=0.25)
+        filename = tmp_path / "custom_time_signal.png"
+
+        fig = profile.plot_time_signal_and_spectrum(
+            period=1.0,
+            time_step_duration=0.25,
+            num_time_steps=signal.shape[0],
+            filename=filename,
+        )
+
+        assert fig is not None
+        assert filename.exists()
+        plt.close("all")
+
+    def test_plot_time_signal_and_spectrum_accepts_external_axes(self):
+        """Test plotting into caller-provided axes."""
+        signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=0.25)
+        fig, axs = plt.subplots(1, 2)
+
+        result_fig = profile.plot_time_signal_and_spectrum(
+            period=1.0,
+            time_step_duration=0.25,
+            num_time_steps=signal.shape[0],
+            axs=axs,
+        )
+
+        assert result_fig is fig
+        assert len(axs[0].lines) == 1
+        assert len(axs[1].lines) == 1
+        plt.close("all")
+
+
+class TestTemporalProfilePlotting:
+    """Tests for shared temporal profile plotting helpers."""
+
+    def test_plot_time_signal_and_spectrum_gaussian_writes_file(self, tmp_path):
+        """Test that Gaussian pulse plots can be written to disk."""
+        center_wave = WaveCharacter(frequency=193.4e12)
+        profile = GaussianPulseProfile(
+            spectral_width=WaveCharacter(frequency=10e12),
+            center_wave=center_wave,
+        )
+        filename = tmp_path / "gaussian_time_signal.png"
+
+        fig = profile.plot_time_signal_and_spectrum(
+            period=center_wave.get_period(),
+            time_step_duration=1e-15,
+            num_time_steps=64,
+            filename=filename,
+        )
+
+        assert fig is not None
+        assert filename.exists()
+        plt.close("all")
 
 
 class TestProfileComparison:

--- a/tests/unit/objects/sources/test_profile.py
+++ b/tests/unit/objects/sources/test_profile.py
@@ -4,15 +4,19 @@ import math
 
 import jax
 import jax.numpy as jnp
-import matplotlib
 import numpy as np
 import pytest
 
-matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 from fdtdx.core.wavelength import WaveCharacter
-from fdtdx.objects.sources.profile import CustomTimeSignalProfile, GaussianPulseProfile, SingleFrequencyProfile
+from fdtdx.objects.sources.profile import (
+    CustomTimeSignalProfile,
+    GaussianPulseProfile,
+    SingleFrequencyProfile,
+    _auto_range,
+    _unit_scale,
+)
 
 
 class TestSingleFrequencyProfile:
@@ -217,6 +221,49 @@ class TestGaussianPulseProfile:
         # Narrower spectrum (longer pulse) should have higher amplitude far from center
         assert narrow_far > wide_far or jnp.isclose(narrow_far, wide_far, rtol=0.5)
 
+    def test_gaussian_plot_ranges_use_physical_time_and_frequency_properties(self):
+        """Test Gaussian plot ranges from known pulse duration and spectral width."""
+        center_wave = WaveCharacter(frequency=193.4e12)
+        profile = GaussianPulseProfile(
+            spectral_width=WaveCharacter(frequency=10e12),
+            center_wave=center_wave,
+        )
+        total_time = 1e-12
+        frequencies = np.linspace(150e12, 240e12, 128)
+        spectrum = np.ones_like(frequencies)
+
+        time_range = profile.get_time_plot_range(period=center_wave.get_period(), total_time=total_time)
+        reference_frequency = profile.get_reference_frequency(period=center_wave.get_period())
+        frequency_range = profile.get_frequency_plot_range(
+            period=center_wave.get_period(),
+            frequencies=frequencies,
+            spectrum=spectrum,
+        )
+
+        assert time_range is not None
+        assert time_range[0] == 0.0
+        assert 0.0 < time_range[1] <= total_time
+        assert reference_frequency == center_wave.get_frequency()
+        assert frequency_range == (frequencies[0], frequencies[-1])
+
+    def test_gaussian_frequency_plot_range_returns_none_if_window_excludes_pulse(self):
+        """Test that Gaussian frequency plot range falls back to auto range when needed."""
+        center_wave = WaveCharacter(frequency=193.4e12)
+        profile = GaussianPulseProfile(
+            spectral_width=WaveCharacter(frequency=10e12),
+            center_wave=center_wave,
+        )
+        frequencies = np.linspace(0.0, 1e12, 8)
+        spectrum = np.ones_like(frequencies)
+
+        frequency_range = profile.get_frequency_plot_range(
+            period=center_wave.get_period(),
+            frequencies=frequencies,
+            spectrum=spectrum,
+        )
+
+        assert frequency_range is None
+
 
 class TestCustomTimeSignalProfile:
     """Tests for CustomTimeSignalProfile class."""
@@ -237,7 +284,7 @@ class TestCustomTimeSignalProfile:
         profile = CustomTimeSignalProfile(signal=[0.0, 1.0, 0.0], time_step_duration=0.25)
 
         assert isinstance(profile.signal, jax.Array)
-        assert profile.signal.dtype == jnp.float32
+        assert jnp.allclose(profile.signal, jnp.array([0.0, 1.0, 0.0]))
 
     def test_invalid_parameters_raise(self):
         """Test validation for signal shape, sample cadence, and interpolation mode."""
@@ -288,7 +335,11 @@ class TestCustomTimeSignalProfile:
         assert jnp.allclose(amplitudes, expected)
 
     def test_outside_sample_window_returns_outside_value(self):
-        """Test outside_value before the first sample and after the last sample."""
+        """Test outside_value before the first sample and after the sampled window.
+
+        Times in the final fractional sample interval return the last sample due to
+        boundary clamping; outside_value is used starting at start_time + n * dt.
+        """
         signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
         profile = CustomTimeSignalProfile(
             signal=signal,
@@ -297,10 +348,10 @@ class TestCustomTimeSignalProfile:
             outside_value=-3.0,
         )
 
-        times = jnp.array([0.75, 1.0, 1.75, 2.0], dtype=jnp.float32)
+        times = jnp.array([0.75, 1.0, 1.75, 1.875, 2.0], dtype=jnp.float32)
         amplitudes = profile.get_amplitude(time=times, period=1.0)
 
-        expected = jnp.array([-3.0, 0.0, 8.0, -3.0], dtype=jnp.float32)
+        expected = jnp.array([-3.0, 0.0, 8.0, 8.0, -3.0], dtype=jnp.float32)
         assert jnp.allclose(amplitudes, expected)
 
     def test_phase_shift_is_ignored(self):
@@ -326,7 +377,7 @@ class TestCustomTimeSignalProfile:
         assert jnp.allclose(amplitudes, expected)
 
     def test_reference_frequency_is_spectral_centroid(self):
-        """Reference frequency is computed as the power-weighted spectral centroid.
+        """Reference frequency is computed as the magnitude-weighted spectral centroid.
 
         For a Gaussian-windowed carrier the centroid should be very close to the
         carrier frequency — no user-supplied metadata required.
@@ -346,6 +397,12 @@ class TestCustomTimeSignalProfile:
         ref_freq = profile.get_reference_frequency(period=1.0 / f0)
         assert abs(ref_freq - f0) / f0 < 0.02
 
+    def test_reference_frequency_returns_zero_for_zero_signal(self):
+        """Test zero signal has a zero spectral reference frequency."""
+        profile = CustomTimeSignalProfile(signal=jnp.zeros((8,), dtype=jnp.float32), time_step_duration=0.25)
+
+        assert profile.get_reference_frequency(period=1.0) == 0.0
+
     def test_plot_time_signal_and_spectrum_custom_writes_file(self, tmp_path):
         """Test that custom time-signal plots can be written to disk."""
         signal = jnp.array([0.0, 2.0, 4.0, 8.0], dtype=jnp.float32)
@@ -361,6 +418,7 @@ class TestCustomTimeSignalProfile:
 
         assert fig is not None
         assert filename.exists()
+        assert filename.stat().st_size > 0
         plt.close("all")
 
     def test_plot_time_signal_and_spectrum_accepts_external_axes(self):
@@ -379,6 +437,27 @@ class TestCustomTimeSignalProfile:
         assert result_fig is fig
         assert len(axs[0].lines) == 1
         assert len(axs[1].lines) == 1
+        plt.close("all")
+
+    def test_plot_time_signal_and_spectrum_accepts_explicit_ranges_and_raw_spectrum(self):
+        """Test explicit plot ranges and unnormalized spectrum display."""
+        signal = jnp.array([0.0, 1.0, 0.0, -1.0], dtype=jnp.float32)
+        profile = CustomTimeSignalProfile(signal=signal, time_step_duration=0.25)
+
+        fig = profile.plot_time_signal_and_spectrum(
+            period=1.0,
+            time_step_duration=0.25,
+            num_time_steps=signal.shape[0],
+            time_range=(0.0, 0.75),
+            frequency_range=(0.0, 2.0),
+            normalize_spectrum=False,
+        )
+
+        assert fig is not None
+        plotted_signal = fig.axes[0].lines[0].get_ydata()
+        spectrum_label = fig.axes[1].get_ylabel()
+        assert np.allclose(plotted_signal, np.asarray(signal))
+        assert spectrum_label == "|FFT|"
         plt.close("all")
 
     def test_analytical_fidelity_time_and_frequency_domain(self):
@@ -442,6 +521,86 @@ class TestCustomTimeSignalProfile:
 class TestTemporalProfilePlotting:
     """Tests for shared temporal profile plotting helpers."""
 
+    def test_unit_scale_uses_last_unit_for_small_values(self):
+        """Test display-unit selection falls back to the smallest provided scale."""
+        assert _unit_scale(1e-15, (("ms", 1e3), ("s", 1.0))) == ("s", 1.0)
+
+    def test_auto_range_handles_empty_single_zero_and_single_peak_arrays(self):
+        """Test automatic plot range edge cases without needing matplotlib."""
+        assert _auto_range(np.array([]), np.array([]), relative_threshold=0.1, pad_fraction=0.1) == (0.0, 1.0)
+        assert _auto_range(np.array([2.0]), np.array([1.0]), relative_threshold=0.1, pad_fraction=0.1) == (2.0, 2.0)
+        assert _auto_range(
+            np.array([0.0, 1.0, 2.0]),
+            np.array([0.0, 0.0, 0.0]),
+            relative_threshold=0.1,
+            pad_fraction=0.1,
+        ) == (0.0, 2.0)
+        assert _auto_range(
+            np.array([0.0, 1.0, 2.0]),
+            np.array([0.0, 1.0, 0.0]),
+            relative_threshold=2.0,
+            pad_fraction=0.1,
+        ) == (0.0, 2.0)
+
+        peak_range = _auto_range(
+            np.array([0.0, 1.0, 2.0]),
+            np.array([0.0, 1.0, 0.0]),
+            relative_threshold=1.0,
+            pad_fraction=0.1,
+        )
+        assert peak_range == (0.0, 2.0)
+
+    def test_auto_range_includes_reference_center_when_requested(self):
+        """Test automatic plot range expands to include a supplied reference center."""
+        plot_range = _auto_range(
+            np.array([0.0, 1.0, 2.0, 3.0]),
+            np.array([0.0, 0.0, 1.0, 0.0]),
+            relative_threshold=0.5,
+            pad_fraction=0.0,
+            center=1.0,
+        )
+
+        assert plot_range == (1.0, 2.0)
+
+    def test_temporal_profile_sampling_rejects_invalid_grid(self):
+        """Test time-signal sampling validates the FDTD time grid."""
+        profile = SingleFrequencyProfile()
+
+        with pytest.raises(ValueError, match="at least 2"):
+            profile.sample_time_signal(period=1.0, time_step_duration=0.1, num_time_steps=1)
+        with pytest.raises(ValueError, match="positive"):
+            profile.sample_time_signal(period=1.0, time_step_duration=0.0, num_time_steps=2)
+
+    def test_frequency_spectrum_can_return_unnormalized_zero_spectrum(self):
+        """Test non-normalized spectrum output and zero-signal normalization branch."""
+        zero_profile = CustomTimeSignalProfile(signal=jnp.zeros((4,), dtype=jnp.float32), time_step_duration=0.25)
+        frequencies, zero_spectrum = zero_profile.frequency_spectrum(
+            period=1.0,
+            time_step_duration=0.25,
+            num_time_steps=4,
+            normalize=True,
+        )
+        _, raw_spectrum = zero_profile.frequency_spectrum(
+            period=1.0,
+            time_step_duration=0.25,
+            num_time_steps=4,
+            normalize=False,
+        )
+
+        assert frequencies.shape == zero_spectrum.shape
+        assert np.allclose(zero_spectrum, 0.0)
+        assert np.allclose(raw_spectrum, 0.0)
+
+    def test_base_profile_plot_ranges_default_to_auto_detection(self):
+        """Test base temporal profile range hooks request automatic plot ranges."""
+        profile = SingleFrequencyProfile()
+        frequencies = np.linspace(0.0, 1.0, 4)
+        spectrum = np.ones_like(frequencies)
+
+        assert profile.get_reference_frequency(period=0.25) == 4.0
+        assert profile.get_time_plot_range(period=0.25, total_time=1.0) is None
+        assert profile.get_frequency_plot_range(period=0.25, frequencies=frequencies, spectrum=spectrum) is None
+
     def test_plot_time_signal_and_spectrum_gaussian_writes_file(self, tmp_path):
         """Test that Gaussian pulse plots can be written to disk."""
         center_wave = WaveCharacter(frequency=193.4e12)
@@ -460,6 +619,7 @@ class TestTemporalProfilePlotting:
 
         assert fig is not None
         assert filename.exists()
+        assert filename.stat().st_size > 0
         plt.close("all")
 
 

--- a/tests/unit/objects/sources/test_profile.py
+++ b/tests/unit/objects/sources/test_profile.py
@@ -4,10 +4,9 @@ import math
 
 import jax
 import jax.numpy as jnp
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-
-import matplotlib.pyplot as plt
 
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.sources.profile import (

--- a/tests/unit/objects/sources/test_source.py
+++ b/tests/unit/objects/sources/test_source.py
@@ -6,6 +6,7 @@ These are unit tests that test the base classes and their methods.
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from fdtdx.config import SimulationConfig
@@ -200,6 +201,94 @@ class TestHardConstantAmplitudePlanceSource:
 
         E_updated = placed.update_E(E, inv_perm, 1.0, time_step, inverse=False)
         assert not jnp.allclose(E_updated, E)
+
+    def test_sample_time_signal_accepts_explicit_config_before_placement(self, micro_config):
+        """Test source time-signal sampling with an explicit config before placement."""
+        source = HardConstantAmplitudePlanceSource(
+            partial_grid_shape=(8, 8, 1),
+            wave_character=WaveCharacter(wavelength=1.55e-6),
+            direction="-",
+        )
+
+        time, signal = source.sample_time_signal(config=micro_config)
+
+        assert time.shape == signal.shape
+        assert time.shape == (micro_config.time_steps_total,)
+
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "sample_time_signal",
+            "frequency_spectrum",
+            "plot_time_signal_and_spectrum",
+        ],
+    )
+    def test_time_signal_methods_require_config_or_placement(self, method_name):
+        """Test that unplaced source time-signal methods require an explicit config."""
+        source = HardConstantAmplitudePlanceSource(
+            partial_grid_shape=(8, 8, 1),
+            wave_character=WaveCharacter(wavelength=1.55e-6),
+            direction="-",
+        )
+
+        with pytest.raises(ValueError, match="place_objects"):
+            getattr(source, method_name)()
+
+    def test_sample_time_signal_matches_explicit_and_stored_config(self, micro_config, jax_key):
+        """Test explicit config and placed source config give the same sampled signal."""
+        source = HardConstantAmplitudePlanceSource(
+            partial_grid_shape=(8, 8, 1),
+            wave_character=WaveCharacter(wavelength=1.55e-6),
+            direction="-",
+        )
+        placed = source.place_on_grid(
+            grid_slice_tuple=((0, 8), (0, 8), (4, 5)),
+            config=micro_config,
+            key=jax_key,
+        )
+
+        time_explicit, signal_explicit = placed.sample_time_signal(config=micro_config)
+        time_stored, signal_stored = placed.sample_time_signal()
+
+        assert np.allclose(time_stored, time_explicit)
+        assert np.allclose(signal_stored, signal_explicit)
+
+    def test_frequency_spectrum_accepts_explicit_config_before_placement(self, micro_config):
+        """Test source spectrum sampling with an explicit config before placement."""
+        source = HardConstantAmplitudePlanceSource(
+            partial_grid_shape=(8, 8, 1),
+            wave_character=WaveCharacter(wavelength=1.55e-6),
+            direction="-",
+        )
+
+        frequencies, spectrum = source.frequency_spectrum(config=micro_config, normalize=False)
+
+        assert frequencies.shape == spectrum.shape
+        assert frequencies.shape == (micro_config.time_steps_total // 2 + 1,)
+        assert np.max(spectrum) > 0.0
+
+    def test_plot_time_signal_and_spectrum_accepts_explicit_config_and_axes(self, micro_config):
+        """Test source plotting forwards explicit config and caller-provided axes."""
+        import matplotlib.pyplot as plt
+
+        source = HardConstantAmplitudePlanceSource(
+            partial_grid_shape=(8, 8, 1),
+            wave_character=WaveCharacter(wavelength=1.55e-6),
+            direction="-",
+        )
+        fig, axs = plt.subplots(1, 2)
+
+        result_fig = source.plot_time_signal_and_spectrum(
+            config=micro_config,
+            axs=axs,
+            time_range="full",
+            frequency_range="full",
+        )
+
+        assert result_fig is fig
+        assert len(axs[0].lines) == 1
+        assert len(axs[1].lines) == 1
+        plt.close("all")
 
 
 class TestDirectionalPlaneSourceBaseProperties:


### PR DESCRIPTION
Adds visualization of source signals in both the time and frequency domains, as well as functionality to define custom time-domain source profiles.

This serves to:

1. Verify the actual injected signal and its spectral content before running a simulation, e.g. to check that the source covers the frequency range used for response analysis.
2. Define custom time-domain source signals for direct source control, e.g. for adaptive spectral weighting in time-domain optimization workflows; see [Gedeon et al., IEEE TAP 2025](https://doi.org/10.1109/TAP.2025.3590211).

Plot example comparing a Gaussian pulse and a custom Hamming-windowed sinc signal:

<img width="1667" height="917" alt="source_comparison" src="https://github.com/user-attachments/assets/5401e9ec-ca0c-4be9-a792-2df1230b65b9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inject precomputed time-waveforms via a new custom temporal profile; enhanced temporal profiles can sample, compute one-sided spectra (optional normalization), and plot time+frequency with auto-scaled axes and file export.
  * Source objects expose convenient sampling, spectrum, and plotting helpers.

* **Documentation**
  * API docs updated to list the new temporal profile types and analysis/plotting methods.

* **Tests**
  * Extensive unit/integration tests for sampling, interpolation, spectra, plotting, and end-to-end physics comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->