### PR TITLE
Add bent waveguide mode support via Tidy3D mode solver args

### DIFF
--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -154,10 +154,11 @@ def compute_mode(
 
     def mode_helper(permittivity, permeability):
         if bend_radius is not None:
+            assert bend_axis is not None
             transverse_axes = [ax for ax in range(3) if ax != propagation_axis]
             tidy3d_bend_axis = transverse_axes.index(bend_axis)
             bend_radius_um = bend_radius / 1e-6
-            plane_center = tuple(float(0.5 * (coord[0] + coord[-1])) for coord in coords)
+            plane_center = (float(0.5 * (coords[0][0] + coords[0][-1])), float(0.5 * (coords[1][0] + coords[1][-1])))
         else:
             tidy3d_bend_axis = None
             bend_radius_um = None

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -98,6 +98,8 @@ def compute_mode(
     mode_index: int = 0,
     filter_pol: Literal["te", "tm"] | None = None,
     dtype: jnp.dtype = jnp.float32,
+    bend_radius: float | None = None,
+    bend_axis: int | None = None,
 ) -> tuple[
     jax.Array,  # E
     jax.Array,  # H
@@ -123,6 +125,11 @@ def compute_mode(
         filter_pol (Literal["te", "tm"] | None, optional). If not None, modes are filtered by polarization.
         dtype (jnp.dtype, optional): Float dtype of the simulation. Controls whether mode fields are returned
             as complex64 (float32) or complex128 (float64). Defaults to jnp.float32.
+        bend_radius (float | None, optional): Bend radius of the waveguide in meters. Must be set together with
+            bend_axis. When set, the mode solver uses a conformal transformation to account for the bend. Defaults to
+            None (straight waveguide).
+        bend_axis (int | None, optional): Physical axis index (0/1/2) pointing from the waveguide toward the center
+            of curvature. Must differ from the propagation axis. Required when bend_radius is set. Defaults to None.
 
     Returns:
         Tuple[jax.Array, jax.Array, jax.Array]:
@@ -140,10 +147,21 @@ def compute_mode(
             or sum(dim == 1 for dim in inv_permeabilities.shape[1:]) != 1
         ):
             raise Exception(f"Invalid shape of inv_permeabilities: {inv_permeabilities.shape}")
+    if (bend_radius is None) != (bend_axis is None):
+        raise ValueError("bend_radius and bend_axis must both be set or both be None")
 
     np_complex_dtype = np.complex128 if dtype == jnp.float64 else np.complex64
 
     def mode_helper(permittivity, permeability):
+        if bend_radius is not None:
+            transverse_axes = [ax for ax in range(3) if ax != propagation_axis]
+            tidy3d_bend_axis = transverse_axes.index(bend_axis)
+            bend_radius_um = bend_radius / 1e-6
+            plane_center = tuple(float(0.5 * (coord[0] + coord[-1])) for coord in coords)
+        else:
+            tidy3d_bend_axis = None
+            bend_radius_um = None
+            plane_center = None
         modes = tidy3d_mode_computation_wrapper(
             frequency=frequency,
             permittivity_cross_section=permittivity,
@@ -151,6 +169,9 @@ def compute_mode(
             coords=coords,
             direction=direction,
             num_modes=2 * (mode_index + 1) + 10,
+            bend_radius=bend_radius_um,
+            bend_axis=tidy3d_bend_axis,
+            plane_center=plane_center,
         )
 
         # sort modes by polarization
@@ -283,6 +304,9 @@ def tidy3d_mode_computation_wrapper(
     angle_phi: float = 0.0,
     num_modes: int = 10,
     precision: Literal["single", "double"] = "double",
+    bend_radius: float | None = None,
+    bend_axis: int | None = None,
+    plane_center: tuple[float, float] | None = None,
 ) -> List[ModeTupleType]:
     """Compute optical modes of a waveguide cross-section.
 
@@ -301,6 +325,11 @@ def tidy3d_mode_computation_wrapper(
         angle_phi (float, optional): Azimuthal angle in radians. Defaults to 0.0.
         num_modes (int, optional): Number of modes to compute. Defaults to 10.
         precision (Literal["single", "double"], optional): Numerical precision. Defaults to "double".
+        bend_radius (float | None, optional): Bend radius in microns (tidy3d units). Defaults to None.
+        bend_axis (int | None, optional): Axis index (0 or 1) of the center of curvature in tidy3d's transverse
+            coordinate frame. Defaults to None.
+        plane_center (tuple[float, float] | None, optional): Center of the mode plane in the same units as coords.
+            Required by tidy3d when bend_radius is set. Defaults to None.
 
     Notes:
         tidy3d assumes propagation in z-direction. The output fields should be handled accordingly.
@@ -317,8 +346,8 @@ def tidy3d_mode_computation_wrapper(
         num_pml=(0, 0),
         angle_theta=angle_theta,
         angle_phi=angle_phi,
-        bend_radius=None,
-        bend_axis=None,
+        bend_radius=bend_radius,
+        bend_axis=bend_axis,
         precision=precision,
         track_freq="central",
         group_index_step=False,
@@ -363,6 +392,7 @@ def tidy3d_mode_computation_wrapper(
         mode_spec=mode_spec,
         direction=direction,
         mu_cross=mu_cross,
+        plane_center=plane_center,
     )
     ((Ex, Ey, Ez), (Hx, Hy, Hz)) = EH.squeeze()
 

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -39,6 +39,15 @@ class ModeOverlapDetector(PhasorDetector):
     #: When specified, only modes of the given polarization type are considered. Defaults to None.
     filter_pol: Literal["te", "tm"] | None = frozen_field(default=None)
 
+    #: Bend radius of the waveguide in meters. When set, the mode solver accounts for the conformal
+    #: transformation introduced by the bend. Must be set together with bend_axis. Defaults to None
+    #: (straight waveguide).
+    bend_radius: float | None = frozen_field(default=None)
+
+    #: Physical axis index (0=x, 1=y, 2=z) pointing from the waveguide center toward the center of
+    #: curvature. Must differ from the propagation axis. Required when bend_radius is set.
+    bend_axis: int | None = frozen_field(default=None)
+
     #: Cannot be specified here since the detector needs all components.
     components: Sequence[Literal["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]] = frozen_field(
         default=("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"),
@@ -70,6 +79,12 @@ class ModeOverlapDetector(PhasorDetector):
         )
         if len(self.wave_characters) > 1:
             raise NotImplementedError()
+        if (self.bend_radius is None) != (self.bend_axis is None):
+            raise ValueError("bend_radius and bend_axis must both be set or both be None")
+        if self.bend_axis is not None and self.bend_axis == self.propagation_axis:
+            raise ValueError(
+                f"bend_axis ({self.bend_axis}) must differ from the propagation axis ({self.propagation_axis})"
+            )
         return self
 
     def apply(
@@ -95,6 +110,8 @@ class ModeOverlapDetector(PhasorDetector):
             mode_index=self.mode_index,
             filter_pol=self.filter_pol,
             dtype=self._config.dtype,
+            bend_radius=self.bend_radius,
+            bend_axis=self.bend_axis,
         )
 
         self = self.aset("_mode_E", mode_E, create_new_ok=True)

--- a/tests/unit/core/physics/test_modes.py
+++ b/tests/unit/core/physics/test_modes.py
@@ -138,6 +138,18 @@ class TestSortModes:
 class TestComputeMode:
     """Test the compute_mode function."""
 
+    def test_only_bend_radius_raises(self):
+        """Setting bend_radius without bend_axis raises ValueError."""
+        inv_permittivities = jnp.ones((1, 5, 6, 1))
+        with pytest.raises(ValueError, match="both be set or both be None"):
+            compute_mode(2e14, inv_permittivities, 1.0, 1e-8, "+", bend_radius=5e-6)
+
+    def test_only_bend_axis_raises(self):
+        """Setting bend_axis without bend_radius raises ValueError."""
+        inv_permittivities = jnp.ones((1, 5, 6, 1))
+        with pytest.raises(ValueError, match="both be set or both be None"):
+            compute_mode(2e14, inv_permittivities, 1.0, 1e-8, "+", bend_axis=1)
+
     def test_invalid_permittivities_shape(self):
         """Test that invalid permittivities shape raises exception."""
         frequency = 2e14
@@ -612,3 +624,102 @@ class TestTidy3DModeComputationWrapper:
 
         assert len(modes) == 1
         assert modes[0].neff == 1.6 + 0.2j
+
+
+class TestComputeModeBendPassthrough:
+    """Tests that bend args are correctly converted and passed to tidy3d_mode_computation_wrapper."""
+
+    def _make_mock_mode(self, shape=(5, 6)):
+        return ModeTupleType(
+            neff=1.5 + 0.1j,
+            Ex=np.ones(shape, dtype=np.complex64),
+            Ey=np.ones(shape, dtype=np.complex64),
+            Ez=np.ones(shape, dtype=np.complex64),
+            Hx=np.ones(shape, dtype=np.complex64),
+            Hy=np.ones(shape, dtype=np.complex64),
+            Hz=np.ones(shape, dtype=np.complex64),
+        )
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_no_bend_passes_none_to_wrapper(self, mock_normalize, mock_wrapper):
+        """Without bend args, None is passed for bend_radius, bend_axis, and plane_center."""
+        mock_wrapper.return_value = [self._make_mock_mode()]
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+
+        compute_mode(2e14, jnp.ones((1, 5, 6, 1)), 1.0, 1e-8, "+")
+
+        kwargs = mock_wrapper.call_args.kwargs
+        assert kwargs["bend_radius"] is None
+        assert kwargs["bend_axis"] is None
+        assert kwargs["plane_center"] is None
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_bend_radius_converted_meters_to_micrometers(self, mock_normalize, mock_wrapper):
+        """bend_radius is divided by 1e-6 before being passed to tidy3d (m → µm)."""
+        mock_wrapper.return_value = [self._make_mock_mode()]
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+
+        compute_mode(2e14, jnp.ones((1, 5, 6, 1)), 1.0, 1e-8, "+", bend_radius=5e-6, bend_axis=0)
+
+        kwargs = mock_wrapper.call_args.kwargs
+        assert kwargs["bend_radius"] == pytest.approx(5.0)  # 5e-6 m = 5.0 µm
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_bend_axis_remapped_z_propagation(self, mock_normalize, mock_wrapper):
+        """For z-propagation, transverse axes are [0,1]: physical bend_axis=1 → tidy3d index 1."""
+        mock_wrapper.return_value = [self._make_mock_mode()]
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+
+        # z-propagation: inv_permittivities shape (1, 5, 6, 1), singleton at dim 3
+        compute_mode(2e14, jnp.ones((1, 5, 6, 1)), 1.0, 1e-8, "+", bend_radius=10e-6, bend_axis=1)
+
+        kwargs = mock_wrapper.call_args.kwargs
+        assert kwargs["bend_axis"] == 1  # transverse_axes=[0,1], index(1)=1
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_bend_axis_remapped_x_propagation(self, mock_normalize, mock_wrapper):
+        """For x-propagation, transverse axes are [1,2]: physical bend_axis=2 → tidy3d index 1."""
+        mock_wrapper.return_value = [self._make_mock_mode()]
+        mock_normalize.return_value = (
+            jnp.ones((3, 1, 5, 6), dtype=jnp.complex64),
+            jnp.ones((3, 1, 5, 6), dtype=jnp.complex64),
+        )
+
+        # x-propagation: inv_permittivities shape (1, 1, 5, 6), singleton at dim 1
+        compute_mode(2e14, jnp.ones((1, 1, 5, 6)), 1.0, 1e-8, "+", bend_radius=10e-6, bend_axis=2)
+
+        kwargs = mock_wrapper.call_args.kwargs
+        assert kwargs["bend_axis"] == 1  # transverse_axes=[1,2], index(2)=1
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_plane_center_is_midpoint_of_transverse_coords(self, mock_normalize, mock_wrapper):
+        """plane_center is computed as the midpoint of each transverse coordinate array."""
+        mock_wrapper.return_value = [self._make_mock_mode()]
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+
+        resolution = 1e-8
+        # z-propagation with transverse dims 5 (x) and 6 (y)
+        # coords[0] = np.arange(6) * resolution/1e-6, so last = 5 * resolution/1e-6
+        # coords[1] = np.arange(7) * resolution/1e-6, so last = 6 * resolution/1e-6
+        compute_mode(2e14, jnp.ones((1, 5, 6, 1)), 1.0, resolution, "+", bend_radius=5e-6, bend_axis=0)
+
+        kwargs = mock_wrapper.call_args.kwargs
+        expected = (0.5 * 5 * resolution / 1e-6, 0.5 * 6 * resolution / 1e-6)
+        assert kwargs["plane_center"] == pytest.approx(expected)

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -393,26 +393,20 @@ class TestModeOverlapDetectorBentWaveguide:
         self, single_frequency, simulation_config, plane_grid_slice, random_key
     ):
         """bend_axis matching the propagation axis (z=2 for plane_grid_slice) raises ValueError."""
-        det = ModeOverlapDetector(
-            wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=2
-        )
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=2)
         with pytest.raises(ValueError, match="must differ from the propagation axis"):
             det.place_on_grid(plane_grid_slice, simulation_config, random_key)
 
     def test_valid_bend_params_x_axis(self, single_frequency, simulation_config, plane_grid_slice, random_key):
         """Valid bend_radius + bend_axis=0 (x-axis, transverse to z-propagation) succeeds."""
-        det = ModeOverlapDetector(
-            wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=0
-        )
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=0)
         placed = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         assert placed.bend_radius == 5e-6
         assert placed.bend_axis == 0
 
     def test_valid_bend_params_y_axis(self, single_frequency, simulation_config, plane_grid_slice, random_key):
         """Valid bend_radius + bend_axis=1 (y-axis, transverse to z-propagation) succeeds."""
-        det = ModeOverlapDetector(
-            wave_characters=single_frequency, direction="+", bend_radius=10e-6, bend_axis=1
-        )
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+", bend_radius=10e-6, bend_axis=1)
         placed = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         assert placed.bend_radius == 10e-6
         assert placed.bend_axis == 1
@@ -420,9 +414,7 @@ class TestModeOverlapDetectorBentWaveguide:
     def test_valid_bend_params_x_propagation(self, single_frequency, simulation_config, random_key):
         """Valid bend setup for x-propagating waveguide: bend_axis must be 1 or 2."""
         x_plane = ((0, 1), (0, 8), (0, 8))
-        det = ModeOverlapDetector(
-            wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=2
-        )
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=2)
         placed = det.place_on_grid(x_plane, simulation_config, random_key)
         assert placed.propagation_axis == 0
         assert placed.bend_axis == 2
@@ -430,8 +422,6 @@ class TestModeOverlapDetectorBentWaveguide:
     def test_bend_axis_same_as_x_propagation_raises(self, single_frequency, simulation_config, random_key):
         """bend_axis=0 for x-propagating waveguide (propagation_axis=0) raises ValueError."""
         x_plane = ((0, 1), (0, 8), (0, 8))
-        det = ModeOverlapDetector(
-            wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=0
-        )
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=0)
         with pytest.raises(ValueError, match="must differ from the propagation axis"):
             det.place_on_grid(x_plane, simulation_config, random_key)

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -67,6 +67,26 @@ class TestModeOverlapDetectorDefaults:
         det = ModeOverlapDetector(wave_characters=single_frequency, direction="+", filter_pol="tm")
         assert det.filter_pol == "tm"
 
+    def test_bend_radius_default_none(self, single_frequency):
+        """bend_radius defaults to None (straight waveguide)."""
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
+        assert det.bend_radius is None
+
+    def test_bend_axis_default_none(self, single_frequency):
+        """bend_axis defaults to None (straight waveguide)."""
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
+        assert det.bend_axis is None
+
+    def test_bend_radius_stored(self, single_frequency):
+        """Custom bend_radius value is stored."""
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=0)
+        assert det.bend_radius == 5e-6
+
+    def test_bend_axis_stored(self, single_frequency):
+        """Custom bend_axis value is stored."""
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=0)
+        assert det.bend_axis == 0
+
 
 class TestModeOverlapDetectorPropagationAxis:
     """Tests for the propagation_axis property."""
@@ -352,3 +372,66 @@ class TestModeOverlapDetectorComputeOverlapPath:
 
         assert jnp.iscomplexobj(result_stored)
         assert jnp.isclose(result_stored, result_explicit)
+
+
+class TestModeOverlapDetectorBentWaveguide:
+    """Tests for bent waveguide mode parameters (bend_radius / bend_axis)."""
+
+    def test_only_bend_radius_raises(self, single_frequency, simulation_config, plane_grid_slice, random_key):
+        """Setting bend_radius without bend_axis raises ValueError."""
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+", bend_radius=5e-6)
+        with pytest.raises(ValueError, match="both be set or both be None"):
+            det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+
+    def test_only_bend_axis_raises(self, single_frequency, simulation_config, plane_grid_slice, random_key):
+        """Setting bend_axis without bend_radius raises ValueError."""
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+", bend_axis=0)
+        with pytest.raises(ValueError, match="both be set or both be None"):
+            det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+
+    def test_bend_axis_equals_propagation_axis_raises(
+        self, single_frequency, simulation_config, plane_grid_slice, random_key
+    ):
+        """bend_axis matching the propagation axis (z=2 for plane_grid_slice) raises ValueError."""
+        det = ModeOverlapDetector(
+            wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=2
+        )
+        with pytest.raises(ValueError, match="must differ from the propagation axis"):
+            det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+
+    def test_valid_bend_params_x_axis(self, single_frequency, simulation_config, plane_grid_slice, random_key):
+        """Valid bend_radius + bend_axis=0 (x-axis, transverse to z-propagation) succeeds."""
+        det = ModeOverlapDetector(
+            wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=0
+        )
+        placed = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        assert placed.bend_radius == 5e-6
+        assert placed.bend_axis == 0
+
+    def test_valid_bend_params_y_axis(self, single_frequency, simulation_config, plane_grid_slice, random_key):
+        """Valid bend_radius + bend_axis=1 (y-axis, transverse to z-propagation) succeeds."""
+        det = ModeOverlapDetector(
+            wave_characters=single_frequency, direction="+", bend_radius=10e-6, bend_axis=1
+        )
+        placed = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        assert placed.bend_radius == 10e-6
+        assert placed.bend_axis == 1
+
+    def test_valid_bend_params_x_propagation(self, single_frequency, simulation_config, random_key):
+        """Valid bend setup for x-propagating waveguide: bend_axis must be 1 or 2."""
+        x_plane = ((0, 1), (0, 8), (0, 8))
+        det = ModeOverlapDetector(
+            wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=2
+        )
+        placed = det.place_on_grid(x_plane, simulation_config, random_key)
+        assert placed.propagation_axis == 0
+        assert placed.bend_axis == 2
+
+    def test_bend_axis_same_as_x_propagation_raises(self, single_frequency, simulation_config, random_key):
+        """bend_axis=0 for x-propagating waveguide (propagation_axis=0) raises ValueError."""
+        x_plane = ((0, 1), (0, 8), (0, 8))
+        det = ModeOverlapDetector(
+            wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=0
+        )
+        with pytest.raises(ValueError, match="must differ from the propagation axis"):
+            det.place_on_grid(x_plane, simulation_config, random_key)


### PR DESCRIPTION
This PR adds bend mode support to compute_mode and ModeOverlapDetector by passing bend parameters through to Tidy3D’s mode solver.

The new options are:

- bend_radius: bend radius in meters, using fdtdx units
- bend_axis: physical axis index pointing from the waveguide toward the center of curvature

Internally, fdtdx maps these into the convention expected by Tidy3D:

- converts bend_radius from meters to microns
- remaps the physical bend_axis into Tidy3D’s transverse mode-plane axis index
- provides the mode plane center required by Tidy3D for bent-mode computation

The PR also adds validation so bend parameters are only accepted when they are physically well-defined:

- bend_radius and bend_axis must be set together
- bend_axis must be transverse to the propagation axis

Tests cover:

- default straight-waveguide behavior
- invalid partial bend configuration
- invalid bend axis matching propagation axis
- valid bend configurations for different propagation axes
- passthrough/conversion of bend radius, bend axis, and plane center into the Tidy3D wrapper

No additional integration test is included because the bent-mode solve itself is delegated to Tidy3D. This PR only validates fdtdx-side behavior: argument validation, unit conversion, axis remapping, plane-center calculation, and passthrough into the Tidy3D mode solver wrapper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bend radius and bend axis parameters for mode computation with automatic unit scaling and coordinate transformation
  * Integrated bend geometry parameters into the mode overlap detector
  * Added validation ensuring bend parameters are consistently configured and compatible with propagation axis

* **Tests**
  * Added comprehensive test coverage for bend parameter validation, scaling, and transformation verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->