### PR TITLE
Provide progress callback for simulations

### DIFF
--- a/src/fdtdx/core/progress.py
+++ b/src/fdtdx/core/progress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Callable
 
 import jax
 import jax.experimental
@@ -70,6 +71,8 @@ class SimulationProgressBar:
         desc: str = "FDTD",
         update_interval: int = 1,
         step_offset: int = 0,
+        show_tqdm: bool = True,
+        progress_callback: Callable[[int, int], None] | None = None,
     ):
         self.total_steps = total_steps
         self.desc = desc
@@ -78,6 +81,8 @@ class SimulationProgressBar:
         # For full simulations this is 0; for partial runs (custom_fdtd_forward)
         # it equals start_time so that bar.n stays in [0, total_steps].
         self.step_offset = step_offset
+        self.show_tqdm = show_tqdm
+        self.progress_callback = progress_callback
         self._bar = None
 
     # Host-side callbacks
@@ -96,18 +101,22 @@ class SimulationProgressBar:
         ``step_offset`` is subtracted so the bar position stays relative to
         the start of this particular simulation segment.
         """
-        if self._bar is None:
-            # Lazy import: only reached at XLA execution time.
-            from tqdm.auto import tqdm
+        relative_step = int(time_step) - self.step_offset
+        if self.show_tqdm:
+            if self._bar is None:
+                # Lazy import: only reached at XLA execution time.
+                from tqdm.auto import tqdm
 
-            self._bar = tqdm(
-                total=self.total_steps,
-                desc=self.desc,
-                unit="step",
-                dynamic_ncols=True,
-            )
-        self._bar.n = int(time_step) - self.step_offset
-        self._bar.refresh()
+                self._bar = tqdm(
+                    total=self.total_steps,
+                    desc=self.desc,
+                    unit="step",
+                    dynamic_ncols=True,
+                )
+            self._bar.n = relative_step
+            self._bar.refresh()
+        if self.progress_callback is not None:
+            self.progress_callback(relative_step, self.total_steps)
 
     def _host_close(self) -> None:
         """Force the bar to 100 % and close it.
@@ -117,11 +126,13 @@ class SimulationProgressBar:
         completion regardless of whether the last step landed on an
         update-interval boundary.
         """
-        if self._bar is not None:
+        if self.show_tqdm and self._bar is not None:
             self._bar.n = self.total_steps
             self._bar.refresh()
             self._bar.close()
             self._bar = None
+        if self.progress_callback is not None:
+            self.progress_callback(self.total_steps, self.total_steps)
 
     # JAX-side callback factory
 
@@ -182,6 +193,7 @@ def _make_pbar(
     total_steps: int,
     desc: str,
     step_offset: int = 0,
+    progress_callback: Callable[[int, int], None] | None = None,
 ) -> SimulationProgressBar | None:
     """Return a :class:`SimulationProgressBar` or ``None``.
 
