### PR TITLE
refactor: split FieldState from ArrayContainer and add reset() method

### DIFF
--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -35,7 +35,7 @@ from fdtdx.core.physics.modes import compute_mode
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.fdtd.backward import full_backward
-from fdtdx.fdtd.container import ArrayContainer, ObjectContainer, ParameterContainer, SimulationState
+from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer, ParameterContainer, SimulationState
 from fdtdx.fdtd.initialization import apply_params, place_objects, resolve_object_constraints
 from fdtdx.fdtd.wrapper import run_fdtd
 from fdtdx.interfaces.modules import DtypeConversion
@@ -132,6 +132,7 @@ __all__ = [
     "EnergyDetector",
     "ExtrudedPolygon",
     "FieldDetector",
+    "FieldState",
     "GaussianPlaneSource",
     "GaussianPulseProfile",
     "GaussianSmoothing2D",

--- a/src/fdtdx/conversion/vti.py
+++ b/src/fdtdx/conversion/vti.py
@@ -35,8 +35,8 @@ def export_arrays_snapshot_to_vti(arrays: ArrayContainer, path: Path | str, reso
     """
     cell_data = {
         "permittivity": 1 / arrays.inv_permittivities,
-        "E": arrays.E,
-        "H": arrays.H,
+        "E": arrays.fields.E,
+        "H": arrays.fields.H,
     }
 
     if isinstance(arrays.inv_permeabilities, jax.Array) and arrays.inv_permeabilities.shape != ():

--- a/src/fdtdx/fdtd/backward.py
+++ b/src/fdtdx/fdtd/backward.py
@@ -93,7 +93,7 @@ def backward(
         key=key,
     )
 
-    H = arrays.H
+    H = arrays.fields.H
 
     arrays = update_H_reverse(
         time_step=time_step,
@@ -110,11 +110,11 @@ def backward(
     )
 
     if reset_fields:
-        new_fields = {f: getattr(arrays, f) for f in fields_to_reset}
+        new_fields = {f: getattr(arrays.fields, f) for f in fields_to_reset}
         for boundary in objects.boundary_objects:
             new_fields = boundary.apply_field_reset(new_fields)
         for name, f in new_fields.items():
-            arrays = arrays.aset(name, f)
+            arrays = arrays.aset(f"fields->{name}", f)
 
     if record_detectors:
         arrays = update_detector_states(

--- a/src/fdtdx/fdtd/container.py
+++ b/src/fdtdx/fdtd/container.py
@@ -316,7 +316,22 @@ class ArrayContainer(TreeClass):
         reset_detector_states: bool = True,
         reset_recording_state: bool = False,
     ) -> "ArrayContainer":
-        """Return a copy with all dynamic fields zeroed and material properties preserved."""
+        """Return a reset copy of this array container.
+
+        Dynamic field arrays are zeroed while material arrays and conductivity
+        arrays are preserved. Detector states are reset by default because they
+        accumulate time-dependent measurements. Recording state is preserved by
+        default so partial simulations can continue writing to the same buffers.
+
+        Args:
+            reset_detector_states: Whether to zero all detector state arrays.
+                Defaults to True.
+            reset_recording_state: Whether to zero recording data and state
+                arrays when a recording state is present. Defaults to False.
+
+        Returns:
+            A new ArrayContainer with reset dynamic state.
+        """
         arrays = self.aset("fields", jax.tree.map(jnp.zeros_like, self.fields))
 
         detector_states = self.detector_states
@@ -337,17 +352,3 @@ class ArrayContainer(TreeClass):
 
 # time step and arrays
 SimulationState = tuple[jax.Array, ArrayContainer]
-
-
-# Keep as a module-level alias so existing imports don't break during migration.
-# Will be removed once all call sites are updated.
-def reset_array_container(
-    arrays: "ArrayContainer",
-    objects: "ObjectContainer",
-    reset_detector_states: bool = True,
-    reset_recording_state: bool = False,
-) -> "ArrayContainer":
-    return arrays.reset(
-        reset_detector_states=reset_detector_states,
-        reset_recording_state=reset_recording_state,
-    )

--- a/src/fdtdx/fdtd/container.py
+++ b/src/fdtdx/fdtd/container.py
@@ -8,6 +8,7 @@ like sources, detectors, PML boundaries, Bloch/periodic boundaries, and devices.
 from typing import Callable, Self
 
 import jax
+import jax.numpy as jnp
 
 from fdtdx.core.jax.pytrees import TreeClass, autoinit, frozen_field
 from fdtdx.interfaces.state import RecordingState
@@ -251,12 +252,11 @@ class ObjectContainer(TreeClass):
 
 
 @autoinit
-class ArrayContainer(TreeClass):
-    """Container for simulation field arrays and states.
+class FieldState(TreeClass):
+    """Dynamic electromagnetic field state that evolves each time step.
 
-    This class holds the electromagnetic field arrays and various state information
-    needed during FDTD simulation. It includes the E and H fields, material properties,
-    and states for boundaries, detectors and recordings.
+    Grouping these together makes it impossible to forget a field when resetting
+    simulation state — ArrayContainer.reset() zeroes this entire struct at once.
     """
 
     #: Electric field array.
@@ -265,11 +265,24 @@ class ArrayContainer(TreeClass):
     #: Magnetic field array.
     H: jax.Array
 
-    #: Auxiliary electric field array.
+    #: PML auxiliary electric field.
     psi_E: jax.Array
 
-    #: Auxiliary magnetic field array.
+    #: PML auxiliary magnetic field.
     psi_H: jax.Array
+
+
+@autoinit
+class ArrayContainer(TreeClass):
+    """Container for simulation field arrays and states.
+
+    This class holds the electromagnetic field arrays and various state information
+    needed during FDTD simulation. It includes the E and H fields, material properties,
+    and states for boundaries, detectors and recordings.
+    """
+
+    #: Dynamic electromagnetic fields (E, H and PML auxiliaries).
+    fields: FieldState
 
     #: Alpha array for PML calculations.
     alpha: jax.Array
@@ -298,47 +311,43 @@ class ArrayContainer(TreeClass):
     #: field for magnetic conductivity terms. Defaults to None.
     magnetic_conductivity: jax.Array | None = None
 
+    def reset(
+        self,
+        reset_detector_states: bool = True,
+        reset_recording_state: bool = False,
+    ) -> "ArrayContainer":
+        """Return a copy with all dynamic fields zeroed and material properties preserved."""
+        arrays = self.aset("fields", jax.tree.map(jnp.zeros_like, self.fields))
+
+        detector_states = self.detector_states
+        if reset_detector_states:
+            detector_states = {k: {k2: v2 * 0 for k2, v2 in v.items()} for k, v in detector_states.items()}
+        arrays = arrays.aset("detector_states", detector_states)
+
+        recording_state = self.recording_state
+        if reset_recording_state and self.recording_state is not None:
+            recording_state = RecordingState(
+                data={k: v * 0 for k, v in self.recording_state.data.items()},
+                state={k: v * 0 for k, v in self.recording_state.state.items()},
+            )
+        arrays = arrays.aset("recording_state", recording_state)
+
+        return arrays
+
 
 # time step and arrays
 SimulationState = tuple[jax.Array, ArrayContainer]
 
 
+# Keep as a module-level alias so existing imports don't break during migration.
+# Will be removed once all call sites are updated.
 def reset_array_container(
-    arrays: ArrayContainer,
-    objects: ObjectContainer,
+    arrays: "ArrayContainer",
+    objects: "ObjectContainer",
     reset_detector_states: bool = True,
     reset_recording_state: bool = False,
-) -> ArrayContainer:
-    """Reset an ArrayContainer's fields and optionally its states.
-
-    This function creates a new ArrayContainer with zeroed E and H fields while preserving
-    material properties. It can optionally reset detector and recording states.
-
-    Args:
-        arrays (ArrayContainer): The ArrayContainer to reset.
-        objects (ObjectContainer): ObjectContainer with simulation objects.
-        reset_detector_states (bool, optional): Whether to zero detector states. Defaults to True.
-        reset_recording_state (bool, optional): Whether to zero recording state. Defaults to False.
-
-    Returns:
-        ArrayContainer: A new ArrayContainer with reset fields and optionally reset states.
-    """
-    E = arrays.E * 0
-    arrays = arrays.aset("E", E)
-    H = arrays.H * 0
-    arrays = arrays.aset("H", H)
-
-    detector_states = arrays.detector_states
-    if reset_detector_states:
-        detector_states = {k: {k2: v2 * 0 for k2, v2 in v.items()} for k, v in detector_states.items()}
-    arrays = arrays.aset("detector_states", detector_states)
-
-    recording_state = arrays.recording_state
-    if reset_recording_state and arrays.recording_state is not None:
-        recording_state = RecordingState(
-            data={k: v * 0 for k, v in arrays.recording_state.data.items()},
-            state={k: v * 0 for k, v in arrays.recording_state.state.items()},
-        )
-    arrays = arrays.aset("recording_state", recording_state)
-
-    return arrays
+) -> "ArrayContainer":
+    return arrays.reset(
+        reset_detector_states=reset_detector_states,
+        reset_recording_state=reset_recording_state,
+    )

--- a/src/fdtdx/fdtd/fdtd.py
+++ b/src/fdtdx/fdtd/fdtd.py
@@ -9,7 +9,7 @@ import jax.numpy as jnp
 from fdtdx.config import SimulationConfig
 from fdtdx.core.progress import _make_pbar, _wrap_body_with_progress
 from fdtdx.fdtd.backward import backward
-from fdtdx.fdtd.container import ArrayContainer, ObjectContainer, SimulationState, reset_array_container
+from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer, SimulationState
 from fdtdx.fdtd.forward import forward, forward_single_args_wrapper
 from fdtdx.fdtd.stop_conditions import StoppingCondition, TimeStepCondition
 from fdtdx.interfaces.state import RecordingState
@@ -65,7 +65,7 @@ def reversible_fdtd(
     """
     # if arrays.magnetic_conductivity is not None or arrays.electric_conductivity is not None:
     #     raise Exception(f"Reversible FDTD does not work with Conductive Materials")
-    arrays = reset_array_container(arrays, objects)
+    arrays = arrays.reset()
 
     pbar = _make_pbar(
         show_progress=show_progress,
@@ -114,10 +114,7 @@ def reversible_fdtd(
         recording_state: RecordingState | None,
     ):
         arr = ArrayContainer(
-            E=E,
-            H=H,
-            psi_E=psi_E,
-            psi_H=psi_H,
+            fields=FieldState(E=E, H=H, psi_E=psi_E, psi_H=psi_H),
             alpha=alpha,
             kappa=kappa,
             sigma=sigma,
@@ -131,10 +128,10 @@ def reversible_fdtd(
         state = reversible_fdtd_base(arr)
         return (
             state[0],
-            state[1].E,
-            state[1].H,
-            state[1].psi_E,
-            state[1].psi_H,
+            state[1].fields.E,
+            state[1].fields.H,
+            state[1].fields.psi_E,
+            state[1].fields.psi_H,
             state[1].alpha,
             state[1].kappa,
             state[1].sigma,
@@ -167,10 +164,10 @@ def reversible_fdtd(
                 simulate_boundaries=True,
             ),
             state[0],
-            state[1].E,
-            state[1].H,
-            state[1].psi_E,
-            state[1].psi_H,
+            state[1].fields.E,
+            state[1].fields.H,
+            state[1].fields.psi_E,
+            state[1].fields.psi_H,
             state[1].alpha,
             state[1].kappa,
             state[1].sigma,
@@ -212,10 +209,7 @@ def reversible_fdtd(
         ) = residual
 
         s_k = ArrayContainer(
-            E=res_E,
-            H=res_H,
-            psi_E=res_psi_E,
-            psi_H=res_psi_H,
+            fields=FieldState(E=res_E, H=res_H, psi_E=res_psi_E, psi_H=res_psi_H),
             alpha=res_alpha,
             kappa=res_kappa,
             sigma=res_sigma,
@@ -261,10 +255,7 @@ def reversible_fdtd(
         recording_state: RecordingState | None,
     ):
         arr = ArrayContainer(
-            E=E,
-            H=H,
-            psi_E=psi_E,
-            psi_H=psi_H,
+            fields=FieldState(E=E, H=H, psi_E=psi_E, psi_H=psi_H),
             alpha=alpha,
             kappa=kappa,
             sigma=sigma,
@@ -279,10 +270,10 @@ def reversible_fdtd(
 
         primal_out = (
             s_k[0],
-            s_k[1].E,
-            s_k[1].H,
-            s_k[1].psi_E,
-            s_k[1].psi_H,
+            s_k[1].fields.E,
+            s_k[1].fields.H,
+            s_k[1].fields.psi_E,
+            s_k[1].fields.psi_H,
             s_k[1].alpha,
             s_k[1].kappa,
             s_k[1].sigma,
@@ -293,10 +284,10 @@ def reversible_fdtd(
         )
         residual = (
             s_k[0],
-            s_k[1].E,
-            s_k[1].H,
-            s_k[1].psi_E,
-            s_k[1].psi_H,
+            s_k[1].fields.E,
+            s_k[1].fields.H,
+            s_k[1].fields.psi_E,
+            s_k[1].fields.psi_H,
             s_k[1].alpha,
             s_k[1].kappa,
             s_k[1].sigma,
@@ -323,10 +314,10 @@ def reversible_fdtd(
         detector_states,
         recording_state,
     ) = reversible_fdtd_primal(
-        E=arrays.E,
-        H=arrays.H,
-        psi_E=arrays.psi_E,
-        psi_H=arrays.psi_H,
+        E=arrays.fields.E,
+        H=arrays.fields.H,
+        psi_E=arrays.fields.psi_E,
+        psi_H=arrays.fields.psi_H,
         alpha=arrays.alpha,
         kappa=arrays.kappa,
         sigma=arrays.sigma,
@@ -338,10 +329,7 @@ def reversible_fdtd(
     _close_pbar()
 
     out_arrs = ArrayContainer(
-        E=E,
-        H=H,
-        psi_E=psi_E,
-        psi_H=psi_H,
+        fields=FieldState(E=E, H=H, psi_E=psi_E, psi_H=psi_H),
         alpha=alpha,
         kappa=kappa,
         sigma=sigma,
@@ -390,7 +378,7 @@ def checkpointed_fdtd(
         The number of checkpoints can be configured through config.gradient_config.num_checkpoints.
         More checkpoints reduce recomputation but increase memory usage.
     """
-    arrays = reset_array_container(arrays, objects)
+    arrays = arrays.reset()
     state = (jnp.asarray(0, dtype=jnp.int32), arrays)
     if stopping_condition is not None:
         stopping_condition = stopping_condition.setup(state, config, objects)
@@ -471,7 +459,7 @@ def custom_fdtd_forward(
         running partial simulations for analysis purposes.
     """
     if reset_container:
-        arrays = reset_array_container(arrays, objects)
+        arrays = arrays.reset()
     state = (jnp.asarray(start_time, dtype=jnp.int32), arrays)
 
     # start_time and end_time must be statically known Python ints here so that

--- a/src/fdtdx/fdtd/forward.py
+++ b/src/fdtdx/fdtd/forward.py
@@ -1,7 +1,7 @@
 import jax
 
 from fdtdx.config import SimulationConfig
-from fdtdx.fdtd.container import ArrayContainer, ObjectContainer, SimulationState
+from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer, SimulationState
 from fdtdx.fdtd.update import collect_interfaces, update_detector_states, update_E, update_H
 from fdtdx.interfaces.state import RecordingState
 from fdtdx.objects.detectors.detector import DetectorState
@@ -42,10 +42,7 @@ def forward_single_args_wrapper(
 ]:
     # Wrapper function that unpacks ArrayContainer into individual arrays for JAX transformations.
     arr = ArrayContainer(
-        E=E,
-        H=H,
-        psi_E=psi_E,
-        psi_H=psi_H,
+        fields=FieldState(E=E, H=H, psi_E=psi_E, psi_H=psi_H),
         alpha=alpha,
         kappa=kappa,
         sigma=sigma,
@@ -65,10 +62,10 @@ def forward_single_args_wrapper(
     )
     return (
         state[0],
-        state[1].E,
-        state[1].H,
-        state[1].psi_E,
-        state[1].psi_H,
+        state[1].fields.E,
+        state[1].fields.H,
+        state[1].fields.psi_E,
+        state[1].fields.psi_H,
         state[1].alpha,
         state[1].kappa,
         state[1].sigma,
@@ -114,7 +111,7 @@ def forward(
         SimulationState: Updated simulation state for the next time step
     """
     time_step, arrays = state
-    H_prev = arrays.H
+    H_prev = arrays.fields.H
     arrays = update_E(
         time_step=time_step,
         arrays=arrays,

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.sharding import create_named_sharded_matrix
 from fdtdx.core.jax.ste import straight_through_estimator
-from fdtdx.fdtd.container import ArrayContainer, ObjectContainer, ParameterContainer
+from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer, ParameterContainer
 from fdtdx.materials import (
     compute_allowed_electric_conductivities,
     compute_allowed_magnetic_conductivities,
@@ -599,10 +599,7 @@ def _init_arrays(
         config = config.aset("gradient_config", grad_cfg)
 
     arrays = ArrayContainer(
-        E=E,
-        H=H,
-        psi_E=psi_E,
-        psi_H=psi_H,
+        fields=FieldState(E=E, H=H, psi_E=psi_E, psi_H=psi_H),
         alpha=alpha,
         kappa=kappa,
         sigma=sigma,

--- a/src/fdtdx/fdtd/stop_conditions.py
+++ b/src/fdtdx/fdtd/stop_conditions.py
@@ -138,7 +138,9 @@ class EnergyThresholdCondition(StoppingCondition):
         curr_time_step, arrays = state
         time_condition = curr_time_step < self.max_steps
         min_steps_condition = curr_time_step < self.min_steps
-        total_energy = jnp.sum(compute_energy(arrays.E, arrays.H, arrays.inv_permittivities, arrays.inv_permeabilities))
+        total_energy = jnp.sum(
+            compute_energy(arrays.fields.E, arrays.fields.H, arrays.inv_permittivities, arrays.inv_permeabilities)
+        )
         converged = total_energy < self.threshold
 
         return time_condition & (min_steps_condition | ~converged)

--- a/src/fdtdx/fdtd/update.py
+++ b/src/fdtdx/fdtd/update.py
@@ -136,17 +136,17 @@ def update_E(
     inv_eps = arrays.inv_permittivities
     sigma_E = arrays.electric_conductivity
     c = config.courant_number
-    H_pad = pad_fields_for_boundaries(arrays.H, objects, config)
+    H_pad = pad_fields_for_boundaries(arrays.fields.H, objects, config)
     curl, psi_E = curl_H(
         config,
         H_pad,
-        arrays.psi_E,
+        arrays.fields.psi_E,
         arrays.alpha,
         arrays.kappa,
         arrays.sigma,
         simulate_boundaries,
     )
-    arrays = arrays.aset("psi_E", psi_E)
+    arrays = arrays.aset("fields->psi_E", psi_E)
 
     # Check if we have full anisotropic tensors (shape[0] == 9)
     inv_eps_is_full_tensor = inv_eps.shape[0] == 9
@@ -164,7 +164,7 @@ def update_E(
         # standard update formula using lossless material
         # Component-wise multiplication for diagonally anisotropic materials:
         # E[i, x, y, z] = factor * E[i, x, y, z] + c * curl[i, x, y, z] * inv_eps[i, x, y, z]
-        E = factor * arrays.E + c * curl * inv_eps
+        E = factor * arrays.fields.E + c * curl * inv_eps
 
         if sigma_E is not None:
             # update formula for lossy material. Simplifies to Noop for conductivity = 0
@@ -181,7 +181,7 @@ def update_E(
         A, B = compute_anisotropic_update_matrices(inv_eps, sigma_E, c, eta0)
 
         # We need to pad the fields and curl to account for ghost cells when computing the averages
-        E_pad = pad_fields_for_boundaries(arrays.E, objects, config)
+        E_pad = pad_fields_for_boundaries(arrays.fields.E, objects, config)
         curl_pad = pad_fields_for_boundaries(curl, objects, config)
 
         # Compute the averages of the fields and curl
@@ -201,17 +201,17 @@ def update_E(
         # K = curl(H)
         # Ex <= (Axx * Ex + Axy * x_avg(Ey) + Axz * x_avg(Ez)) +
         #       (Bxx * Kx + Bxy * x_avg(Ky) + Bxz * x_avg(Kz))
-        Ex = (A[0, 0] * arrays.E[0] + A[0, 1] * Ey_x_avg + A[0, 2] * Ez_x_avg) + (
+        Ex = (A[0, 0] * arrays.fields.E[0] + A[0, 1] * Ey_x_avg + A[0, 2] * Ez_x_avg) + (
             B[0, 0] * curl[0] + B[0, 1] * curlHy_x_avg + B[0, 2] * curlHz_x_avg
         )
         # Ey <= (Ayx * y_avg(Ex) + Ayy * Ey + Ayz * y_avg(Ez)) +
         #       (Byx * y_avg(Kx) + Byy * Ky + Byz * y_avg(Kz))
-        Ey = (A[1, 0] * Ex_y_avg + A[1, 1] * arrays.E[1] + A[1, 2] * Ez_y_avg) + (
+        Ey = (A[1, 0] * Ex_y_avg + A[1, 1] * arrays.fields.E[1] + A[1, 2] * Ez_y_avg) + (
             B[1, 0] * curlHx_y_avg + B[1, 1] * curl[1] + B[1, 2] * curlHz_y_avg
         )
         # Ez <= (Azx * z_avg(Ex) + Azy * z_avg(Ey) + Azz * Ez) +
         #       (Bzx * z_avg(Kx) + Bzy * z_avg(Ky) + Bzz * Kz)
-        Ez = (A[2, 0] * Ex_z_avg + A[2, 1] * Ey_z_avg + A[2, 2] * arrays.E[2]) + (
+        Ez = (A[2, 0] * Ex_z_avg + A[2, 1] * Ey_z_avg + A[2, 2] * arrays.fields.E[2]) + (
             B[2, 0] * curlHx_z_avg + B[2, 1] * curlHy_z_avg + B[2, 2] * curl[2]
         )
 
@@ -236,7 +236,7 @@ def update_E(
         )
 
     E = apply_boundary_post_E_update(E, objects)
-    arrays = arrays.at["E"].set(E)
+    arrays = arrays.aset("fields->E", E)
     return arrays
 
 
@@ -261,7 +261,7 @@ def update_E_reverse(
     Returns:
         ArrayContainer: Updated ArrayContainer with reversed E field values
     """
-    E = arrays.E
+    E = arrays.fields.E
     for source in objects.sources:
 
         def _update():
@@ -283,11 +283,11 @@ def update_E_reverse(
     inv_eps = arrays.inv_permittivities
     sigma_E = arrays.electric_conductivity
     c = config.courant_number
-    H_pad = pad_fields_for_boundaries(arrays.H, objects, config)
+    H_pad = pad_fields_for_boundaries(arrays.fields.H, objects, config)
     curl, _ = curl_H(
         config,
         H_pad,
-        arrays.psi_E,
+        arrays.fields.psi_E,
         arrays.alpha,
         arrays.kappa,
         arrays.sigma,
@@ -353,7 +353,7 @@ def update_E_reverse(
         E = jnp.stack((Ex, Ey, Ez), axis=0)
 
     E = apply_boundary_post_E_update(E, objects)
-    arrays = arrays.at["E"].set(E)
+    arrays = arrays.aset("fields->E", E)
 
     return arrays
 
@@ -389,17 +389,17 @@ def update_H(
     inv_mu = arrays.inv_permeabilities
     sigma_H = arrays.magnetic_conductivity
     c = config.courant_number
-    E_pad = pad_fields_for_boundaries(arrays.E, objects, config)
+    E_pad = pad_fields_for_boundaries(arrays.fields.E, objects, config)
     curl, psi_H = curl_E(
         config,
         E_pad,
-        arrays.psi_H,
+        arrays.fields.psi_H,
         arrays.alpha,
         arrays.kappa,
         arrays.sigma,
         simulate_boundaries,
     )
-    arrays = arrays.aset("psi_H", psi_H)
+    arrays = arrays.aset("fields->psi_H", psi_H)
 
     # Check if we have full anisotropic tensors (shape[0] == 9)
     # inv_mu can be a scalar (float) for non-magnetic materials
@@ -416,7 +416,7 @@ def update_H(
             factor = 1 - c * sigma_H / eta0 * inv_mu / 2
 
         # standard update formula for lossless material
-        H = factor * arrays.H - c * curl * inv_mu
+        H = factor * arrays.fields.H - c * curl * inv_mu
 
         if sigma_H is not None:
             # update formula for lossy material. Simplifies to NoOp for conductivity = 0
@@ -433,7 +433,7 @@ def update_H(
         A, B = compute_anisotropic_update_matrices(inv_mu, sigma_H, c, 1 / eta0)
 
         # We need to pad the fields and curl to account for ghost cells when computing the averages
-        H_pad = pad_fields_for_boundaries(arrays.H, objects, config)
+        H_pad = pad_fields_for_boundaries(arrays.fields.H, objects, config)
         curl_pad = pad_fields_for_boundaries(curl, objects, config)
 
         # Compute the averages of the fields and curl
@@ -453,17 +453,17 @@ def update_H(
         # K = curl(E)
         # Hx <= (Axx * Hx + Axy * x_avg(Hy) + Axz * x_avg(Hz)) -
         #       (Bxx * Kx + Bxy * x_avg(Ky) + Bxz * x_avg(Kz))
-        Hx = (A[0, 0] * arrays.H[0] + A[0, 1] * Hy_x_avg + A[0, 2] * Hz_x_avg) - (
+        Hx = (A[0, 0] * arrays.fields.H[0] + A[0, 1] * Hy_x_avg + A[0, 2] * Hz_x_avg) - (
             B[0, 0] * curl[0] + B[0, 1] * curlEy_x_avg + B[0, 2] * curlEz_x_avg
         )
         # Hy <= (Ayx * y_avg(Hx) + Ayy * Hy + Ayz * y_avg(Hz)) -
         #       (Byx * y_avg(Kx) + Byy * Ky + Byz * y_avg(Kz))
-        Hy = (A[1, 0] * Hx_y_avg + A[1, 1] * arrays.H[1] + A[1, 2] * Hz_y_avg) - (
+        Hy = (A[1, 0] * Hx_y_avg + A[1, 1] * arrays.fields.H[1] + A[1, 2] * Hz_y_avg) - (
             B[1, 0] * curlEx_y_avg + B[1, 1] * curl[1] + B[1, 2] * curlEz_y_avg
         )
         # Hz <= (Azx * z_avg(Hx) + Azy * z_avg(Hy) + Azz * Hz) -
         #       (Bzx * z_avg(Kx) + Bzy * z_avg(Ky) + Bzz * Kz)
-        Hz = (A[2, 0] * Hx_z_avg + A[2, 1] * Hy_z_avg + A[2, 2] * arrays.H[2]) - (
+        Hz = (A[2, 0] * Hx_z_avg + A[2, 1] * Hy_z_avg + A[2, 2] * arrays.fields.H[2]) - (
             B[2, 0] * curlEx_z_avg + B[2, 1] * curlEy_z_avg + B[2, 2] * curl[2]
         )
 
@@ -488,7 +488,7 @@ def update_H(
         )
 
     H = apply_boundary_post_H_update(H, objects)
-    arrays = arrays.at["H"].set(H)
+    arrays = arrays.aset("fields->H", H)
     return arrays
 
 
@@ -513,7 +513,7 @@ def update_H_reverse(
     Returns:
         ArrayContainer: Updated ArrayContainer with reversed H field values
     """
-    H = arrays.H
+    H = arrays.fields.H
     for source in objects.sources:
 
         def _update():
@@ -535,11 +535,11 @@ def update_H_reverse(
     inv_mu = arrays.inv_permeabilities
     sigma_H = arrays.magnetic_conductivity
     c = config.courant_number
-    E_pad = pad_fields_for_boundaries(arrays.E, objects, config)
+    E_pad = pad_fields_for_boundaries(arrays.fields.E, objects, config)
     curl, _ = curl_E(
         config,
         E_pad,
-        arrays.psi_H,
+        arrays.fields.psi_H,
         arrays.alpha,
         arrays.kappa,
         arrays.sigma,
@@ -608,7 +608,7 @@ def update_H_reverse(
         H = jnp.stack((Hx, Hy, Hz), axis=0)
 
     H = apply_boundary_post_H_update(H, objects)
-    arrays = arrays.at["H"].set(H)
+    arrays = arrays.aset("fields->H", H)
 
     return arrays
 
@@ -638,8 +638,8 @@ def update_detector_states(
     Returns:
         ArrayContainer: Updated ArrayContainer with new detector states
     """
-    E_pad = pad_fields_for_boundaries(arrays.E, objects, config)
-    H_avg_pad = pad_fields_for_boundaries((H_prev + arrays.H) / 2, objects, config)
+    E_pad = pad_fields_for_boundaries(arrays.fields.E, objects, config)
+    H_avg_pad = pad_fields_for_boundaries((H_prev + arrays.fields.H) / 2, objects, config)
     interpolated_E, interpolated_H = interpolate_fields(
         E_pad=E_pad,
         H_pad=H_avg_pad,
@@ -662,8 +662,8 @@ def update_detector_states(
             d._is_on_at_time_step_arr[time_step],
             helper_fn,
             lambda e, h, _: state[d.name],
-            interpolated_E if d.exact_interpolation else arrays.E,
-            interpolated_H if d.exact_interpolation else arrays.H,
+            interpolated_E if d.exact_interpolation else arrays.fields.E,
+            interpolated_H if d.exact_interpolation else arrays.fields.H,
             d,
         )
     arrays = arrays.aset("detector_states", state)

--- a/tests/integration/fdtd/test_initialization.py
+++ b/tests/integration/fdtd/test_initialization.py
@@ -97,8 +97,8 @@ def test_place_objects_initializes_arrays(simple_config, simple_volume, simple_m
     _obj_container, arrays, _params, _config, _info = place_objects(
         [simple_volume, obj], simple_config, [constraint], key
     )
-    assert arrays.E is not None
-    assert arrays.H is not None
+    assert arrays.fields.E is not None
+    assert arrays.fields.H is not None
     assert arrays.inv_permittivities is not None
     # simple_material has permittivity=2.0 → inv_perm ≈ 0.5 in the material region.
     # Verify at least one voxel was actually updated (differs from vacuum value 1.0).

--- a/tests/integration/fdtd/test_stop_conditions.py
+++ b/tests/integration/fdtd/test_stop_conditions.py
@@ -4,7 +4,7 @@ import pytest
 
 from fdtdx.config import SimulationConfig
 from fdtdx.core.wavelength import WaveCharacter
-from fdtdx.fdtd.container import ArrayContainer
+from fdtdx.fdtd.container import ArrayContainer, FieldState
 from fdtdx.fdtd.initialization import place_objects
 
 # Import the module to test
@@ -34,10 +34,7 @@ class TestCondition:
 
         # Create array container
         arrays = ArrayContainer(
-            E=E,
-            H=H,
-            psi_E=psi_E,
-            psi_H=psi_H,
+            fields=FieldState(E=E, H=H, psi_E=psi_E, psi_H=psi_H),
             alpha=alpha,
             kappa=kappa,
             sigma=sigma,
@@ -194,13 +191,13 @@ class TestCondition:
         # To simulate having a lower energy than the threshold, we'll manually
         # create a state where the energy is below the threshold,
         # by setting its attributes, E and H, to a small value
-        nE = arrays.E.size
-        nH = arrays.H.size
+        nE = arrays.fields.E.size
+        nH = arrays.fields.H.size
         v = jnp.sqrt(threshold / float(nE + nH)) * 0.9
-        v = jnp.asarray(v, dtype=arrays.E.dtype)
-        E_new = jnp.full_like(arrays.E, v)
-        H_new = jnp.full_like(arrays.H, v)
-        arrays_new = arrays.aset("E", E_new).aset("H", H_new)
+        v = jnp.asarray(v, dtype=arrays.fields.E.dtype)
+        E_new = jnp.full_like(arrays.fields.E, v)
+        H_new = jnp.full_like(arrays.fields.H, v)
+        arrays_new = arrays.aset("fields->E", E_new).aset("fields->H", H_new)
         state_below_thresh = (jnp.array(min_steps + 1), arrays_new)
         cond_fun = cond_fun.setup(state_below_thresh, config, objects)
         assert not cond_fun(state_below_thresh, config, objects)

--- a/tests/integration/utils/test_sparams.py
+++ b/tests/integration/utils/test_sparams.py
@@ -296,12 +296,12 @@ class TestSetupSparamsArrayContainer:
     def test_e_field_shape_matches_grid(self, minimal_setup):
         objs, arrays, _config = minimal_setup
         expected = (3, *objs.volume.grid_shape)
-        assert arrays.E.shape == expected
+        assert arrays.fields.E.shape == expected
 
     def test_h_field_shape_matches_grid(self, minimal_setup):
         objs, arrays, _config = minimal_setup
         expected = (3, *objs.volume.grid_shape)
-        assert arrays.H.shape == expected
+        assert arrays.fields.H.shape == expected
 
     def test_detector_states_keys_match_detectors(self, minimal_setup):
         objs, arrays, _config = minimal_setup
@@ -310,8 +310,8 @@ class TestSetupSparamsArrayContainer:
 
     def test_fields_initialized_to_zero(self, minimal_setup):
         _objs, arrays, _config = minimal_setup
-        assert jnp.all(arrays.E == 0)
-        assert jnp.all(arrays.H == 0)
+        assert jnp.all(arrays.fields.E == 0)
+        assert jnp.all(arrays.fields.H == 0)
 
     def test_inv_permittivities_positive(self, minimal_setup):
         _objs, arrays, _config = minimal_setup

--- a/tests/simulation/fdtd/test_fdtd.py
+++ b/tests/simulation/fdtd/test_fdtd.py
@@ -96,7 +96,7 @@ class TestReversibleFdtdGradients:
     def _loss_fn(self, inv_permittivities, arrays, objects, config, key):
         """L2 loss on output inv_permittivities through a full forward+backward pass.
 
-        Uses inv_permittivities (not E) because reset_array_container zeros E/H,
+        Uses inv_permittivities (not E) because ArrayContainer.reset zeros E/H,
         and without sources E stays zero. inv_permittivities passes through the
         simulation unchanged, giving a non-trivial gradient through the custom VJP.
         """

--- a/tests/simulation/fdtd/test_fdtd.py
+++ b/tests/simulation/fdtd/test_fdtd.py
@@ -9,7 +9,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import GradientConfig, SimulationConfig
-from fdtdx.fdtd.container import ArrayContainer, ObjectContainer
+from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer
 from fdtdx.fdtd.fdtd import reversible_fdtd
 from fdtdx.interfaces.recorder import Recorder
 
@@ -62,10 +62,12 @@ def recording_state(sim_config):
 def sim_arrays(field_shape, recording_state):
     auxiliary_field_shape = (6, 2, 2, 2)
     return ArrayContainer(
-        E=jnp.zeros(field_shape),
-        H=jnp.zeros(field_shape),
-        psi_E=jnp.zeros(auxiliary_field_shape),
-        psi_H=jnp.zeros(auxiliary_field_shape),
+        fields=FieldState(
+            E=jnp.zeros(field_shape),
+            H=jnp.zeros(field_shape),
+            psi_E=jnp.zeros(auxiliary_field_shape),
+            psi_H=jnp.zeros(auxiliary_field_shape),
+        ),
         alpha=jnp.zeros(field_shape),
         kappa=jnp.ones(field_shape),
         sigma=jnp.zeros(field_shape),
@@ -99,10 +101,9 @@ class TestReversibleFdtdGradients:
         simulation unchanged, giving a non-trivial gradient through the custom VJP.
         """
         arrays = ArrayContainer(
-            E=arrays.E,
-            H=arrays.H,
-            psi_E=arrays.psi_E,
-            psi_H=arrays.psi_H,
+            fields=FieldState(
+                E=arrays.fields.E, H=arrays.fields.H, psi_E=arrays.fields.psi_E, psi_H=arrays.fields.psi_H
+            ),
             alpha=arrays.alpha,
             kappa=arrays.kappa,
             sigma=arrays.sigma,
@@ -133,10 +134,12 @@ class TestReversibleFdtdGradients:
         """With nonzero initial E fields, gradients should be non-zero."""
         auxiliary_field_shape = (6, 2, 2, 2)
         arrays = ArrayContainer(
-            E=jnp.ones(field_shape) * 0.5,
-            H=jnp.ones(field_shape) * 0.3,
-            psi_E=jnp.zeros(auxiliary_field_shape),
-            psi_H=jnp.zeros(auxiliary_field_shape),
+            fields=FieldState(
+                E=jnp.ones(field_shape) * 0.5,
+                H=jnp.ones(field_shape) * 0.3,
+                psi_E=jnp.zeros(auxiliary_field_shape),
+                psi_H=jnp.zeros(auxiliary_field_shape),
+            ),
             alpha=jnp.zeros(field_shape),
             kappa=jnp.ones(field_shape),
             sigma=jnp.zeros(field_shape),

--- a/tests/simulation/fdtd/test_time_reversal.py
+++ b/tests/simulation/fdtd/test_time_reversal.py
@@ -15,7 +15,7 @@ import jax.numpy as jnp
 import fdtdx
 from fdtdx.config import GradientConfig, SimulationConfig
 from fdtdx.fdtd.backward import backward
-from fdtdx.fdtd.container import ArrayContainer
+from fdtdx.fdtd.container import ArrayContainer, FieldState
 from fdtdx.fdtd.fdtd import reversible_fdtd
 from fdtdx.fdtd.forward import forward
 from fdtdx.interfaces.recorder import Recorder
@@ -80,7 +80,7 @@ def _build_simulation(boundary_types, bloch_vector=(0.0, 0.0, 0.0)):
 def _add_gradient_config(arrays, config, obj_container):
     """Attach a gradient recorder to the config and arrays."""
     input_shape_dtypes = {}
-    field_dtype = arrays.E.dtype
+    field_dtype = arrays.fields.E.dtype
     for boundary in obj_container.pml_objects:
         cur_shape = boundary.interface_grid_shape()
         extended_shape = (3, *cur_shape)
@@ -112,14 +112,14 @@ def _seed_fields(arrays, key, obj_container=None):
     destroy information during the forward step.
     """
     k1, k2 = jax.random.split(key)
-    E = jax.random.normal(k1, arrays.E.shape, dtype=arrays.E.dtype) * 1e-3
-    H = jax.random.normal(k2, arrays.H.shape, dtype=arrays.H.dtype) * 1e-3
+    E = jax.random.normal(k1, arrays.fields.E.shape, dtype=arrays.fields.E.dtype) * 1e-3
+    H = jax.random.normal(k2, arrays.fields.H.shape, dtype=arrays.fields.H.dtype) * 1e-3
     if obj_container is not None:
         for b in obj_container.boundary_objects:
             E = b.apply_post_E_update(E)
             H = b.apply_post_H_update(H)
-    arrays = arrays.aset("E", E)
-    arrays = arrays.aset("H", H)
+    arrays = arrays.aset("fields->E", E)
+    arrays = arrays.aset("fields->H", H)
     return arrays
 
 
@@ -132,8 +132,8 @@ def _forward_backward_roundtrip(obj_container, arrays, config, has_pml):
     arrays, config = _add_gradient_config(arrays, config, obj_container)
 
     # Save original fields
-    E_original = arrays.E.copy()
-    H_original = arrays.H.copy()
+    E_original = arrays.fields.E.copy()
+    H_original = arrays.fields.H.copy()
 
     # Forward one step
     state_fwd = forward(
@@ -365,10 +365,9 @@ class TestGradientPMLBlochComplex:
     @staticmethod
     def _loss_fn(inv_permittivities, arrays, objects, config, key):
         arrays = ArrayContainer(
-            E=arrays.E,
-            H=arrays.H,
-            psi_E=arrays.psi_E,
-            psi_H=arrays.psi_H,
+            fields=FieldState(
+                E=arrays.fields.E, H=arrays.fields.H, psi_E=arrays.fields.psi_E, psi_H=arrays.fields.psi_H
+            ),
             alpha=arrays.alpha,
             kappa=arrays.kappa,
             sigma=arrays.sigma,
@@ -404,5 +403,5 @@ class TestGradientPMLBlochComplex:
     def test_fields_are_complex(self):
         """Verify the simulation actually uses complex-valued fields."""
         _, arrays, _ = self._build()
-        assert jnp.issubdtype(arrays.E.dtype, jnp.complexfloating)
-        assert jnp.issubdtype(arrays.H.dtype, jnp.complexfloating)
+        assert jnp.issubdtype(arrays.fields.E.dtype, jnp.complexfloating)
+        assert jnp.issubdtype(arrays.fields.H.dtype, jnp.complexfloating)

--- a/tests/simulation/fdtd/test_time_reversal.py
+++ b/tests/simulation/fdtd/test_time_reversal.py
@@ -157,7 +157,7 @@ def _forward_backward_roundtrip(obj_container, arrays, config, has_pml):
     )
 
     _, arrays_bwd = state_bwd
-    return E_original, H_original, arrays_bwd.E, arrays_bwd.H
+    return E_original, H_original, arrays_bwd.fields.E, arrays_bwd.fields.H
 
 
 # ── Boundary type definitions ──────────────────────────────────────────────────

--- a/tests/unit/conversion/test_vti.py
+++ b/tests/unit/conversion/test_vti.py
@@ -252,8 +252,9 @@ class TestExportArraysSnapshotToVti:
         """Create a mock ArrayContainer with the given properties."""
         mock = MagicMock()
         mock.inv_permittivities = jnp.ones(shape, dtype=jnp.float32) * 0.5
-        mock.E = jnp.zeros(shape, dtype=jnp.float32)
-        mock.H = jnp.zeros(shape, dtype=jnp.float32)
+        mock.fields = MagicMock()
+        mock.fields.E = jnp.zeros(shape, dtype=jnp.float32)
+        mock.fields.H = jnp.zeros(shape, dtype=jnp.float32)
 
         if scalar_permeability:
             mock.inv_permeabilities = 1.0
@@ -317,8 +318,8 @@ class TestExportArraysSnapshotToVti:
         """The function computes 1/inv_permittivities, so values should be inverted."""
         arrays = self._make_mock_arrays()
         arrays.inv_permittivities = jnp.full((3, 3, 3), 0.25, dtype=jnp.float32)
-        arrays.E = jnp.zeros((3, 3, 3), dtype=jnp.float32)
-        arrays.H = jnp.zeros((3, 3, 3), dtype=jnp.float32)
+        arrays.fields.E = jnp.zeros((3, 3, 3), dtype=jnp.float32)
+        arrays.fields.H = jnp.zeros((3, 3, 3), dtype=jnp.float32)
         arrays.inv_permeabilities = 1.0
         arrays.electric_conductivity = None
         arrays.magnetic_conductivity = None

--- a/tests/unit/fdtd/test_backward.py
+++ b/tests/unit/fdtd/test_backward.py
@@ -65,16 +65,17 @@ class TestBackward:
     @pytest.fixture
     def mock_arrays(self):
         arrays = Mock()
-        arrays.E = jnp.ones((3, 10, 10, 10))
-        arrays.H = jnp.full((3, 10, 10, 10), 2.0)
+        arrays.fields.E = jnp.ones((3, 10, 10, 10))
+        arrays.fields.H = jnp.full((3, 10, 10, 10), 2.0)
 
         aset_log = {}
 
         def aset(field_name, value):
             aset_log[field_name] = value
             new = Mock()
-            new.E = value if field_name == "E" else arrays.E
-            new.H = value if field_name == "H" else arrays.H
+            new.fields = Mock()
+            new.fields.E = value if field_name == "fields->E" else arrays.fields.E
+            new.fields.H = value if field_name == "fields->H" else arrays.fields.H
             new.aset = aset
             return new
 
@@ -135,7 +136,7 @@ class TestBackward:
         patched_updates["update_detectors"].assert_called_once()
         call_kwargs = patched_updates["update_detectors"].call_args.kwargs
         assert call_kwargs["inverse"] is True
-        assert jnp.array_equal(call_kwargs["H_prev"], mock_arrays.H)
+        assert jnp.array_equal(call_kwargs["H_prev"], mock_arrays.fields.H)
 
     def test_reset_fields_calls_apply_field_reset_on_all_boundaries(
         self, mock_arrays, mock_objects, key, patched_updates
@@ -187,5 +188,5 @@ class TestBackward:
             fields_to_reset=("E",),
         )
 
-        assert "E" in mock_arrays._aset_log
-        assert "H" not in mock_arrays._aset_log
+        assert "fields->E" in mock_arrays._aset_log
+        assert "fields->H" not in mock_arrays._aset_log

--- a/tests/unit/fdtd/test_container.py
+++ b/tests/unit/fdtd/test_container.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import jax.numpy as jnp
 import pytest
 
-from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer, reset_array_container
+from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer
 from fdtdx.interfaces.state import RecordingState
 from fdtdx.materials import Material
 from fdtdx.objects.boundaries.bloch import BlochBoundary
@@ -318,7 +318,7 @@ class TestArrayContainer:
         assert container.inv_permeabilities == 1.0
 
 
-class TestResetArrayContainer:
+class TestArrayContainerReset:
     def setup_method(self):
         self.E = jnp.ones((3, 5, 5, 5))
         self.H = jnp.ones((3, 5, 5, 5))
@@ -350,40 +350,36 @@ class TestResetArrayContainer:
         self.objects = ObjectContainer(object_list=[self.mock_boundary], volume_idx=0)
 
     def test_e_and_h_fields_zeroed(self):
-        result = reset_array_container(arrays=self.array_container, objects=self.objects)
+        result = self.array_container.reset()
         assert jnp.all(result.fields.E == 0)
         assert jnp.all(result.fields.H == 0)
 
     def test_material_properties_preserved(self):
-        result = reset_array_container(arrays=self.array_container, objects=self.objects)
+        result = self.array_container.reset()
         assert jnp.array_equal(result.inv_permittivities, self.inv_permittivities)
         assert jnp.array_equal(result.inv_permeabilities, self.inv_permeabilities)
 
     def test_detector_states_reset_by_default(self):
-        result = reset_array_container(arrays=self.array_container, objects=self.objects)
+        result = self.array_container.reset()
         assert jnp.all(result.detector_states["detector1"]["data"] == 0)
 
     def test_detector_states_preserved_when_not_reset(self):
-        result = reset_array_container(arrays=self.array_container, objects=self.objects, reset_detector_states=False)
+        result = self.array_container.reset(reset_detector_states=False)
         assert jnp.array_equal(
             result.detector_states["detector1"]["data"],
             self.detector_states["detector1"]["data"],
         )
 
     def test_recording_state_not_reset_by_default(self):
-        result = reset_array_container(arrays=self.array_container, objects=self.objects)
+        result = self.array_container.reset()
         assert result.recording_state == self.recording_state
 
     def test_recording_state_reset(self):
-        result = reset_array_container(arrays=self.array_container, objects=self.objects, reset_recording_state=True)
+        result = self.array_container.reset(reset_recording_state=True)
         assert jnp.all(result.recording_state.data["recording"] == 0)
         assert jnp.all(result.recording_state.state["state"] == 0)
 
     def test_recording_state_none_handled(self):
         array_container_no_recording = self.array_container.aset("recording_state", None)
-        result = reset_array_container(
-            arrays=array_container_no_recording,
-            objects=self.objects,
-            reset_recording_state=True,
-        )
+        result = array_container_no_recording.reset(reset_recording_state=True)
         assert result.recording_state is None

--- a/tests/unit/fdtd/test_container.py
+++ b/tests/unit/fdtd/test_container.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import jax.numpy as jnp
 import pytest
 
-from fdtdx.fdtd.container import ArrayContainer, ObjectContainer, reset_array_container
+from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer, reset_array_container
 from fdtdx.interfaces.state import RecordingState
 from fdtdx.materials import Material
 from fdtdx.objects.boundaries.bloch import BlochBoundary
@@ -261,10 +261,7 @@ class TestArrayContainer:
         self.recording_state = Mock(spec=RecordingState)
 
         self.array_container = ArrayContainer(
-            E=self.E,
-            H=self.H,
-            psi_E=self.psi_E,
-            psi_H=self.psi_H,
+            fields=FieldState(E=self.E, H=self.H, psi_E=self.psi_E, psi_H=self.psi_H),
             alpha=self.alpha,
             kappa=self.kappa,
             sigma=self.sigma,
@@ -275,8 +272,8 @@ class TestArrayContainer:
         )
 
     def test_creation(self):
-        assert jnp.array_equal(self.array_container.E, self.E)
-        assert jnp.array_equal(self.array_container.H, self.H)
+        assert jnp.array_equal(self.array_container.fields.E, self.E)
+        assert jnp.array_equal(self.array_container.fields.H, self.H)
         assert jnp.array_equal(self.array_container.inv_permittivities, self.inv_permittivities)
         assert jnp.array_equal(self.array_container.inv_permeabilities, self.inv_permeabilities)
         assert self.array_container.detector_states == self.detector_states
@@ -287,10 +284,7 @@ class TestArrayContainer:
         magnetic_conductivity = jnp.ones((3, 10, 10, 10))
 
         container = ArrayContainer(
-            E=self.E,
-            H=self.H,
-            psi_E=self.psi_E,
-            psi_H=self.psi_H,
+            fields=FieldState(E=self.E, H=self.H, psi_E=self.psi_E, psi_H=self.psi_H),
             alpha=self.alpha,
             kappa=self.kappa,
             sigma=self.sigma,
@@ -312,10 +306,7 @@ class TestArrayContainer:
     def test_inv_permeabilities_float(self):
         """Test that inv_permeabilities can be a float."""
         container = ArrayContainer(
-            E=self.E,
-            H=self.H,
-            psi_E=self.psi_E,
-            psi_H=self.psi_H,
+            fields=FieldState(E=self.E, H=self.H, psi_E=self.psi_E, psi_H=self.psi_H),
             alpha=self.alpha,
             kappa=self.kappa,
             sigma=self.sigma,
@@ -343,10 +334,7 @@ class TestResetArrayContainer:
         self.recording_state = RecordingState(data={"recording": jnp.ones(10)}, state={"state": jnp.ones(5)})
 
         self.array_container = ArrayContainer(
-            E=self.E,
-            H=self.H,
-            psi_E=self.psi_E,
-            psi_H=self.psi_H,
+            fields=FieldState(E=self.E, H=self.H, psi_E=self.psi_E, psi_H=self.psi_H),
             alpha=self.alpha,
             kappa=self.kappa,
             sigma=self.sigma,
@@ -363,8 +351,8 @@ class TestResetArrayContainer:
 
     def test_e_and_h_fields_zeroed(self):
         result = reset_array_container(arrays=self.array_container, objects=self.objects)
-        assert jnp.all(result.E == 0)
-        assert jnp.all(result.H == 0)
+        assert jnp.all(result.fields.E == 0)
+        assert jnp.all(result.fields.H == 0)
 
     def test_material_properties_preserved(self):
         result = reset_array_container(arrays=self.array_container, objects=self.objects)

--- a/tests/unit/fdtd/test_fdtd.py
+++ b/tests/unit/fdtd/test_fdtd.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import GradientConfig, SimulationConfig
-from fdtdx.fdtd.container import ArrayContainer, ObjectContainer
+from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer
 from fdtdx.fdtd.fdtd import checkpointed_fdtd, custom_fdtd_forward, reversible_fdtd
 from fdtdx.fdtd.stop_conditions import TimeStepCondition
 from fdtdx.objects.object import SimulationObject
@@ -30,10 +30,12 @@ def field_shape():
 def dummy_arrays(field_shape):
     auxiliary_field_shape = (6, 2, 2, 2)
     return ArrayContainer(
-        E=jnp.zeros(field_shape),
-        H=jnp.zeros(field_shape),
-        psi_E=jnp.zeros(auxiliary_field_shape),
-        psi_H=jnp.zeros(auxiliary_field_shape),
+        fields=FieldState(
+            E=jnp.zeros(field_shape),
+            H=jnp.zeros(field_shape),
+            psi_E=jnp.zeros(auxiliary_field_shape),
+            psi_H=jnp.zeros(auxiliary_field_shape),
+        ),
         alpha=jnp.zeros(field_shape),
         kappa=jnp.ones(field_shape),
         sigma=jnp.zeros(field_shape),
@@ -126,10 +128,12 @@ class TestReversibleFdtd:
     def test_with_nonzero_initial_fields(self, dummy_objects, config_few_steps, key, field_shape):
         auxiliary_field_shape = (6, 2, 2, 2)
         arrays = ArrayContainer(
-            E=jnp.ones(field_shape) * 0.5,
-            H=jnp.ones(field_shape) * 0.3,
-            psi_E=jnp.zeros(auxiliary_field_shape),
-            psi_H=jnp.zeros(auxiliary_field_shape),
+            fields=FieldState(
+                E=jnp.ones(field_shape) * 0.5,
+                H=jnp.ones(field_shape) * 0.3,
+                psi_E=jnp.zeros(auxiliary_field_shape),
+                psi_H=jnp.zeros(auxiliary_field_shape),
+            ),
             alpha=jnp.zeros(field_shape),
             kappa=jnp.ones(field_shape),
             sigma=jnp.zeros(field_shape),
@@ -307,7 +311,7 @@ class TestShowProgressFlag:
         t, arrs = reversible_fdtd(dummy_arrays, dummy_objects, config_few_steps, key, show_progress=True)
         assert isinstance(t, jax.Array)
         assert isinstance(arrs, ArrayContainer)
-        assert arrs.E.shape == dummy_arrays.E.shape
+        assert arrs.E.shape == dummy_arrays.fields.E.shape
 
     def test_checkpointed_fdtd_with_progress(self, dummy_arrays, dummy_objects, config_checkpointed):
         key = jax.random.PRNGKey(0)

--- a/tests/unit/fdtd/test_fdtd.py
+++ b/tests/unit/fdtd/test_fdtd.py
@@ -99,8 +99,8 @@ class TestReversibleFdtd:
 
     def test_output_shapes_match_input(self, dummy_arrays, dummy_objects, config_few_steps, key, field_shape):
         _, arrs = reversible_fdtd(dummy_arrays, dummy_objects, config_few_steps, key)
-        assert arrs.E.shape == field_shape
-        assert arrs.H.shape == field_shape
+        assert arrs.fields.E.shape == field_shape
+        assert arrs.fields.H.shape == field_shape
         assert arrs.inv_permittivities.shape == field_shape
         assert arrs.inv_permeabilities.shape == field_shape
 
@@ -146,7 +146,7 @@ class TestReversibleFdtd:
         )
         t, arrs = reversible_fdtd(arrays, dummy_objects, config_few_steps, key)
         assert int(t) == config_few_steps.time_steps_total
-        assert arrs.E.shape == field_shape
+        assert arrs.fields.E.shape == field_shape
 
     def test_empty_objects(self, dummy_arrays, empty_objects, config_few_steps, key):
         t, arrs = reversible_fdtd(dummy_arrays, empty_objects, config_few_steps, key)
@@ -166,8 +166,8 @@ class TestCheckpointedFdtd:
 
     def test_output_shapes_match_input(self, dummy_arrays, dummy_objects, config_checkpointed, key, field_shape):
         _, arrs = checkpointed_fdtd(dummy_arrays, dummy_objects, config_checkpointed, key)
-        assert arrs.E.shape == field_shape
-        assert arrs.H.shape == field_shape
+        assert arrs.fields.E.shape == field_shape
+        assert arrs.fields.H.shape == field_shape
 
     def test_empty_objects(self, dummy_arrays, empty_objects, config_checkpointed, key):
         t, arrs = checkpointed_fdtd(dummy_arrays, empty_objects, config_checkpointed, key)
@@ -244,8 +244,8 @@ class TestCustomFdtdForward:
             start_time=0,
             end_time=1,
         )
-        assert arrs.E.shape == field_shape
-        assert arrs.H.shape == field_shape
+        assert arrs.fields.E.shape == field_shape
+        assert arrs.fields.H.shape == field_shape
 
     def test_reset_container_false(self, dummy_arrays, dummy_objects, config_few_steps, key):
         t, arrs = custom_fdtd_forward(
@@ -311,7 +311,7 @@ class TestShowProgressFlag:
         t, arrs = reversible_fdtd(dummy_arrays, dummy_objects, config_few_steps, key, show_progress=True)
         assert isinstance(t, jax.Array)
         assert isinstance(arrs, ArrayContainer)
-        assert arrs.E.shape == dummy_arrays.fields.E.shape
+        assert arrs.fields.E.shape == dummy_arrays.fields.E.shape
 
     def test_checkpointed_fdtd_with_progress(self, dummy_arrays, dummy_objects, config_checkpointed):
         key = jax.random.PRNGKey(0)

--- a/tests/unit/fdtd/test_fdtd_misc.py
+++ b/tests/unit/fdtd/test_fdtd_misc.py
@@ -78,8 +78,8 @@ def test_collect_boundary_interfaces(mock_arraycontainer, mock_pml):
     assert "pml1_E" in result
     assert "pml1_H" in result
 
-    expected_E = arrays.E[:, 0:1]
-    expected_H = arrays.H[:, 0:1]
+    expected_E = arrays.fields.E[:, 0:1]
+    expected_H = arrays.fields.H[:, 0:1]
 
     assert jnp.array_equal(result["pml1_E"], expected_E)
     assert jnp.array_equal(result["pml1_H"], expected_H)
@@ -93,7 +93,7 @@ def test_collect_boundary_interfaces_single_field(mock_arraycontainer, mock_pml)
 
     assert "pml1_E" in result
     assert "pml1_H" not in result
-    assert jnp.array_equal(result["pml1_E"], arrays.E[:, 0:1])
+    assert jnp.array_equal(result["pml1_E"], arrays.fields.E[:, 0:1])
 
 
 def test_collect_boundary_interfaces_multiple_pmls(mock_arraycontainer):
@@ -107,8 +107,8 @@ def test_collect_boundary_interfaces_multiple_pmls(mock_arraycontainer):
     assert "pml1_H" in result
     assert "pml2_E" in result
     assert "pml2_H" in result
-    assert jnp.array_equal(result["pml1_E"], arrays.E[:, 0:1])
-    assert jnp.array_equal(result["pml2_E"], arrays.E[:, 1:2])
+    assert jnp.array_equal(result["pml1_E"], arrays.fields.E[:, 0:1])
+    assert jnp.array_equal(result["pml2_E"], arrays.fields.E[:, 1:2])
 
 
 def test_add_boundary_interfaces(mock_arraycontainer, mock_pml):

--- a/tests/unit/fdtd/test_fdtd_misc.py
+++ b/tests/unit/fdtd/test_fdtd_misc.py
@@ -21,14 +21,35 @@ class MockPML:
 class MockArrayContainer:
     """Mock replacement for ArrayContainer.
 
-    - Fields (E, H) are plain jnp arrays.
+    - Fields (E, H) are exposed through fields.E and fields.H.
+    - Direct E and H properties are kept for misc.py compatibility.
     - Supports arrays.at["E"].set(...) to set the whole field (used in add_boundary_interfaces).
     - Slicing and arr.at[..., ...].set(...) for individual jnp arrays is delegated to jax.numpy arrays.
     """
 
+    class _Fields:
+        def __init__(self, E, H):
+            self.E = E
+            self.H = H
+
     def __init__(self, E, H):
-        self.E = E
-        self.H = H
+        self.fields = MockArrayContainer._Fields(E=E, H=H)
+
+    @property
+    def E(self):
+        return self.fields.E
+
+    @E.setter
+    def E(self, value):
+        self.fields.E = value
+
+    @property
+    def H(self):
+        return self.fields.H
+
+    @H.setter
+    def H(self, value):
+        self.fields.H = value
 
     class _AtHelper:
         def __init__(self, parent):

--- a/tests/unit/fdtd/test_forward.py
+++ b/tests/unit/fdtd/test_forward.py
@@ -15,10 +15,12 @@ from fdtdx.objects.detectors.detector import DetectorState
 def arrays():
     """Create an ArrayContainer with small test arrays."""
     return ArrayContainer(
-        E=jnp.ones((3, 4, 4, 4)),
-        H=jnp.ones((3, 4, 4, 4)) * 2.0,
-        psi_E=jnp.zeros((6, 4, 4, 4)),
-        psi_H=jnp.zeros((6, 4, 4, 4)),
+        fields=FieldState(
+            E=jnp.ones((3, 4, 4, 4)),
+            H=jnp.ones((3, 4, 4, 4)) * 2.0,
+            psi_E=jnp.zeros((6, 4, 4, 4)),
+            psi_H=jnp.zeros((6, 4, 4, 4)),
+        ),
         alpha=jnp.zeros((3, 4, 4, 4)),
         kappa=jnp.ones((3, 4, 4, 4)),
         sigma=jnp.zeros((3, 4, 4, 4)),

--- a/tests/unit/fdtd/test_forward.py
+++ b/tests/unit/fdtd/test_forward.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
-from fdtdx.fdtd.container import ArrayContainer, ObjectContainer
+from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer
 from fdtdx.fdtd.forward import forward, forward_single_args_wrapper
 from fdtdx.interfaces.state import RecordingState
 from fdtdx.objects.detectors.detector import DetectorState
@@ -32,7 +32,7 @@ def arrays():
 @pytest.fixture
 def updated_arrays(arrays):
     """Arrays returned by update_E/update_H (E field modified to distinguish)."""
-    return arrays.aset("E", arrays.E * 3.0)
+    return arrays.aset("fields->E", arrays.fields.E * 3.0)
 
 
 @pytest.fixture
@@ -140,9 +140,9 @@ class TestForward:
             assert result[1] is updated_arrays
 
     def test_h_prev_captured_before_update_e(self, arrays, config, objects, key):
-        """H_prev is saved from original arrays.H before update_E modifies arrays."""
-        modified_H = arrays.H * 99.0
-        arrays_after_E = arrays.aset("H", modified_H)
+        """H_prev is saved from original arrays.fields.H before update_E modifies arrays."""
+        modified_H = arrays.fields.H * 99.0
+        arrays_after_E = arrays.aset("fields->H", modified_H)
 
         with (
             patch("fdtdx.fdtd.forward.update_E", return_value=arrays_after_E),
@@ -161,14 +161,14 @@ class TestForward:
 
             # H_prev should be the original H, not the modified one
             h_prev_arg = mock_det.call_args[1]["H_prev"]
-            assert jnp.array_equal(h_prev_arg, arrays.H)
+            assert jnp.array_equal(h_prev_arg, arrays.fields.H)
             assert not jnp.array_equal(h_prev_arg, modified_H)
 
     def test_record_boundaries_calls_collect_interfaces_with_stop_gradient(
         self, arrays, updated_arrays, config, objects, key
     ):
         """record_boundaries=True calls collect_interfaces wrapped in stop_gradient."""
-        collected = updated_arrays.aset("E", updated_arrays.E + 1.0)
+        collected = updated_arrays.aset("fields->E", updated_arrays.fields.E + 1.0)
 
         with (
             patch("fdtdx.fdtd.forward.update_E", return_value=updated_arrays),
@@ -260,7 +260,7 @@ class TestForward:
     def test_boundary_recording_before_detector_recording(self, arrays, updated_arrays, config, objects, key):
         """Boundary recording happens before detector recording (order matters)."""
         call_order = []
-        boundary_result = updated_arrays.aset("E", updated_arrays.E + 10.0)
+        boundary_result = updated_arrays.aset("fields->E", updated_arrays.fields.E + 10.0)
 
         def track_ci(**kwargs):
             call_order.append("collect_interfaces")
@@ -296,16 +296,16 @@ class TestForwardSingleArgsWrapper:
 
     def test_wrapper_constructs_array_container_and_calls_forward(self, arrays, config, objects, key):
         """Wrapper creates ArrayContainer from individual args and calls forward."""
-        result_arrays = arrays.aset("E", arrays.E * 5.0)
+        result_arrays = arrays.aset("fields->E", arrays.fields.E * 5.0)
         mock_state = (jnp.array(1), result_arrays)
 
         with patch("fdtdx.fdtd.forward.forward", return_value=mock_state) as mock_fwd:
             forward_single_args_wrapper(
                 time_step=jnp.array(0),
-                E=arrays.E,
-                H=arrays.H,
-                psi_E=arrays.psi_E,
-                psi_H=arrays.psi_H,
+                E=arrays.fields.E,
+                H=arrays.fields.H,
+                psi_E=arrays.fields.psi_E,
+                psi_H=arrays.fields.psi_H,
                 alpha=arrays.alpha,
                 kappa=arrays.kappa,
                 sigma=arrays.sigma,
@@ -327,8 +327,8 @@ class TestForwardSingleArgsWrapper:
             state_arg = call_kwargs["state"]
             assert jnp.array_equal(state_arg[0], jnp.array(0))
             assert isinstance(state_arg[1], ArrayContainer)
-            assert jnp.array_equal(state_arg[1].E, arrays.E)
-            assert jnp.array_equal(state_arg[1].H, arrays.H)
+            assert jnp.array_equal(state_arg[1].fields.E, arrays.fields.E)
+            assert jnp.array_equal(state_arg[1].fields.H, arrays.fields.H)
             # Verify flags are passed through
             assert call_kwargs["config"] is config
             assert call_kwargs["objects"] is objects
@@ -340,10 +340,12 @@ class TestForwardSingleArgsWrapper:
     def test_wrapper_returns_all_12_unpacked_fields(self, arrays, config, objects, key):
         """Wrapper unpacks the returned SimulationState into 12 individual values."""
         result_arrays = ArrayContainer(
-            E=arrays.E * 2.0,
-            H=arrays.H * 3.0,
-            psi_E=arrays.psi_E + 1.0,
-            psi_H=arrays.psi_H + 2.0,
+            fields=FieldState(
+                E=arrays.fields.E * 2.0,
+                H=arrays.fields.H * 3.0,
+                psi_E=arrays.fields.psi_E + 1.0,
+                psi_H=arrays.fields.psi_H + 2.0,
+            ),
             alpha=arrays.alpha + 0.1,
             kappa=arrays.kappa * 1.5,
             sigma=arrays.sigma + 0.5,
@@ -357,10 +359,10 @@ class TestForwardSingleArgsWrapper:
         with patch("fdtdx.fdtd.forward.forward", return_value=mock_state):
             result = forward_single_args_wrapper(
                 time_step=jnp.array(6),
-                E=arrays.E,
-                H=arrays.H,
-                psi_E=arrays.psi_E,
-                psi_H=arrays.psi_H,
+                E=arrays.fields.E,
+                H=arrays.fields.H,
+                psi_E=arrays.fields.psi_E,
+                psi_H=arrays.fields.psi_H,
                 alpha=arrays.alpha,
                 kappa=arrays.kappa,
                 sigma=arrays.sigma,
@@ -378,10 +380,10 @@ class TestForwardSingleArgsWrapper:
 
             assert len(result) == 12
             assert result[0] == 7  # time_step
-            assert jnp.array_equal(result[1], result_arrays.E)
-            assert jnp.array_equal(result[2], result_arrays.H)
-            assert jnp.array_equal(result[3], result_arrays.psi_E)
-            assert jnp.array_equal(result[4], result_arrays.psi_H)
+            assert jnp.array_equal(result[1], result_arrays.fields.E)
+            assert jnp.array_equal(result[2], result_arrays.fields.H)
+            assert jnp.array_equal(result[3], result_arrays.fields.psi_E)
+            assert jnp.array_equal(result[4], result_arrays.fields.psi_H)
             assert jnp.array_equal(result[5], result_arrays.alpha)
             assert jnp.array_equal(result[6], result_arrays.kappa)
             assert jnp.array_equal(result[7], result_arrays.sigma)

--- a/tests/unit/fdtd/test_stop_conditions.py
+++ b/tests/unit/fdtd/test_stop_conditions.py
@@ -5,7 +5,7 @@ import pytest
 
 from fdtdx.config import SimulationConfig
 from fdtdx.core.wavelength import WaveCharacter
-from fdtdx.fdtd.container import ArrayContainer
+from fdtdx.fdtd.container import ArrayContainer, FieldState
 from fdtdx.fdtd.stop_conditions import DetectorConvergenceCondition, EnergyThresholdCondition, TimeStepCondition
 
 # ---------------------------------------------------------------------------
@@ -21,10 +21,12 @@ def _make_arrays(time_steps_total=None, detector_states=None):
     if detector_states is None:
         detector_states = {}
     return ArrayContainer(
-        E=jnp.ones((3, 4, 4, 4)),
-        H=jnp.ones((3, 4, 4, 4)),
-        psi_E=jnp.zeros((6, 4, 4, 4)),
-        psi_H=jnp.zeros((6, 4, 4, 4)),
+        fields=FieldState(
+            E=jnp.ones((3, 4, 4, 4)),
+            H=jnp.ones((3, 4, 4, 4)),
+            psi_E=jnp.zeros((6, 4, 4, 4)),
+            psi_H=jnp.zeros((6, 4, 4, 4)),
+        ),
         alpha=jnp.zeros((3, 4, 4, 4)),
         kappa=jnp.ones((3, 4, 4, 4)),
         sigma=jnp.zeros((3, 4, 4, 4)),
@@ -126,10 +128,12 @@ class TestEnergyThresholdCondition:
         # Use an extremely high threshold so energy would normally stop the simulation,
         # but min_steps forces continuation regardless.
         zero_arrays = ArrayContainer(
-            E=jnp.zeros((3, 4, 4, 4)),
-            H=jnp.zeros((3, 4, 4, 4)),
-            psi_E=jnp.zeros((6, 4, 4, 4)),
-            psi_H=jnp.zeros((6, 4, 4, 4)),
+            fields=FieldState(
+                E=jnp.zeros((3, 4, 4, 4)),
+                H=jnp.zeros((3, 4, 4, 4)),
+                psi_E=jnp.zeros((6, 4, 4, 4)),
+                psi_H=jnp.zeros((6, 4, 4, 4)),
+            ),
             alpha=jnp.zeros((3, 4, 4, 4)),
             kappa=jnp.ones((3, 4, 4, 4)),
             sigma=jnp.zeros((3, 4, 4, 4)),
@@ -160,7 +164,7 @@ class TestEnergyThresholdCondition:
         # Craft tiny E and H so energy < threshold
         tiny = jnp.full((3, 4, 4, 4), 1e-10)
         arrays = _make_arrays()
-        arrays = arrays.aset("E", tiny).aset("H", tiny)
+        arrays = arrays.aset("fields->E", tiny).aset("fields->H", tiny)
         cond = EnergyThresholdCondition(threshold=threshold, min_steps=min_steps).setup(
             _make_state(0, arrays), config, None
         )

--- a/tests/unit/fdtd/test_update.py
+++ b/tests/unit/fdtd/test_update.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.constants import eta0
-from fdtdx.fdtd.container import ArrayContainer
+from fdtdx.fdtd.container import ArrayContainer, FieldState
 from fdtdx.fdtd.update import (
     add_interfaces,
     collect_interfaces,
@@ -40,10 +40,12 @@ def _make_arrays(
 ):
     """Build a minimal real ArrayContainer for update tests."""
     return ArrayContainer(
-        E=E if E is not None else jnp.ones(FIELD_SHAPE),
-        H=H if H is not None else jnp.zeros(FIELD_SHAPE),
-        psi_E=jnp.zeros(PSI_SHAPE),
-        psi_H=jnp.zeros(PSI_SHAPE),
+        fields=FieldState(
+            E=E if E is not None else jnp.ones(FIELD_SHAPE),
+            H=H if H is not None else jnp.zeros(FIELD_SHAPE),
+            psi_E=jnp.zeros(PSI_SHAPE),
+            psi_H=jnp.zeros(PSI_SHAPE),
+        ),
         alpha=jnp.zeros(FIELD_SHAPE),
         kappa=jnp.ones(FIELD_SHAPE),
         sigma=jnp.zeros(FIELD_SHAPE),
@@ -660,7 +662,7 @@ class TestUpdateDetectorStates:
         assert jnp.allclose(captured["H"], interp_H)
 
     def test_no_interpolation_passes_raw_fields(self):
-        """exact_interpolation=False: helper_fn receives raw arrays.E and arrays.H."""
+        """exact_interpolation=False: helper_fn receives raw arrays.fields.E and arrays.fields.H."""
         det = self._make_detector(exact_interpolation=False)
         objects = self._make_det_objects(forward_detectors=[det])
         raw_E = jnp.ones(FIELD_SHAPE) * 5.0
@@ -688,7 +690,7 @@ class TestUpdateDetectorStates:
         assert jnp.allclose(captured["H"], raw_H)
 
     def test_interpolate_fields_receives_h_avg(self):
-        """interpolate_fields receives padded (H_prev + arrays.H) / 2 as H_pad."""
+        """interpolate_fields receives padded (H_prev + arrays.fields.H) / 2 as H_pad."""
         objects = self._make_det_objects(forward_detectors=[])
         H_field = jnp.ones(FIELD_SHAPE) * 4.0
         H_prev = jnp.ones(FIELD_SHAPE) * 2.0

--- a/tests/unit/fdtd/test_update.py
+++ b/tests/unit/fdtd/test_update.py
@@ -174,7 +174,7 @@ class TestUpdateE:
         """With zero curl and no conductivity, E is unchanged."""
         E_init = jnp.ones(FIELD_SHAPE) * 3.0
         result = self._call(_make_arrays(E=E_init), curl=CURL_ZERO)
-        assert jnp.allclose(result.E, E_init)
+        assert jnp.allclose(result.fields.E, E_init)
 
     def test_isotropic_no_conductivity_formula(self):
         """E^(n+1) = E^(n) + c * curl(H) * inv_eps."""
@@ -184,7 +184,7 @@ class TestUpdateE:
         inv_eps = jnp.ones(FIELD_SHAPE)
         result = self._call(_make_arrays(E=E_init, inv_permittivities=inv_eps), config=_make_config(c=c), curl=curl)
         expected = E_init + c * curl * inv_eps  # 1.0 + 0.5 * 2.0 * 1.0 = 2.0
-        assert jnp.allclose(result.E, expected)
+        assert jnp.allclose(result.fields.E, expected)
 
     def test_isotropic_with_conductivity_formula(self):
         """Lossy material forward update (Schneider 3.12): sigma_E != 0."""
@@ -196,13 +196,13 @@ class TestUpdateE:
         result = self._call(arrays, config=_make_config(c=c), curl=CURL_ZERO)
         half = c * sigma_E * eta0 * inv_eps / 2
         expected = (1 - half) * E_init / (1 + half)
-        assert jnp.allclose(result.E, expected, rtol=1e-5)
+        assert jnp.allclose(result.fields.E, expected, rtol=1e-5)
 
     def test_psi_E_updated_from_curl_H(self):
         """psi_E in the returned container matches the psi returned by curl_H."""
         new_psi = jnp.ones(PSI_SHAPE) * 9.0
         result = self._call(_make_arrays(), psi=new_psi)
-        assert jnp.allclose(result.psi_E, new_psi)
+        assert jnp.allclose(result.fields.psi_E, new_psi)
 
     def test_simulate_boundaries_flag_forwarded(self):
         """simulate_boundaries=True is passed to curl_H."""
@@ -221,8 +221,8 @@ class TestUpdateE:
         """inv_eps.shape[0]==9 triggers the anisotropic path; output is (3,N,N,N) and finite."""
         inv_eps = _diag_anisotropic_tensor((NX, NY, NZ))
         result = self._call(_make_arrays(inv_permittivities=inv_eps))
-        assert result.E.shape == FIELD_SHAPE
-        assert jnp.all(jnp.isfinite(result.E))
+        assert result.fields.E.shape == FIELD_SHAPE
+        assert jnp.all(jnp.isfinite(result.fields.E))
 
     def test_no_sources_skips_lax_cond(self):
         """With no sources, jax.lax.cond is never invoked."""
@@ -301,7 +301,7 @@ class TestUpdateEReverse:
         """With zero curl and no conductivity, E is unchanged."""
         E_init = jnp.ones(FIELD_SHAPE) * 3.0
         result = self._call(_make_arrays(E=E_init), curl=CURL_ZERO)
-        assert jnp.allclose(result.E, E_init)
+        assert jnp.allclose(result.fields.E, E_init)
 
     def test_isotropic_no_conductivity_formula(self):
         """Reverse update: E^(n) = E^(n+1) - c * curl * inv_eps."""
@@ -311,7 +311,7 @@ class TestUpdateEReverse:
         inv_eps = jnp.ones(FIELD_SHAPE)
         result = self._call(_make_arrays(E=E_fwd, inv_permittivities=inv_eps), config=_make_config(c=c), curl=curl)
         expected = E_fwd - c * curl * inv_eps  # 2.0 - 0.5 = 1.5
-        assert jnp.allclose(result.E, expected)
+        assert jnp.allclose(result.fields.E, expected)
 
     def test_isotropic_with_conductivity_reverses_forward(self):
         """Reverse lossy update recovers the original E field (zero curl)."""
@@ -324,14 +324,14 @@ class TestUpdateEReverse:
         E_fwd = (1 - half) * E_init / (1 + half)
         arrays = _make_arrays(E=E_fwd, inv_permittivities=inv_eps, electric_conductivity=sigma_E)
         result = self._call(arrays, config=_make_config(c=c), curl=CURL_ZERO)
-        assert jnp.allclose(result.E, E_init, rtol=1e-5)
+        assert jnp.allclose(result.fields.E, E_init, rtol=1e-5)
 
     def test_anisotropic_full_tensor_correct_shape_and_finite(self):
         """inv_eps.shape[0]==9 triggers anisotropic reverse path; output is finite."""
         inv_eps = _diag_anisotropic_tensor((NX, NY, NZ))
         result = self._call(_make_arrays(inv_permittivities=inv_eps))
-        assert result.E.shape == FIELD_SHAPE
-        assert jnp.all(jnp.isfinite(result.E))
+        assert result.fields.E.shape == FIELD_SHAPE
+        assert jnp.all(jnp.isfinite(result.fields.E))
 
     def test_with_source_calls_lax_cond(self):
         """Source reverse update is invoked via jax.lax.cond with inverse=True."""
@@ -377,7 +377,7 @@ class TestUpdateH:
         """With zero curl and no conductivity, H is unchanged."""
         H_init = jnp.ones(FIELD_SHAPE) * 3.0
         result = self._call(_make_arrays(H=H_init), curl=CURL_ZERO)
-        assert jnp.allclose(result.H, H_init)
+        assert jnp.allclose(result.fields.H, H_init)
 
     def test_isotropic_no_conductivity_formula(self):
         """H^(n+1/2) = H^(n-1/2) - c * curl(E) * inv_mu."""
@@ -387,7 +387,7 @@ class TestUpdateH:
         inv_mu = jnp.ones(FIELD_SHAPE)
         result = self._call(_make_arrays(H=H_init, inv_permeabilities=inv_mu), config=_make_config(c=c), curl=curl)
         expected = H_init - c * curl * inv_mu  # 2.0 - 0.5 = 1.5
-        assert jnp.allclose(result.H, expected)
+        assert jnp.allclose(result.fields.H, expected)
 
     def test_isotropic_with_conductivity_formula(self):
         """Lossy magnetic material update (sigma_H != 0)."""
@@ -399,13 +399,13 @@ class TestUpdateH:
         result = self._call(arrays, config=_make_config(c=c), curl=CURL_ZERO)
         half = c * sigma_H / eta0 * inv_mu / 2
         expected = (1 - half) * H_init / (1 + half)
-        assert jnp.allclose(result.H, expected, rtol=1e-5)
+        assert jnp.allclose(result.fields.H, expected, rtol=1e-5)
 
     def test_psi_H_updated_from_curl_E(self):
         """psi_H in the returned container matches the psi returned by curl_E."""
         new_psi = jnp.ones(PSI_SHAPE) * 7.0
         result = self._call(_make_arrays(), psi=new_psi)
-        assert jnp.allclose(result.psi_H, new_psi)
+        assert jnp.allclose(result.fields.psi_H, new_psi)
 
     def test_simulate_boundaries_flag_forwarded(self):
         """simulate_boundaries=True is passed as 7th positional arg to curl_E."""
@@ -423,8 +423,8 @@ class TestUpdateH:
         """inv_mu.shape[0]==9 triggers the anisotropic path; output is (3,N,N,N) and finite."""
         inv_mu = _diag_anisotropic_tensor((NX, NY, NZ))
         result = self._call(_make_arrays(inv_permeabilities=inv_mu))
-        assert result.H.shape == FIELD_SHAPE
-        assert jnp.all(jnp.isfinite(result.H))
+        assert result.fields.H.shape == FIELD_SHAPE
+        assert jnp.all(jnp.isfinite(result.fields.H))
 
     def test_no_sources_skips_lax_cond(self):
         """With no sources, jax.lax.cond is never invoked."""
@@ -503,7 +503,7 @@ class TestUpdateHReverse:
         """With zero curl and no conductivity, H is unchanged."""
         H_init = jnp.ones(FIELD_SHAPE) * 3.0
         result = self._call(_make_arrays(H=H_init), curl=CURL_ZERO)
-        assert jnp.allclose(result.H, H_init)
+        assert jnp.allclose(result.fields.H, H_init)
 
     def test_isotropic_no_conductivity_formula(self):
         """Reverse update without conductivity: H^(n-1/2) = H^(n+1/2) + c * curl * inv_mu."""
@@ -513,7 +513,7 @@ class TestUpdateHReverse:
         inv_mu = jnp.ones(FIELD_SHAPE)
         result = self._call(_make_arrays(H=H_fwd, inv_permeabilities=inv_mu), config=_make_config(c=c), curl=curl)
         expected = H_fwd + c * curl * inv_mu  # 1.5 + 0.5 = 2.0
-        assert jnp.allclose(result.H, expected)
+        assert jnp.allclose(result.fields.H, expected)
 
     def test_isotropic_with_conductivity_reverses_forward(self):
         """Reverse lossy update recovers the original H field (zero curl)."""
@@ -525,14 +525,14 @@ class TestUpdateHReverse:
         H_fwd = (1 - half) * H_init / (1 + half)
         arrays = _make_arrays(H=H_fwd, inv_permeabilities=inv_mu, magnetic_conductivity=sigma_H)
         result = self._call(arrays, config=_make_config(c=c), curl=CURL_ZERO)
-        assert jnp.allclose(result.H, H_init, rtol=1e-5)
+        assert jnp.allclose(result.fields.H, H_init, rtol=1e-5)
 
     def test_anisotropic_full_tensor_correct_shape_and_finite(self):
         """inv_mu.shape[0]==9 triggers anisotropic reverse path; output is finite."""
         inv_mu = _diag_anisotropic_tensor((NX, NY, NZ))
         result = self._call(_make_arrays(inv_permeabilities=inv_mu))
-        assert result.H.shape == FIELD_SHAPE
-        assert jnp.all(jnp.isfinite(result.H))
+        assert result.fields.H.shape == FIELD_SHAPE
+        assert jnp.all(jnp.isfinite(result.fields.H))
 
     def test_with_source_calls_lax_cond(self):
         """Source reverse update is invoked via jax.lax.cond with inverse=True."""


### PR DESCRIPTION
reset_array_container was a standalone function that manually zeroed E and H but silently omitted the PML auxiliary fields psi_E and psi_H, which were added later without updating the reset logic. This was the root cause of issue https://github.com/ymahlau/fdtdx/issues/260.

The fix introduces FieldState, a dedicated struct holding all dynamic fields that evolve each time step: E, H, psi_E, and psi_H. ArrayContainer now holds a single fields: FieldState instead of four flat fields, and a reset() method on ArrayContainer zeros the entire struct via jax.tree.map(jnp.zeros_like, self.fields). Adding a new dynamic field in the future — such as dispersion auxiliary fields — only requires adding it to FieldState.
The reset is then automatically correct with no code changes needed elsewhere, making this class of bug impossible to reintroduce.

The standalone reset_array_container function is removed; its three call sites in fdtd.py are replaced with arrays.reset().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `FieldState` is now publicly exported.
  * `ArrayContainer.reset()` added to reset field and detector/recording state.

* **Refactor**
  * Electromagnetic field data are now stored in a nested field container, with calling patterns and tests updated accordingly for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->