### PR TITLE
Propagate simulation dtype through sources and utility functions

### DIFF
--- a/src/fdtdx/config.py
+++ b/src/fdtdx/config.py
@@ -105,6 +105,15 @@ class SimulationConfig(TreeClass):
             jax.config.update("jax_platform_name", "cpu")
 
     @property
+    def complex_dtype(self) -> jnp.dtype:
+        """Complex dtype matching the simulation's float dtype.
+
+        Returns:
+            jnp.dtype: ``jnp.complex128`` when ``dtype`` is ``jnp.float64``, otherwise ``jnp.complex64``.
+        """
+        return jnp.complex128 if self.dtype == jnp.float64 else jnp.complex64
+
+    @property
     def courant_number(self) -> float:
         """Calculate the Courant number for the simulation.
 

--- a/src/fdtdx/config.py
+++ b/src/fdtdx/config.py
@@ -105,15 +105,6 @@ class SimulationConfig(TreeClass):
             jax.config.update("jax_platform_name", "cpu")
 
     @property
-    def complex_dtype(self) -> jnp.dtype:
-        """Complex dtype matching the simulation's float dtype.
-
-        Returns:
-            jnp.dtype: ``jnp.complex128`` when ``dtype`` is ``jnp.float64``, otherwise ``jnp.complex64``.
-        """
-        return jnp.complex128 if self.dtype == jnp.float64 else jnp.complex64
-
-    @property
     def courant_number(self) -> float:
         """Calculate the Courant number for the simulation.
 