@@ -189,30 +201,36 @@ def _make_pbar(
     Returning ``None`` causes :func:`_wrap_body_with_progress` to leave the
     body function completely unmodified — zero JAX overhead.
 
-    ``None`` is returned when any of the following apply:
+    ``None`` is returned when all of the following apply:
 
     * ``show_progress`` is ``False``
+    * ``progress_callback`` is ``None``
     * ``total_steps`` is zero or negative (nothing to show)
-    * tqdm is not installed (checked here via a cheap import probe so the
-      simulation functions never import tqdm themselves)
 
-    The tqdm probe only attempts ``import tqdm`` — it does **not** import
-    ``tqdm.auto`` or instantiate anything, so its cost is a single
-    ``sys.modules`` lookup on repeated calls.
+    When ``show_progress`` is ``True``, tqdm availability is probed. If tqdm
+    is missing a warning is issued and the tqdm bar is skipped, but a
+    ``progress_callback`` (if provided) still fires normally.
     """
-    if not show_progress or total_steps <= 0:
+    if total_steps <= 0:
+        return None
+    if not show_progress and progress_callback is None:
         return None
 
-    try:
-        import tqdm  # noqa: F401 — availability probe only
-    except ImportError:
-        import warnings
+    show_tqdm = show_progress
+    if show_tqdm:
+        try:
+            import tqdm  # noqa: F401 — availability probe only
+        except ImportError:
+            import warnings
 
-        warnings.warn(
-            "tqdm is not installed — progress bar disabled. Install it with: pip install tqdm",
-            ImportWarning,
-            stacklevel=3,
-        )
+            warnings.warn(
+                "tqdm is not installed — progress bar disabled. Install it with: pip install tqdm",
+                ImportWarning,
+                stacklevel=3,
+            )
+            show_tqdm = False
+
+    if not show_tqdm and progress_callback is None:
         return None
 
     return SimulationProgressBar(
@@ -220,6 +238,8 @@ def _make_pbar(
         desc=desc,
         update_interval=_auto_update_interval(total_steps),
         step_offset=step_offset,
+        show_tqdm=show_tqdm,
+        progress_callback=progress_callback,
     )
 
 

--- a/src/fdtdx/fdtd/fdtd.py
+++ b/src/fdtdx/fdtd/fdtd.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import partial
 
 import equinox.internal as eqxi
@@ -22,6 +23,7 @@ def reversible_fdtd(
     config: SimulationConfig,
     key: jax.Array,
     show_progress: bool = True,
+    progress_callback: Callable[[int, int], None] | None = None,
 ) -> SimulationState:
     """Run a memory-efficient differentiable FDTD simulation leveraging time-reversal symmetry.
 
@@ -71,6 +73,7 @@ def reversible_fdtd(
         show_progress=show_progress,
         total_steps=config.time_steps_total,
         desc="FDTD (reversible)",
+        progress_callback=progress_callback,
     )
 
     # Build the (optionally instrumented) forward body function once so both
@@ -350,6 +353,7 @@ def checkpointed_fdtd(
     key: jax.Array,
     stopping_condition: StoppingCondition | None = None,
     show_progress: bool = True,
+    progress_callback: Callable[[int, int], None] | None = None,
 ) -> SimulationState:
     """Run an FDTD simulation with gradient checkpointing for memory efficiency.
 
@@ -389,6 +393,7 @@ def checkpointed_fdtd(
         show_progress=show_progress,
         total_steps=config.time_steps_total,
         desc="FDTD (checkpointed)",
+        progress_callback=progress_callback,
     )
 
     _forward_body = partial(
@@ -429,6 +434,7 @@ def custom_fdtd_forward(
     start_time: int | jax.Array,
     end_time: int | jax.Array,
     show_progress: bool = True,
+    progress_callback: Callable[[int, int], None] | None = None,
 ) -> SimulationState:
     """Run a customizable forward FDTD simulation between specified time steps.
 
@@ -469,6 +475,7 @@ def custom_fdtd_forward(
     if isinstance(start_time, jax.Array) or isinstance(end_time, jax.Array):
         # Traced arrays: skip the progress bar entirely to avoid concretization.
         show_progress = False
+        progress_callback = None
         n_steps = 0
     else:
         n_steps = int(end_time) - int(start_time)
@@ -477,7 +484,8 @@ def custom_fdtd_forward(
         show_progress=show_progress,
         total_steps=n_steps,
         desc="FDTD (forward)",
-        step_offset=0 if not show_progress else int(start_time),
+        step_offset=0 if not show_progress and progress_callback is None else int(start_time),
+        progress_callback=progress_callback,
     )
 
     _forward_body = partial(

--- a/src/fdtdx/fdtd/wrapper.py
+++ b/src/fdtdx/fdtd/wrapper.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import jax
 
 from fdtdx.config import SimulationConfig
@@ -15,6 +17,7 @@ def run_fdtd(
     key: jax.Array,
     stopping_condition: StoppingCondition | None = None,
     show_progress: bool = True,
+    progress_callback: Callable[[int, int], None] | None = None,
 ) -> SimulationState:
     if stopping_condition is not None:
         if config.gradient_config is not None:
@@ -33,6 +36,7 @@ def run_fdtd(
             key=key,
             stopping_condition=stopping_condition,
             show_progress=show_progress,
+            progress_callback=progress_callback,
         )
     if config.gradient_config.method == "reversible":
         return reversible_fdtd(
@@ -41,6 +45,7 @@ def run_fdtd(
             config=config,
             key=key,
             show_progress=show_progress,
+            progress_callback=progress_callback,
         )
     elif config.gradient_config.method == "checkpointed":
         return checkpointed_fdtd(
@@ -50,6 +55,7 @@ def run_fdtd(
             key=key,
             stopping_condition=stopping_condition,
             show_progress=show_progress,
+            progress_callback=progress_callback,
         )
     else:
         raise Exception(f"Unknown gradient computation method: {config.gradient_config.method}")

--- a/src/fdtdx/utils/sparams.py
+++ b/src/fdtdx/utils/sparams.py
@@ -294,7 +294,7 @@ def calculate_sparam(
         min_steps=round(config.time_steps_total / 5),
     )
 
-    jitted_fdtd = jax.jit(run_fdtd, static_argnames=["show_progress"])
+    jitted_fdtd = jax.jit(run_fdtd, static_argnames=["show_progress", "progress_callback"])
     _, final_arrays = jitted_fdtd(
         arrays=arrays,
         objects=objects,

--- a/tests/unit/fdtd/test_wrapper.py
+++ b/tests/unit/fdtd/test_wrapper.py
@@ -191,7 +191,10 @@ class TestRunFdtd:
         """progress_callback is passed through to checkpointed_fdtd (no gradient_config)."""
         arrays, objects, config, key = setup
         config.gradient_config = None
-        cb = lambda s, t: None
+
+        def cb(s, t):
+            return None
+
         mock_result = Mock(spec=SimulationState)
 
         with patch("fdtdx.fdtd.wrapper.checkpointed_fdtd", return_value=mock_result) as mock_ckpt:
@@ -204,7 +207,10 @@ class TestRunFdtd:
         arrays, objects, config, key = setup
         config.gradient_config = Mock()
         config.gradient_config.method = "reversible"
-        cb = lambda s, t: None
+
+        def cb(s, t):
+            return None
+
         mock_result = Mock(spec=SimulationState)
 
         with patch("fdtdx.fdtd.wrapper.reversible_fdtd", return_value=mock_result) as mock_rev:
@@ -217,7 +223,10 @@ class TestRunFdtd:
         arrays, objects, config, key = setup
         config.gradient_config = Mock()
         config.gradient_config.method = "checkpointed"
-        cb = lambda s, t: None
+
+        def cb(s, t):
+            return None
+
         mock_result = Mock(spec=SimulationState)
 
         with patch("fdtdx.fdtd.wrapper.checkpointed_fdtd", return_value=mock_result) as mock_ckpt:

--- a/tests/unit/fdtd/test_wrapper.py
+++ b/tests/unit/fdtd/test_wrapper.py
@@ -38,6 +38,7 @@ class TestRunFdtd:
             key=key,
             stopping_condition=None,
             show_progress=True,
+            progress_callback=None,
         )
         assert result is mock_result
 
@@ -57,6 +58,7 @@ class TestRunFdtd:
             config=config,
             key=key,
             show_progress=True,
+            progress_callback=None,
         )
         assert result is mock_result
 
@@ -77,6 +79,7 @@ class TestRunFdtd:
             key=key,
             stopping_condition=None,
             show_progress=True,
+            progress_callback=None,
         )
         assert result is mock_result
 
@@ -179,3 +182,56 @@ class TestRunFdtd:
             run_fdtd(arrays, objects, config, key)
 
         assert mock_ckpt.call_args[1]["show_progress"] is True
+
+    # ------------------------------------------------------------------ #
+    # progress_callback propagation                                         #
+    # ------------------------------------------------------------------ #
+
+    def test_progress_callback_forwarded_to_checkpointed_no_gradient(self, setup):
+        """progress_callback is passed through to checkpointed_fdtd (no gradient_config)."""
+        arrays, objects, config, key = setup
+        config.gradient_config = None
+        cb = lambda s, t: None
+        mock_result = Mock(spec=SimulationState)
+
+        with patch("fdtdx.fdtd.wrapper.checkpointed_fdtd", return_value=mock_result) as mock_ckpt:
+            run_fdtd(arrays, objects, config, key, progress_callback=cb)
+
+        assert mock_ckpt.call_args[1]["progress_callback"] is cb
+
+    def test_progress_callback_forwarded_to_reversible(self, setup):
+        """progress_callback is passed through to reversible_fdtd."""
+        arrays, objects, config, key = setup
+        config.gradient_config = Mock()
+        config.gradient_config.method = "reversible"
+        cb = lambda s, t: None
+        mock_result = Mock(spec=SimulationState)
+
+        with patch("fdtdx.fdtd.wrapper.reversible_fdtd", return_value=mock_result) as mock_rev:
+            run_fdtd(arrays, objects, config, key, progress_callback=cb)
+
+        assert mock_rev.call_args[1]["progress_callback"] is cb
+
+    def test_progress_callback_forwarded_to_checkpointed_gradient(self, setup):
+        """progress_callback is passed through to checkpointed_fdtd (checkpointed gradient)."""
+        arrays, objects, config, key = setup
+        config.gradient_config = Mock()
+        config.gradient_config.method = "checkpointed"
+        cb = lambda s, t: None
+        mock_result = Mock(spec=SimulationState)
+
+        with patch("fdtdx.fdtd.wrapper.checkpointed_fdtd", return_value=mock_result) as mock_ckpt:
+            run_fdtd(arrays, objects, config, key, progress_callback=cb)
+
+        assert mock_ckpt.call_args[1]["progress_callback"] is cb
+
+    def test_progress_callback_defaults_to_none(self, setup):
+        """progress_callback defaults to None when not supplied."""
+        arrays, objects, config, key = setup
+        config.gradient_config = None
+        mock_result = Mock(spec=SimulationState)
+
+        with patch("fdtdx.fdtd.wrapper.checkpointed_fdtd", return_value=mock_result) as mock_ckpt:
+            run_fdtd(arrays, objects, config, key)
+
+        assert mock_ckpt.call_args[1]["progress_callback"] is None


### PR DESCRIPTION
This PR adds a progress callback hook to FDTD execution so callers can observe simulation progress without depending directly on the built-in terminal progress bar.

This is useful for integrations where tqdm output is not the right interface, for example:

- notebooks or GUI applications that need to update their own progress display
- web/API jobs that need to report progress to a frontend or job queue
- tests or scripts that want deterministic progress events without parsing terminal output
- downstream libraries that wrap run_fdtd and need progress visibility without taking over stdout/stderr

The callback keeps progress reporting decoupled from presentation. The existing progress bar can remain the default user-facing behavior, while advanced callers can plug in their own reporting mechanism.

The default behaviour remains the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional progress callback parameter to simulations. Users can supply a custom callback function to receive real-time progress updates (step index and total steps) during simulation runs.
  * Independent control over progress bar visibility, enabling flexible progress reporting without requiring UI-based indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->