--- a/src/fdtdx/core/grid.py
+++ b/src/fdtdx/core/grid.py
@@ -58,7 +58,7 @@ def calculate_time_offset_yee(
     center_list = [center[0], center[1]]
     propagation_axis = spatial_shape.index(1)
     center_list.insert(propagation_axis, jnp.array(0))
-    center_3d = jnp.asarray(center_list, dtype=jnp.float32)[None, None, None, :]
+    center_3d = jnp.asarray(center_list, dtype=wave_vector.dtype)[None, None, None, :]
     xyz = xyz - center_3d
 
     # yee grid offsets

--- a/src/fdtdx/core/linalg.py
+++ b/src/fdtdx/core/linalg.py
@@ -7,11 +7,12 @@ import jax.numpy as jnp
 def get_wave_vector_raw(
     direction: Literal["+", "-"],
     propagation_axis: int,
+    dtype: jnp.dtype = jnp.float32,
 ) -> jax.Array:  # shape (3,)
     vec_list = [0, 0, 0]
     sign = 1 if direction == "+" else -1
     vec_list[propagation_axis] = sign
-    return jnp.array(vec_list, dtype=jnp.float32)
+    return jnp.array(vec_list, dtype=dtype)
 
 
 def get_orthogonal_vector(
@@ -20,6 +21,7 @@ def get_orthogonal_vector(
     wave_vector: jax.Array | None = None,
     direction: Literal["+", "-"] | None = None,
     propagation_axis: int | None = None,
+    dtype: jnp.dtype = jnp.float32,
 ) -> jax.Array:
     if (v_E is None) == (v_H is None):
         raise Exception(f"Invalid input to orthogonal vector computation: {v_E=}, {v_H=}")
@@ -31,6 +33,7 @@ def get_orthogonal_vector(
         wave_vector = get_wave_vector_raw(
             direction=direction,
             propagation_axis=propagation_axis,
+            dtype=dtype,
         )
     elif wave_vector is None:
         raise Exception("Need to specify either wave_vector or direction and propagation axis")
@@ -108,14 +111,11 @@ def rotate_vector(
 
     horizontal_axis, vertical_axis, propagation_axis = axes_tuple
 
-    # basis vectors
-    e1_list, e2_list, e3_list = [0, 0, 0], [0, 0, 0], [0, 0, 0]
-    e1_list[horizontal_axis] = 1
-    e2_list[vertical_axis] = 1
-    e3_list[propagation_axis] = 1
-    e1 = jnp.asarray(e1_list, dtype=jnp.float32)
-    e2 = jnp.asarray(e2_list, dtype=jnp.float32)
-    e3 = jnp.asarray(e3_list, dtype=jnp.float32)
+    # basis vectors — match the input vector's dtype to avoid implicit promotion warnings
+    _dtype = vector.dtype
+    e1 = jnp.zeros(3, dtype=_dtype).at[horizontal_axis].set(1)
+    e2 = jnp.zeros(3, dtype=_dtype).at[vertical_axis].set(1)
+    e3 = jnp.zeros(3, dtype=_dtype).at[propagation_axis].set(1)
     global_to_raw_basis = jnp.stack((e1, e2, e3), axis=0)
     raw_to_global_basis = jnp.transpose(global_to_raw_basis)
 
@@ -124,14 +124,14 @@ def rotate_vector(
         rotation_axis=1,
         angle_radians=azimuth_angle,
     )
-    u = az_matrix @ jnp.asarray([1, 0, 0], dtype=jnp.float32)
+    u = az_matrix @ jnp.array([1, 0, 0], dtype=_dtype)
 
     # elevation rotates vertical around horizontal axis
     el_matrix = get_single_directional_rotation_matrix(
         rotation_axis=0,
         angle_radians=elevation_angle,
     )
-    v = el_matrix @ jnp.asarray([0, 1, 0], dtype=jnp.float32)
+    v = el_matrix @ jnp.array([0, 1, 0], dtype=_dtype)
     w = jnp.cross(u, v)
     w = w / jnp.linalg.norm(w)
 

--- a/src/fdtdx/core/misc.py
+++ b/src/fdtdx/core/misc.py
@@ -451,15 +451,16 @@ def normalize_polarization_for_source(
     propagation_axis: int,
     fixed_E_polarization_vector: tuple[float, float, float] | None = None,
     fixed_H_polarization_vector: tuple[float, float, float] | None = None,
+    dtype: jnp.dtype = jnp.float32,
 ) -> tuple[jax.Array, jax.Array]:
     # determine E/H polarization
     e_pol = fixed_E_polarization_vector
     h_pol = fixed_H_polarization_vector
     if h_pol is not None:
-        h_pol = jnp.asarray(h_pol, dtype=jnp.float32)
+        h_pol = jnp.asarray(h_pol, dtype=dtype)
         h_pol = h_pol / jnp.linalg.norm(h_pol)
     if e_pol is not None:
-        e_pol = jnp.asarray(e_pol, dtype=jnp.float32)
+        e_pol = jnp.asarray(e_pol, dtype=dtype)
         e_pol = e_pol / jnp.linalg.norm(e_pol)
     if e_pol is None:
         if h_pol is None:
@@ -468,6 +469,7 @@ def normalize_polarization_for_source(
             v_H=h_pol,
             direction=direction,
             propagation_axis=propagation_axis,
+            dtype=dtype,
         )
     if h_pol is None:
         if e_pol is None:
@@ -476,6 +478,7 @@ def normalize_polarization_for_source(
             v_E=e_pol,
             direction=direction,
             propagation_axis=propagation_axis,
+            dtype=dtype,
         )
     return e_pol, h_pol
 

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -97,6 +97,7 @@ def compute_mode(
     direction: Literal["+", "-"],
     mode_index: int = 0,
     filter_pol: Literal["te", "tm"] | None = None,
+    dtype: jnp.dtype = jnp.float32,
 ) -> tuple[
     jax.Array,  # E
     jax.Array,  # H
@@ -120,6 +121,8 @@ def compute_mode(
         direction (Literal["+", "-"]): Propagation direction, either "+" or "-".
         mode_index (int, optional): Index of the mode to compute. Defaults to 0.
         filter_pol (Literal["te", "tm"] | None, optional). If not None, modes are filtered by polarization.
+        dtype (jnp.dtype, optional): Float dtype of the simulation. Controls whether mode fields are returned
+            as complex64 (float32) or complex128 (float64). Defaults to jnp.float32.
 
     Returns:
         Tuple[jax.Array, jax.Array, jax.Array]:
@@ -138,6 +141,8 @@ def compute_mode(
         ):
             raise Exception(f"Invalid shape of inv_permeabilities: {inv_permeabilities.shape}")
 
+    np_complex_dtype = np.complex128 if dtype == jnp.float64 else np.complex64
+
     def mode_helper(permittivity, permeability):
         modes = tidy3d_mode_computation_wrapper(
             frequency=frequency,
@@ -155,23 +160,23 @@ def compute_mode(
 
         if propagation_axis == 0:
             mode_E, mode_H = (
-                np.stack([mode.Ez, mode.Ex, mode.Ey], axis=0).astype(np.complex64),
-                np.stack([mode.Hz, mode.Hx, mode.Hy], axis=0).astype(np.complex64),
+                np.stack([mode.Ez, mode.Ex, mode.Ey], axis=0).astype(np_complex_dtype),
+                np.stack([mode.Hz, mode.Hx, mode.Hy], axis=0).astype(np_complex_dtype),
             )
         elif propagation_axis == 1:
             mode_E, mode_H = (
-                np.stack([mode.Ex, mode.Ez, mode.Ey], axis=0).astype(np.complex64),
-                -np.stack([mode.Hx, mode.Hz, mode.Hy], axis=0).astype(np.complex64),
+                np.stack([mode.Ex, mode.Ez, mode.Ey], axis=0).astype(np_complex_dtype),
+                -np.stack([mode.Hx, mode.Hz, mode.Hy], axis=0).astype(np_complex_dtype),
             )
         elif propagation_axis == 2:
             mode_E, mode_H = (
-                np.stack([mode.Ex, mode.Ey, mode.Ez], axis=0).astype(np.complex64),
-                np.stack([mode.Hx, mode.Hy, mode.Hz], axis=0).astype(np.complex64),
+                np.stack([mode.Ex, mode.Ey, mode.Ez], axis=0).astype(np_complex_dtype),
+                np.stack([mode.Hx, mode.Hy, mode.Hz], axis=0).astype(np_complex_dtype),
             )
         else:
             raise Exception("This should never happen")
 
-        neff = np.asarray(mode.neff).astype(np.complex64)
+        neff = np.asarray(mode.neff).astype(np_complex_dtype)
         return mode_E, mode_H, neff
 
     # compute input to tidy3d Mode solver
@@ -218,10 +223,11 @@ def compute_mode(
     if permittivity_squeezed.shape[0] == 9:
         permittivity_squeezed = permittivity_squeezed[jnp.array(perm_idx_full_anisotropy), :, :]
 
+    jnp_complex_dtype = jnp.complex128 if dtype == jnp.float64 else jnp.complex64
     result_shape_dtype = (
-        jnp.zeros((3, *permittivity_squeezed.shape[1:]), dtype=jnp.complex64),
-        jnp.zeros((3, *permittivity_squeezed.shape[1:]), dtype=jnp.complex64),
-        jnp.zeros(shape=(), dtype=jnp.complex64),
+        jnp.zeros((3, *permittivity_squeezed.shape[1:]), dtype=jnp_complex_dtype),
+        jnp.zeros((3, *permittivity_squeezed.shape[1:]), dtype=jnp_complex_dtype),
+        jnp.zeros(shape=(), dtype=jnp_complex_dtype),
     )
 
     if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0 and inv_permeabilities.shape[0] == 9:

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -94,6 +94,7 @@ class ModeOverlapDetector(PhasorDetector):
             direction=self.direction,
             mode_index=self.mode_index,
             filter_pol=self.filter_pol,
+            dtype=self._config.dtype,
         )
 
         self = self.aset("_mode_E", mode_E, create_new_ok=True)

--- a/src/fdtdx/objects/sources/dipole.py
+++ b/src/fdtdx/objects/sources/dipole.py
@@ -63,7 +63,7 @@ class PointDipoleSource(Source):
         ``azimuth_angle`` / ``elevation_angle`` using the same rotation
         convention as :func:`rotate_vector`.
         """
-        base = jnp.zeros(3, dtype=jnp.float32).at[self.polarization].set(1.0)
+        base = jnp.zeros(3, dtype=self._config.dtype).at[self.polarization].set(1.0)
         if self.azimuth_angle == 0.0 and self.elevation_angle == 0.0:
             return base
         horizontal_axis = (self.polarization + 1) % 3

--- a/src/fdtdx/objects/sources/linear_polarization.py
+++ b/src/fdtdx/objects/sources/linear_polarization.py
@@ -41,10 +41,12 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
             propagation_axis=self.propagation_axis,
             fixed_E_polarization_vector=self.fixed_E_polarization_vector,
             fixed_H_polarization_vector=self.fixed_H_polarization_vector,
+            dtype=self._config.dtype,
         )
         wave_vector_raw = get_wave_vector_raw(
             direction=self.direction,
             propagation_axis=self.propagation_axis,
+            dtype=self._config.dtype,
         )
 
         center, azimuth, elevation = self._get_random_parts(key)
@@ -69,7 +71,7 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
         # basis in plane
         h_list = [0, 0, 0]
         h_list[self.horizontal_axis] = 1
-        h_axis = jnp.asarray(h_list, dtype=jnp.float32)
+        h_axis = jnp.asarray(h_list, dtype=self._config.dtype)
         u_basis = h_axis - jnp.dot(h_axis, wave_vector) * wave_vector
         u_basis = u_basis / jnp.linalg.norm(u_basis)
         v_basis = jnp.cross(wave_vector, u_basis)
@@ -78,12 +80,12 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
         def project(point):
             point_list = [point[0], point[1]]
             point_list.insert(self.propagation_axis, 0)
-            point = jnp.asarray(point_list, dtype=jnp.float32)
+            point = jnp.asarray(point_list, dtype=self._config.dtype)
             projection = point - jnp.dot(point, wave_vector) * wave_vector
             # Convert to plane coordinates
             u = jnp.dot(projection, u_basis)
             v = jnp.dot(projection, v_basis)
-            return jnp.asarray((u, v), dtype=jnp.float32)
+            return jnp.asarray((u, v), dtype=self._config.dtype)
 
         float_projected = jax.vmap(project)(wh_indices.reshape(-1, 2))
         float_projected += center
@@ -223,5 +225,5 @@ class UniformPlaneSource(LinearlyPolarizedPlaneSource):
         center: jax.Array,
     ) -> jax.Array:
         del center
-        profile = jnp.ones(shape=self.grid_shape, dtype=jnp.float32)
+        profile = jnp.ones(shape=self.grid_shape, dtype=self._config.dtype)
         return self.amplitude * profile

--- a/src/fdtdx/objects/sources/mode.py
+++ b/src/fdtdx/objects/sources/mode.py
@@ -75,6 +75,7 @@ class ModePlaneSource(TFSFPlaneSource):
         raw_wave_vector = get_wave_vector_raw(
             direction=self.direction,
             propagation_axis=self.propagation_axis,
+            dtype=self._config.dtype,
         )
         time_offset_E, time_offset_H = calculate_time_offset_yee(
             center=center,

--- a/src/fdtdx/objects/sources/mode.py
+++ b/src/fdtdx/objects/sources/mode.py
@@ -62,6 +62,7 @@ class ModePlaneSource(TFSFPlaneSource):
             direction=self.direction,
             mode_index=self.mode_index,
             filter_pol=self.filter_pol,
+            dtype=self._config.dtype,
         )
         mode_E, mode_H = jnp.real(mode_E), jnp.real(mode_H)
 

--- a/src/fdtdx/objects/sources/source.py
+++ b/src/fdtdx/objects/sources/source.py
@@ -190,6 +190,7 @@ class HardConstantAmplitudePlanceSource(DirectionalPlaneSourceBase):
             propagation_axis=self.propagation_axis,
             fixed_E_polarization_vector=self.fixed_E_polarization_vector,
             fixed_H_polarization_vector=self.fixed_E_polarization_vector,
+            dtype=self._config.dtype,
         )
         E_update = e_pol[:, None, None, None] * magnitude
 
@@ -218,6 +219,7 @@ class HardConstantAmplitudePlanceSource(DirectionalPlaneSourceBase):
             propagation_axis=self.propagation_axis,
             fixed_E_polarization_vector=self.fixed_E_polarization_vector,
             fixed_H_polarization_vector=self.fixed_E_polarization_vector,
+            dtype=self._config.dtype,
         )
         H_update = h_pol[:, None, None, None] * magnitude
 

--- a/src/fdtdx/objects/sources/tfsf.py
+++ b/src/fdtdx/objects/sources/tfsf.py
@@ -130,7 +130,7 @@ class TFSFPlaneSource(DirectionalPlaneSourceBase, ABC):
 
         center = jnp.asarray(
             [center_horizontal + horizontal_offset, center_vertical + vertical_offset],
-            dtype=jnp.float32,
+            dtype=self._config.dtype,
         ).squeeze()
         return center
 


### PR DESCRIPTION
Addresses https://github.com/ymahlau/fdtdx/issues/262

Replace hardcoded float32/complex64 in core utilities and source objects with dtype-aware parameters derived from SimulationConfig.dtype, so that float64 simulations run without JAX implicit-promotion warnings.

New dtype-propagation tests were evaluated but not included: JAX's `jax_enable_x64` is a process-global one-way flag that cannot be unset or scoped per-test, making float64 dtype assertions unreliable inside a shared pytest process.

Float64 correctness can be validated by running a simulation with JAX_ENABLE_X64=1 and SimulationConfig(dtype=jnp.float64) and confirming no JAX implicit-promotion warnings appear. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed numeric precision handling to ensure consistency across all simulation operations
  * Simulation configuration's precision setting now properly propagates through sources, detectors, mode calculations, and field computations
  * Eliminated implicit precision conversions during complex field and wave vector calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->