### PR TITLE
auto-infer bounding-box size for Cylinder, Sphere, and ExtrudedPolygon 

### DIFF
--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -870,7 +870,7 @@ def _apply_constraints_iteratively(
     errors: dict[str, str | None] = {obj.name: None for obj in objects}
 
     # handle static shapes
-    shape_dict = _resolve_static_shapes(
+    shape_dict, auto_shape_axes = _resolve_static_shapes(
         object_map=object_map,
         shape_dict=shape_dict,
         config=config,
@@ -907,12 +907,16 @@ def _apply_constraints_iteratively(
         )
         changed = changed or resolved
 
-        # update the grid slices based on static shape and partial known positions
+        # Slices-from-shapes must run before shapes-from-slices: it propagates a
+        # known shape to an open bound (and silently overrides auto-geometry hints
+        # that conflict with already-fixed bounds).  Shapes-from-slices then locks
+        # the shape from two known bounds in the same iteration.
         resolved, slice_dict, errors = _update_grid_slices_from_shapes(
             object_map=object_map,
             shape_dict=shape_dict,
             slice_dict=slice_dict,
             errors=errors,
+            auto_shape_axes=auto_shape_axes,
         )
         changed = changed or resolved
 
@@ -922,6 +926,7 @@ def _apply_constraints_iteratively(
             shape_dict=shape_dict,
             slice_dict=slice_dict,
             errors=errors,
+            auto_shape_axes=auto_shape_axes,
         )
         changed = changed or resolved
 
@@ -1010,8 +1015,16 @@ def _resolve_static_shapes(
     object_map: dict[str, SimulationObject],
     shape_dict: dict[str, list[int | None]],
     config: SimulationConfig,
-):
-    """Fill in static or directly defined shapes."""
+) -> tuple[dict[str, list[int | None]], set[tuple[str, int]]]:
+    """Fill in static or directly defined shapes.
+
+    Returns shape_dict and a set of (obj_name, axis) pairs whose size was
+    derived automatically from the object geometry (e.g. cylinder radius).
+    These auto-derived sizes are lower-priority than explicit constraints: if
+    a constraint later fixes both bounds for such an axis, the constraint
+    value wins without raising an inconsistency error.
+    """
+    auto_shape_axes: set[tuple[str, int]] = set()
     for obj_name, obj in object_map.items():
         for axis in range(3):
             if obj.partial_grid_shape[axis] is not None:
@@ -1021,7 +1034,42 @@ def _resolve_static_shapes(
                     obj.partial_real_shape[axis] / config.resolution  # type: ignore
                 )
                 shape_dict[obj_name][axis] = cur_grid_shape
-    return shape_dict
+        # Lower-priority auto-geometry hint (e.g. 2*radius for cylinders).
+        # Only fills axes that are still None after user-specified fields.
+        if isinstance(obj, StaticMultiMaterialObject):
+            auto_real = obj.get_geometry_size_hint()
+            for axis in range(3):
+                auto_size = auto_real[axis]
+                if shape_dict[obj_name][axis] is None and auto_size is not None:
+                    shape_dict[obj_name][axis] = round(auto_size / config.resolution)
+                    auto_shape_axes.add((obj_name, axis))
+    return shape_dict, auto_shape_axes
+
+
+def _resolve_shape_bound_conflict(
+    obj_name: str,
+    axis: int,
+    bound_size: int,
+    obj: SimulationObject,
+    shape_dict: dict[str, list[int | None]],
+    errors: dict[str, str | None],
+    auto_shape_axes: set[tuple[str, int]] | None,
+) -> bool:
+    """Handle a conflict where shape_dict and bound-derived size disagree.
+
+    If the shape came from a geometry hint, the constraint-determined bound_size
+    wins silently.  Otherwise the conflict is recorded as an error.
+    Returns True if the conflict was resolved (shape updated), False if it was an error.
+    """
+    if auto_shape_axes and (obj_name, axis) in auto_shape_axes:
+        shape_dict[obj_name][axis] = bound_size
+        auto_shape_axes.discard((obj_name, axis))
+        return True
+    errors[obj_name] = (
+        f"Inconsistent grid shape for object: {shape_dict[obj_name][axis]} != {bound_size},"
+        f" {obj.name} ({obj.__class__})."
+    )
+    return False
 
 
 def _update_grid_slices_from_shapes(
@@ -1029,6 +1077,7 @@ def _update_grid_slices_from_shapes(
     shape_dict: dict[str, list[int | None]],
     slice_dict: dict[str, list[list[int | None]]],
     errors: dict[str, str | None],
+    auto_shape_axes: set[tuple[str, int]] | None = None,
 ):
     resolved_something = False
     for obj_name, s in shape_dict.items():
@@ -1042,8 +1091,8 @@ def _update_grid_slices_from_shapes(
                 continue
             elif b0 is not None and b1 is not None:
                 if s_axis != b1 - b0:
-                    errors[obj_name] = (
-                        f"Inconsistent grid shape for object: {s_axis} != {b1 - b0}, {obj.name} ({obj.__class__})."
+                    resolved_something |= _resolve_shape_bound_conflict(
+                        obj_name, axis, b1 - b0, obj, shape_dict, errors, auto_shape_axes
                     )
             elif b0 is not None:
                 slice_dict[obj_name][axis][1] = b0 + s_axis
@@ -1059,6 +1108,7 @@ def _update_grid_shapes_from_slices(
     shape_dict: dict[str, list[int | None]],
     slice_dict: dict[str, list[list[int | None]]],
     errors: dict[str, str | None],
+    auto_shape_axes: set[tuple[str, int]] | None = None,
 ):
     resolved_something = False
     for obj_name, b in slice_dict.items():
@@ -1071,9 +1121,9 @@ def _update_grid_shapes_from_slices(
                 if s_axis is None:
                     shape_dict[obj_name][axis] = b1 - b0
                     resolved_something = True
-                elif s_axis is not None and b1 - b0 != s_axis:
-                    errors[obj_name] = (
-                        f"Inconsistent grid shape for object: {s_axis} != {b1 - b0}, {obj.name} ({obj.__class__})."
+                elif b1 - b0 != s_axis:
+                    resolved_something |= _resolve_shape_bound_conflict(
+                        obj_name, axis, b1 - b0, obj, shape_dict, errors, auto_shape_axes
                     )
     return resolved_something, shape_dict, errors
 

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -1060,9 +1060,7 @@ def _update_grid_slices_from_shapes(
                 continue
             elif b0 is not None and b1 is not None:
                 if s_axis != b1 - b0:
-                    resolved_something |= _record_shape_bound_conflict(
-                        obj_name, axis, b1 - b0, obj, shape_dict, errors
-                    )
+                    resolved_something |= _record_shape_bound_conflict(obj_name, axis, b1 - b0, obj, shape_dict, errors)
             elif b0 is not None:
                 slice_dict[obj_name][axis][1] = b0 + s_axis
                 resolved_something = True
@@ -1090,9 +1088,7 @@ def _update_grid_shapes_from_slices(
                     shape_dict[obj_name][axis] = b1 - b0
                     resolved_something = True
                 elif b1 - b0 != s_axis:
-                    resolved_something |= _record_shape_bound_conflict(
-                        obj_name, axis, b1 - b0, obj, shape_dict, errors
-                    )
+                    resolved_something |= _record_shape_bound_conflict(obj_name, axis, b1 - b0, obj, shape_dict, errors)
     return resolved_something, shape_dict, errors
 
 

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -870,7 +870,7 @@ def _apply_constraints_iteratively(
     errors: dict[str, str | None] = {obj.name: None for obj in objects}
 
     # handle static shapes
-    shape_dict, auto_shape_axes = _resolve_static_shapes(
+    shape_dict = _resolve_static_shapes(
         object_map=object_map,
         shape_dict=shape_dict,
         config=config,
@@ -907,16 +907,13 @@ def _apply_constraints_iteratively(
         )
         changed = changed or resolved
 
-        # Slices-from-shapes must run before shapes-from-slices: it propagates a
-        # known shape to an open bound (and silently overrides auto-geometry hints
-        # that conflict with already-fixed bounds).  Shapes-from-slices then locks
-        # the shape from two known bounds in the same iteration.
+        # Slices-from-shapes: propagate a known shape to an open bound.
+        # Shapes-from-slices: lock the shape once both bounds are known.
         resolved, slice_dict, errors = _update_grid_slices_from_shapes(
             object_map=object_map,
             shape_dict=shape_dict,
             slice_dict=slice_dict,
             errors=errors,
-            auto_shape_axes=auto_shape_axes,
         )
         changed = changed or resolved
 
@@ -926,7 +923,6 @@ def _apply_constraints_iteratively(
             shape_dict=shape_dict,
             slice_dict=slice_dict,
             errors=errors,
-            auto_shape_axes=auto_shape_axes,
         )
         changed = changed or resolved
 
@@ -1015,59 +1011,33 @@ def _resolve_static_shapes(
     object_map: dict[str, SimulationObject],
     shape_dict: dict[str, list[int | None]],
     config: SimulationConfig,
-) -> tuple[dict[str, list[int | None]], set[tuple[str, int]]]:
-    """Fill in static or directly defined shapes.
-
-    Returns shape_dict and a set of (obj_name, axis) pairs whose size was
-    derived automatically from the object geometry (e.g. cylinder radius).
-    These auto-derived sizes are lower-priority than explicit constraints: if
-    a constraint later fixes both bounds for such an axis, the constraint
-    value wins without raising an inconsistency error.
-    """
-    auto_shape_axes: set[tuple[str, int]] = set()
+) -> dict[str, list[int | None]]:
+    """Fill in shapes from each object's partial_real_shape and partial_grid_shape."""
     for obj_name, obj in object_map.items():
         for axis in range(3):
             if obj.partial_grid_shape[axis] is not None:
                 shape_dict[obj_name][axis] = obj.partial_grid_shape[axis]
             if obj.partial_real_shape[axis] is not None:
-                cur_grid_shape = round(
+                shape_dict[obj_name][axis] = round(
                     obj.partial_real_shape[axis] / config.resolution  # type: ignore
                 )
-                shape_dict[obj_name][axis] = cur_grid_shape
-        # Lower-priority auto-geometry hint (e.g. 2*radius for cylinders).
-        # Only fills axes that are still None after user-specified fields.
-        if isinstance(obj, StaticMultiMaterialObject):
-            auto_real = obj.get_geometry_size_hint()
-            for axis in range(3):
-                auto_size = auto_real[axis]
-                if shape_dict[obj_name][axis] is None and auto_size is not None:
-                    shape_dict[obj_name][axis] = round(auto_size / config.resolution)
-                    auto_shape_axes.add((obj_name, axis))
-    return shape_dict, auto_shape_axes
+    return shape_dict
 
 
-def _resolve_shape_bound_conflict(
+def _record_shape_bound_conflict(
     obj_name: str,
     axis: int,
     bound_size: int,
     obj: SimulationObject,
     shape_dict: dict[str, list[int | None]],
     errors: dict[str, str | None],
-    auto_shape_axes: set[tuple[str, int]] | None,
 ) -> bool:
-    """Handle a conflict where shape_dict and bound-derived size disagree.
-
-    If the shape came from a geometry hint, the constraint-determined bound_size
-    wins silently.  Otherwise the conflict is recorded as an error.
-    Returns True if the conflict was resolved (shape updated), False if it was an error.
-    """
-    if auto_shape_axes and (obj_name, axis) in auto_shape_axes:
-        shape_dict[obj_name][axis] = bound_size
-        auto_shape_axes.discard((obj_name, axis))
-        return True
+    """Record a conflict where shape_dict and bound-derived size disagree. Always an error."""
     errors[obj_name] = (
-        f"Inconsistent grid shape for object: {shape_dict[obj_name][axis]} != {bound_size},"
-        f" {obj.name} ({obj.__class__})."
+        f"Inconsistent grid shape for object: {shape_dict[obj_name][axis]} != {bound_size} "
+        f"for axis={axis}, {obj.name} ({obj.__class__.__name__}). "
+        f"Check partial_real_shape, partial_grid_shape, and any SizeConstraints for this object. "
+        f"If the shape is derived from geometry (e.g. radius), a conflicting constraint was applied."
     )
     return False
 
@@ -1077,7 +1047,6 @@ def _update_grid_slices_from_shapes(
     shape_dict: dict[str, list[int | None]],
     slice_dict: dict[str, list[list[int | None]]],
     errors: dict[str, str | None],
-    auto_shape_axes: set[tuple[str, int]] | None = None,
 ):
     resolved_something = False
     for obj_name, s in shape_dict.items():
@@ -1091,8 +1060,8 @@ def _update_grid_slices_from_shapes(
                 continue
             elif b0 is not None and b1 is not None:
                 if s_axis != b1 - b0:
-                    resolved_something |= _resolve_shape_bound_conflict(
-                        obj_name, axis, b1 - b0, obj, shape_dict, errors, auto_shape_axes
+                    resolved_something |= _record_shape_bound_conflict(
+                        obj_name, axis, b1 - b0, obj, shape_dict, errors
                     )
             elif b0 is not None:
                 slice_dict[obj_name][axis][1] = b0 + s_axis
@@ -1108,7 +1077,6 @@ def _update_grid_shapes_from_slices(
     shape_dict: dict[str, list[int | None]],
     slice_dict: dict[str, list[list[int | None]]],
     errors: dict[str, str | None],
-    auto_shape_axes: set[tuple[str, int]] | None = None,
 ):
     resolved_something = False
     for obj_name, b in slice_dict.items():
@@ -1122,8 +1090,8 @@ def _update_grid_shapes_from_slices(
                     shape_dict[obj_name][axis] = b1 - b0
                     resolved_something = True
                 elif b1 - b0 != s_axis:
-                    resolved_something |= _resolve_shape_bound_conflict(
-                        obj_name, axis, b1 - b0, obj, shape_dict, errors, auto_shape_axes
+                    resolved_something |= _record_shape_bound_conflict(
+                        obj_name, axis, b1 - b0, obj, shape_dict, errors
                     )
     return resolved_something, shape_dict, errors
 
@@ -1273,9 +1241,11 @@ def _apply_size_constraint(
             resolved_something = True
         elif shape_dict[obj_name][axis] != object_shape:
             raise Exception(
-                "Inconsistent grid shape for object: ",
-                f"{shape_dict[obj_name][axis]} != {object_shape} for {axis=}, {obj.name} ({obj.__class__}). ",
-                "Please check if there are multiple constraints or sizes specified for the object.",
+                f"Inconsistent grid shape for object: "
+                f"{shape_dict[obj_name][axis]} != {object_shape} for axis={axis}, "
+                f"{obj.name} ({obj.__class__.__name__}). "
+                f"Check partial_real_shape, partial_grid_shape, and any SizeConstraints for this object. "
+                f"If the shape is derived from geometry (e.g. radius), a conflicting SizeConstraint was applied."
             )
     return resolved_something, shape_dict
 

--- a/src/fdtdx/objects/static_material/cylinder.py
+++ b/src/fdtdx/objects/static_material/cylinder.py
@@ -13,6 +13,10 @@ class Cylinder(StaticMultiMaterialObject):
     This class represents a cylindrical fiber with customizable radius, material,
     and orientation. The fiber can be positioned along any of the three principal axes.
 
+    The cross-section size (diameter = 2 * radius) is automatically inferred for the
+    two axes perpendicular to ``axis``, so ``partial_real_shape`` does not need to be
+    specified for those axes.  The extrusion axis size must still be determined by a
+    constraint or an explicit ``partial_real_shape`` entry.
     """
 
     #: The radius of the fiber in meter.
@@ -23,6 +27,13 @@ class Cylinder(StaticMultiMaterialObject):
 
     #: Name of the material in the materials dictionary to be used for the object.
     material_name: str = frozen_field()
+
+    def get_geometry_size_hint(self) -> tuple[float | None, float | None, float | None]:
+        diameter = 2.0 * self.radius
+        shape: list[float | None] = [None, None, None]
+        shape[self.horizontal_axis] = diameter
+        shape[self.vertical_axis] = diameter
+        return (shape[0], shape[1], shape[2])
 
     @property
     def horizontal_axis(self) -> int:

--- a/src/fdtdx/objects/static_material/cylinder.py
+++ b/src/fdtdx/objects/static_material/cylinder.py
@@ -28,12 +28,23 @@ class Cylinder(StaticMultiMaterialObject):
     #: Name of the material in the materials dictionary to be used for the object.
     material_name: str = frozen_field()
 
-    def get_geometry_size_hint(self) -> tuple[float | None, float | None, float | None]:
+    def __post_init__(self):
         diameter = 2.0 * self.radius
-        shape: list[float | None] = [None, None, None]
-        shape[self.horizontal_axis] = diameter
-        shape[self.vertical_axis] = diameter
-        return (shape[0], shape[1], shape[2])
+        real_shape = list(self.partial_real_shape)
+        grid_shape = list(self.partial_grid_shape)
+        for ax in (self.horizontal_axis, self.vertical_axis):
+            if real_shape[ax] is not None:
+                raise Exception(
+                    f"Cylinder {self.name}: partial_real_shape for axis {ax} is derived from the radius "
+                    f"({diameter:.3e} m). Do not specify it explicitly."
+                )
+            if grid_shape[ax] is not None:
+                raise Exception(
+                    f"Cylinder {self.name}: partial_grid_shape for axis {ax} is derived from the radius. "
+                    f"Do not specify it explicitly."
+                )
+            real_shape[ax] = diameter
+        object.__setattr__(self, "partial_real_shape", tuple(real_shape))
 
     @property
     def horizontal_axis(self) -> int:

--- a/src/fdtdx/objects/static_material/polygon.py
+++ b/src/fdtdx/objects/static_material/polygon.py
@@ -18,6 +18,11 @@ class ExtrudedPolygon(StaticMultiMaterialObject):
     The vertices must be given in a coordinate system centered at the origin, i.e. (0, 0)
     corresponds to the center of the object's bounding box. The polygon is placed so that
     its center coincides with the center of the grid region allocated to this object.
+
+    The cross-section size is automatically inferred from the vertex bounding box for the
+    two axes perpendicular to ``axis``, so ``partial_real_shape`` does not need to be
+    specified for those axes.  The extrusion axis size must still be determined by a
+    constraint or an explicit ``partial_real_shape`` entry.
     """
 
     #: Name of the material in the materials dictionary to be used for the object
@@ -28,6 +33,12 @@ class ExtrudedPolygon(StaticMultiMaterialObject):
 
     #: numpy array of shape (N, 2) with vertices in metrical units (meter), centered at origin.
     vertices: np.ndarray = frozen_field()
+
+    def get_geometry_size_hint(self) -> tuple[float | None, float | None, float | None]:
+        shape: list[float | None] = [None, None, None]
+        shape[self.horizontal_axis] = float(self.vertices[:, 0].max() - self.vertices[:, 0].min())
+        shape[self.vertical_axis] = float(self.vertices[:, 1].max() - self.vertices[:, 1].min())
+        return (shape[0], shape[1], shape[2])
 
     @property
     def horizontal_axis(self) -> int:

--- a/src/fdtdx/objects/static_material/polygon.py
+++ b/src/fdtdx/objects/static_material/polygon.py
@@ -34,11 +34,24 @@ class ExtrudedPolygon(StaticMultiMaterialObject):
     #: numpy array of shape (N, 2) with vertices in metrical units (meter), centered at origin.
     vertices: np.ndarray = frozen_field()
 
-    def get_geometry_size_hint(self) -> tuple[float | None, float | None, float | None]:
-        shape: list[float | None] = [None, None, None]
-        shape[self.horizontal_axis] = float(self.vertices[:, 0].max() - self.vertices[:, 0].min())
-        shape[self.vertical_axis] = float(self.vertices[:, 1].max() - self.vertices[:, 1].min())
-        return (shape[0], shape[1], shape[2])
+    def __post_init__(self):
+        w = float(self.vertices[:, 0].max() - self.vertices[:, 0].min())
+        h = float(self.vertices[:, 1].max() - self.vertices[:, 1].min())
+        real_shape = list(self.partial_real_shape)
+        grid_shape = list(self.partial_grid_shape)
+        for ax, size in ((self.horizontal_axis, w), (self.vertical_axis, h)):
+            if real_shape[ax] is not None:
+                raise Exception(
+                    f"ExtrudedPolygon {self.name}: partial_real_shape for axis {ax} is derived from the "
+                    f"vertex bounding box ({size:.3e} m). Do not specify it explicitly."
+                )
+            if grid_shape[ax] is not None:
+                raise Exception(
+                    f"ExtrudedPolygon {self.name}: partial_grid_shape for axis {ax} is derived from the "
+                    f"vertex bounding box. Do not specify it explicitly."
+                )
+            real_shape[ax] = size
+        object.__setattr__(self, "partial_real_shape", tuple(real_shape))
 
     @property
     def horizontal_axis(self) -> int:

--- a/src/fdtdx/objects/static_material/sphere.py
+++ b/src/fdtdx/objects/static_material/sphere.py
@@ -13,6 +13,10 @@ class Sphere(StaticMultiMaterialObject):
     This class represents a sphere or ellipsoid with customizable radius/radii and material.
     When all three radii are equal, the shape is a perfect sphere.
 
+    The bounding-box size (diameter = 2 * radius per axis) is automatically inferred
+    for all three axes, so ``partial_real_shape`` does not need to be specified.
+    Per-axis radii (``radius_x``, ``radius_y``, ``radius_z``) take precedence over the
+    default ``radius`` when present.
     """
 
     #: The default radius of the sphere in meter (used if specific axis radii are not provided).
@@ -30,6 +34,13 @@ class Sphere(StaticMultiMaterialObject):
 
     #: The radius along the z-axis in meter. If none, use radius. Defaults to None.
     radius_z: float | None = frozen_field(default=None)
+
+    def get_geometry_size_hint(self) -> tuple[float | None, float | None, float | None]:
+        return (
+            2.0 * (self.radius_x if self.radius_x is not None else self.radius),
+            2.0 * (self.radius_y if self.radius_y is not None else self.radius),
+            2.0 * (self.radius_z if self.radius_z is not None else self.radius),
+        )
 
     def get_voxel_mask_for_shape(self) -> jax.Array:
         """Generates a voxel mask for a sphere or ellipsoid shape.

--- a/src/fdtdx/objects/static_material/sphere.py
+++ b/src/fdtdx/objects/static_material/sphere.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 from fdtdx.core.jax.pytrees import autoinit, frozen_field
 from fdtdx.materials import compute_ordered_names
 from fdtdx.objects.static_material.static import StaticMultiMaterialObject
+from fdtdx.typing import UNDEFINED_SHAPE_3D, PartialGridShape3D, PartialRealShape3D
 
 
 @autoinit
@@ -14,7 +15,8 @@ class Sphere(StaticMultiMaterialObject):
     When all three radii are equal, the shape is a perfect sphere.
 
     The bounding-box size (diameter = 2 * radius per axis) is automatically inferred
-    for all three axes, so ``partial_real_shape`` does not need to be specified.
+    for all three axes from the radius parameters. ``partial_real_shape`` and
+    ``partial_grid_shape`` are not constructor parameters — they are set automatically.
     Per-axis radii (``radius_x``, ``radius_y``, ``radius_z``) take precedence over the
     default ``radius`` when present.
     """
@@ -24,7 +26,6 @@ class Sphere(StaticMultiMaterialObject):
 
     #: Name of the sphere material in the materials dictionary to be used for the object.
     material_name: str = frozen_field()
-    # Optional parameters for ellipsoid shape
 
     #: The radius along the x-axis in meter. If none, use radius. Defaults to None.
     radius_x: float | None = frozen_field(default=None)
@@ -35,12 +36,15 @@ class Sphere(StaticMultiMaterialObject):
     #: The radius along the z-axis in meter. If none, use radius. Defaults to None.
     radius_z: float | None = frozen_field(default=None)
 
-    def get_geometry_size_hint(self) -> tuple[float | None, float | None, float | None]:
-        return (
-            2.0 * (self.radius_x if self.radius_x is not None else self.radius),
-            2.0 * (self.radius_y if self.radius_y is not None else self.radius),
-            2.0 * (self.radius_z if self.radius_z is not None else self.radius),
-        )
+    # Derived from radius — not constructor parameters.
+    partial_real_shape: PartialRealShape3D = frozen_field(default=UNDEFINED_SHAPE_3D, init=False)
+    partial_grid_shape: PartialGridShape3D = frozen_field(default=UNDEFINED_SHAPE_3D, init=False)
+
+    def __post_init__(self):
+        rx = self.radius_x if self.radius_x is not None else self.radius
+        ry = self.radius_y if self.radius_y is not None else self.radius
+        rz = self.radius_z if self.radius_z is not None else self.radius
+        object.__setattr__(self, "partial_real_shape", (2.0 * rx, 2.0 * ry, 2.0 * rz))
 
     def get_voxel_mask_for_shape(self) -> jax.Array:
         """Generates a voxel mask for a sphere or ellipsoid shape.

--- a/src/fdtdx/objects/static_material/static.py
+++ b/src/fdtdx/objects/static_material/static.py
@@ -25,6 +25,20 @@ class StaticMultiMaterialObject(OrderableObject, ABC):
     #: the color of the material
     color: Color | None = frozen_field(default=XKCD_LIGHT_GREY)
 
+    def get_geometry_size_hint(self) -> tuple[float | None, float | None, float | None]:
+        """Return geometry-derived real-space size hints (in metres) for each axis.
+
+        The initialization system calls this as a low-priority fallback: if no
+        ``partial_real_shape`` entry and no explicit constraint determines the size
+        for an axis, this hint is used so callers do not need to repeat geometric
+        parameters that are already encoded in the object's fields (e.g. radius).
+
+        Subclasses that carry inherent size information should override this method.
+        Return ``None`` for any axis whose size should remain unconstrained by geometry.
+        The default implementation returns ``(None, None, None)``.
+        """
+        return (None, None, None)
+
     @abstractmethod
     def get_voxel_mask_for_shape(self) -> jax.Array:
         """Get a binary mask of the objects shape. Everything voxel not in the mask, will not be updated by

--- a/src/fdtdx/objects/static_material/static.py
+++ b/src/fdtdx/objects/static_material/static.py
@@ -25,20 +25,6 @@ class StaticMultiMaterialObject(OrderableObject, ABC):
     #: the color of the material
     color: Color | None = frozen_field(default=XKCD_LIGHT_GREY)
 
-    def get_geometry_size_hint(self) -> tuple[float | None, float | None, float | None]:
-        """Return geometry-derived real-space size hints (in metres) for each axis.
-
-        The initialization system calls this as a low-priority fallback: if no
-        ``partial_real_shape`` entry and no explicit constraint determines the size
-        for an axis, this hint is used so callers do not need to repeat geometric
-        parameters that are already encoded in the object's fields (e.g. radius).
-
-        Subclasses that carry inherent size information should override this method.
-        Return ``None`` for any axis whose size should remain unconstrained by geometry.
-        The default implementation returns ``(None, None, None)``.
-        """
-        return (None, None, None)
-
     @abstractmethod
     def get_voxel_mask_for_shape(self) -> jax.Array:
         """Get a binary mask of the objects shape. Everything voxel not in the mask, will not be updated by

--- a/tests/integration/fdtd/test_initialization.py
+++ b/tests/integration/fdtd/test_initialization.py
@@ -195,10 +195,9 @@ def test_static_multi_material_object_sphere(simple_config, simple_volume):
     }
     sphere = Sphere(
         name="sphere1",
-        partial_grid_shape=(20, 20, 20),
         materials=materials,
         material_name="sphere_mat",
-        radius=5.0,  # 5 grid units at resolution=1.0
+        radius=5.0,  # 5 grid units at resolution=1.0 → bounding box 10 cells per axis
     )
     constraint = GridCoordinateConstraint(
         object="sphere1", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[15, 15, 15]

--- a/tests/integration/fdtd/test_placement.py
+++ b/tests/integration/fdtd/test_placement.py
@@ -108,7 +108,7 @@ def test_placement():
 
     # multi material objects
     polygon = fdtdx.ExtrudedPolygon(
-        partial_real_shape=(1e-6, 1e-6, 1e-6),
+        partial_real_shape=(None, None, 1e-6),
         materials=materials,
         axis=2,
         vertices=np.asarray([[0, 0], [0, 200e-9], [200e-9, 200e-9], [200e-9, 100e-9], [0, 0]]),
@@ -118,7 +118,6 @@ def test_placement():
     objects.append(polygon)
 
     sphere = fdtdx.Sphere(
-        partial_real_shape=(1e-6, 1e-6, 1e-6),
         materials=materials,
         radius=300e-9,
         material_name="polymer",
@@ -128,7 +127,7 @@ def test_placement():
 
     cylinder = fdtdx.Cylinder(
         axis=2,
-        partial_real_shape=(1e-6, 1e-6, 1e-6),
+        partial_real_shape=(None, None, 1e-6),
         materials=materials,
         radius=300e-9,
         material_name="polymer",

--- a/tests/integration/placement/test_constraint_placement.py
+++ b/tests/integration/placement/test_constraint_placement.py
@@ -9,6 +9,9 @@ Volume: 2 um x 2 um x 2 um at 100 nm resolution → 20 x 20 x 20 grid cells.
 import fdtdx
 from fdtdx.fdtd.initialization import resolve_object_constraints
 from fdtdx.objects.object import RealCoordinateConstraint
+from fdtdx.objects.static_material.cylinder import Cylinder
+from fdtdx.objects.static_material.polygon import ExtrudedPolygon
+from fdtdx.objects.static_material.sphere import Sphere
 
 # ---------------------------------------------------------------------------
 # Constants / helpers
@@ -694,3 +697,88 @@ def test_extend_to_plus_same_size_on_other_axes():
     assert sl[0] == (0, N)
     assert sl[1] == (0, N)
     assert sl[2] == (3, N)
+
+
+# ---------------------------------------------------------------------------
+# Auto-size from geometry (Cylinder / Sphere / ExtrudedPolygon)
+# ---------------------------------------------------------------------------
+
+_MATS = {"si": fdtdx.Material(permittivity=12.25)}
+
+
+def test_cylinder_auto_size_from_radius():
+    """Cylinder cross-section is sized automatically from radius without partial_real_shape."""
+    vol = _volume()
+    radius = 500e-9  # = 5 grid cells at 100 nm resolution
+    cyl = Cylinder(name="cyl", radius=radius, axis=2, materials=_MATS, material_name="si")
+
+    constraints = [
+        cyl.same_position(vol, axes=(0, 1)),
+        cyl.extend_to(None, axis=2, direction="+"),
+        cyl.extend_to(None, axis=2, direction="-"),
+    ]
+    sl = _sl(_resolve(vol, [cyl], constraints), cyl)
+
+    expected = round(2 * radius / RESOLUTION)  # = 10
+    assert sl[0] == (N // 2 - expected // 2, N // 2 + expected // 2)
+    assert sl[1] == (N // 2 - expected // 2, N // 2 + expected // 2)
+    assert sl[2] == (0, N)
+
+
+def test_cylinder_constraint_overrides_auto_size():
+    """Explicit GridCoordinateConstraints on cross-section axes win over auto-size."""
+    vol = _volume()
+    radius = 500e-9
+    cyl = Cylinder(name="cyl", radius=radius, axis=2, materials=_MATS, material_name="si")
+
+    constraints = [
+        cyl.set_grid_coordinates(axes=0, sides="-", coordinates=4),
+        cyl.set_grid_coordinates(axes=0, sides="+", coordinates=16),
+        cyl.set_grid_coordinates(axes=1, sides="-", coordinates=4),
+        cyl.set_grid_coordinates(axes=1, sides="+", coordinates=16),
+        cyl.extend_to(None, axis=2, direction="+"),
+        cyl.extend_to(None, axis=2, direction="-"),
+    ]
+    sl = _sl(_resolve(vol, [cyl], constraints), cyl)
+
+    # Constraint says 12 cells, auto-size would say 10 — constraint wins.
+    assert sl[0] == (4, 16)
+    assert sl[1] == (4, 16)
+
+
+def test_sphere_auto_size_all_axes():
+    """Sphere bounding box is sized automatically on all three axes."""
+    vol = _volume()
+    radius = 500e-9  # = 5 grid cells
+    sphere = Sphere(name="sphere", radius=radius, materials=_MATS, material_name="si")
+
+    constraints = [sphere.same_position(vol)]
+    sl = _sl(_resolve(vol, [sphere], constraints), sphere)
+
+    expected = round(2 * radius / RESOLUTION)  # = 10
+    lo, hi = N // 2 - expected // 2, N // 2 + expected // 2
+    assert sl[0] == (lo, hi)
+    assert sl[1] == (lo, hi)
+    assert sl[2] == (lo, hi)
+
+
+def test_extruded_polygon_auto_size_from_vertices():
+    """ExtrudedPolygon cross-section is sized from vertex bounding box."""
+    import numpy as np
+
+    vol = _volume()
+    half = 500e-9  # 5 cells → 10-cell square
+    verts = np.array([[-half, -half], [half, -half], [half, half], [-half, half]])
+    poly = ExtrudedPolygon(name="poly", axis=2, material_name="si", materials=_MATS, vertices=verts)
+
+    constraints = [
+        poly.same_position(vol, axes=(0, 1)),
+        poly.extend_to(None, axis=2, direction="+"),
+        poly.extend_to(None, axis=2, direction="-"),
+    ]
+    sl = _sl(_resolve(vol, [poly], constraints), poly)
+
+    expected = round(2 * half / RESOLUTION)  # = 10
+    assert sl[0] == (N // 2 - expected // 2, N // 2 + expected // 2)
+    assert sl[1] == (N // 2 - expected // 2, N // 2 + expected // 2)
+    assert sl[2] == (0, N)

--- a/tests/integration/placement/test_constraint_placement.py
+++ b/tests/integration/placement/test_constraint_placement.py
@@ -725,25 +725,24 @@ def test_cylinder_auto_size_from_radius():
     assert sl[2] == (0, N)
 
 
-def test_cylinder_constraint_overrides_auto_size():
-    """Explicit GridCoordinateConstraints on cross-section axes win over auto-size."""
+def test_cylinder_conflicting_constraint_errors():
+    """GridCoordinateConstraints that conflict with the geometry-derived cross-section size raise an error."""
     vol = _volume()
-    radius = 500e-9
+    radius = 500e-9  # → 10 grid cells cross-section
     cyl = Cylinder(name="cyl", radius=radius, axis=2, materials=_MATS, material_name="si")
 
     constraints = [
         cyl.set_grid_coordinates(axes=0, sides="-", coordinates=4),
-        cyl.set_grid_coordinates(axes=0, sides="+", coordinates=16),
+        cyl.set_grid_coordinates(axes=0, sides="+", coordinates=16),  # 12 cells ≠ 10 derived
         cyl.set_grid_coordinates(axes=1, sides="-", coordinates=4),
         cyl.set_grid_coordinates(axes=1, sides="+", coordinates=16),
         cyl.extend_to(None, axis=2, direction="+"),
         cyl.extend_to(None, axis=2, direction="-"),
     ]
-    sl = _sl(_resolve(vol, [cyl], constraints), cyl)
-
-    # Constraint says 12 cells, auto-size would say 10 — constraint wins.
-    assert sl[0] == (4, 16)
-    assert sl[1] == (4, 16)
+    _slices, errors = resolve_object_constraints(
+        objects=[vol, cyl], constraints=constraints, config=_cfg()
+    )
+    assert errors.get("cyl"), "Expected an error for conflicting cross-section constraint"
 
 
 def test_sphere_auto_size_all_axes():

--- a/tests/integration/placement/test_constraint_placement.py
+++ b/tests/integration/placement/test_constraint_placement.py
@@ -739,9 +739,7 @@ def test_cylinder_conflicting_constraint_errors():
         cyl.extend_to(None, axis=2, direction="+"),
         cyl.extend_to(None, axis=2, direction="-"),
     ]
-    _slices, errors = resolve_object_constraints(
-        objects=[vol, cyl], constraints=constraints, config=_cfg()
-    )
+    _slices, errors = resolve_object_constraints(objects=[vol, cyl], constraints=constraints, config=_cfg())
     assert errors.get("cyl"), "Expected an error for conflicting cross-section constraint"
 
 

--- a/tests/integration/utils/test_plot_material.py
+++ b/tests/integration/utils/test_plot_material.py
@@ -84,7 +84,7 @@ def cylinder_setup():
 
     cylinder = Cylinder(
         name="test_cylinder",
-        radius=0.5e-6,
+        radius=0.3e-6,  # 2*0.3e-6 / 30e-9 = 20 cells, matching the constraints below
         axis=2,
         materials={"dielectric": Material(permittivity=4.0, permeability=1.0)},
         material_name="dielectric",
@@ -499,7 +499,7 @@ def test_plot_material_all_types_objects():
 
     cylinder = Cylinder(
         name="cylinder",
-        radius=0.5e-6,
+        radius=0.4e-6,  # 2*0.4e-6 / 40e-9 = 20 cells, matching the constraints below
         axis=2,
         materials={"silicon": Material(permittivity=11.7, permeability=1.0)},
         material_name="silicon",
@@ -507,7 +507,7 @@ def test_plot_material_all_types_objects():
 
     sphere = Sphere(
         name="sphere",
-        radius=0.5e-6,
+        radius=0.4e-6,  # 2*0.4e-6 / 40e-9 = 20 cells, matching the constraints below
         materials={"high_dielectric": Material(permittivity=9.0, permeability=1.0)},
         material_name="high_dielectric",
     )

--- a/tests/unit/fdtd/test_initialization.py
+++ b/tests/unit/fdtd/test_initialization.py
@@ -365,7 +365,7 @@ def test_resolve_static_shapes_grid_shape(simple_config, simple_volume, simple_m
     obj = UniformMaterialObject(name="obj1", partial_grid_shape=(10, 20, 30), material=simple_material)
     obj_map = {"volume": simple_volume, "obj1": obj}
     shape_dict = {"volume": [None, None, None], "obj1": [None, None, None]}
-    result = _resolve_static_shapes(obj_map, shape_dict, simple_config)
+    result, _ = _resolve_static_shapes(obj_map, shape_dict, simple_config)
     assert result["obj1"] == [10, 20, 30]
 
 
@@ -375,7 +375,7 @@ def test_resolve_static_shapes_real_shape(simple_material):
     obj = UniformMaterialObject(name="obj1", partial_real_shape=(5.0, 10.0, 15.0), material=simple_material)
     obj_map = {"volume": volume, "obj1": obj}
     shape_dict = {"volume": [None, None, None], "obj1": [None, None, None]}
-    result = _resolve_static_shapes(obj_map, shape_dict, config)
+    result, _ = _resolve_static_shapes(obj_map, shape_dict, config)
     # 5.0 / 0.5 = 10, 10.0 / 0.5 = 20, 15.0 / 0.5 = 30
     assert result["obj1"] == [10, 20, 30]
 
@@ -385,7 +385,7 @@ def test_resolve_static_shapes_no_shape(simple_config, simple_material):
     obj = UniformMaterialObject(name="obj1", material=simple_material)
     obj_map = {"volume": volume, "obj1": obj}
     shape_dict = {"volume": [None, None, None], "obj1": [None, None, None]}
-    result = _resolve_static_shapes(obj_map, shape_dict, simple_config)
+    result, _ = _resolve_static_shapes(obj_map, shape_dict, simple_config)
     # volume has grid shape, obj1 has nothing
     assert result["volume"] == [100, 100, 100]
     assert result["obj1"] == [None, None, None]

--- a/tests/unit/fdtd/test_initialization.py
+++ b/tests/unit/fdtd/test_initialization.py
@@ -365,7 +365,7 @@ def test_resolve_static_shapes_grid_shape(simple_config, simple_volume, simple_m
     obj = UniformMaterialObject(name="obj1", partial_grid_shape=(10, 20, 30), material=simple_material)
     obj_map = {"volume": simple_volume, "obj1": obj}
     shape_dict = {"volume": [None, None, None], "obj1": [None, None, None]}
-    result, _ = _resolve_static_shapes(obj_map, shape_dict, simple_config)
+    result = _resolve_static_shapes(obj_map, shape_dict, simple_config)
     assert result["obj1"] == [10, 20, 30]
 
 
@@ -375,7 +375,7 @@ def test_resolve_static_shapes_real_shape(simple_material):
     obj = UniformMaterialObject(name="obj1", partial_real_shape=(5.0, 10.0, 15.0), material=simple_material)
     obj_map = {"volume": volume, "obj1": obj}
     shape_dict = {"volume": [None, None, None], "obj1": [None, None, None]}
-    result, _ = _resolve_static_shapes(obj_map, shape_dict, config)
+    result = _resolve_static_shapes(obj_map, shape_dict, config)
     # 5.0 / 0.5 = 10, 10.0 / 0.5 = 20, 15.0 / 0.5 = 30
     assert result["obj1"] == [10, 20, 30]
 
@@ -385,7 +385,7 @@ def test_resolve_static_shapes_no_shape(simple_config, simple_material):
     obj = UniformMaterialObject(name="obj1", material=simple_material)
     obj_map = {"volume": volume, "obj1": obj}
     shape_dict = {"volume": [None, None, None], "obj1": [None, None, None]}
-    result, _ = _resolve_static_shapes(obj_map, shape_dict, simple_config)
+    result = _resolve_static_shapes(obj_map, shape_dict, simple_config)
     # volume has grid shape, obj1 has nothing
     assert result["volume"] == [100, 100, 100]
     assert result["obj1"] == [None, None, None]
@@ -854,6 +854,88 @@ def test_apply_size_constraint_conflicting_shape_raises(simple_config, simple_vo
     )
     with pytest.raises(Exception):
         _apply_size_constraint(c, obj_map, simple_config, shape_dict)
+
+
+def test_apply_size_constraint_conflicting_shape_raises_descriptive(simple_config, simple_volume, simple_material):
+    """SizeConstraint that conflicts with an already-set shape raises an informative error."""
+    obj = UniformMaterialObject(name="obj1", material=simple_material)
+    obj_map = {"volume": simple_volume, "obj1": obj}
+    shape_dict = {"volume": [100, 100, 100], "obj1": [60, None, None]}
+    c = SizeConstraint(
+        object="obj1",
+        other_object="volume",
+        axes=[0],
+        other_axes=[0],
+        proportions=[0.5],  # computes 50, but shape is already 60
+        grid_offsets=[0],
+        offsets=[None],
+    )
+    with pytest.raises(Exception, match="geometry"):
+        _apply_size_constraint(c, obj_map, simple_config, shape_dict)
+
+
+# ---------------------------------------------------------------------------
+# Cylinder __post_init__ — derived axis conflict tests
+# ---------------------------------------------------------------------------
+
+
+def test_cylinder_partial_grid_shape_on_derived_axis_raises(simple_material):
+    """Cylinder rejects partial_grid_shape for a cross-section axis at construction time."""
+    from fdtdx.objects.static_material.cylinder import Cylinder
+
+    materials = {"mat": simple_material}
+    with pytest.raises(Exception, match="derived from the radius"):
+        Cylinder(
+            name="cyl",
+            radius=5.0,
+            axis=2,
+            material_name="mat",
+            materials=materials,
+            partial_grid_shape=(10, None, None),
+        )
+
+
+def test_cylinder_partial_real_shape_on_derived_axis_raises(simple_material):
+    """Cylinder rejects partial_real_shape for a cross-section axis at construction time."""
+    from fdtdx.objects.static_material.cylinder import Cylinder
+
+    materials = {"mat": simple_material}
+    with pytest.raises(Exception, match="derived from the radius"):
+        Cylinder(
+            name="cyl",
+            radius=5.0,
+            axis=2,
+            material_name="mat",
+            materials=materials,
+            partial_real_shape=(8.0, None, None),
+        )
+
+
+def test_cylinder_sets_cross_section_from_radius(simple_material):
+    """Cylinder.__post_init__ fills partial_real_shape for cross-section axes from radius."""
+    from fdtdx.objects.static_material.cylinder import Cylinder
+
+    materials = {"mat": simple_material}
+    cyl = Cylinder(name="cyl", radius=5.0, axis=2, material_name="mat", materials=materials)
+    assert cyl.partial_real_shape[0] == pytest.approx(10.0)
+    assert cyl.partial_real_shape[1] == pytest.approx(10.0)
+    assert cyl.partial_real_shape[2] is None  # extrusion axis still free
+
+
+def test_cylinder_extrusion_axis_partial_real_shape_accepted(simple_material):
+    """Cylinder accepts partial_real_shape for the extrusion axis."""
+    from fdtdx.objects.static_material.cylinder import Cylinder
+
+    materials = {"mat": simple_material}
+    cyl = Cylinder(
+        name="cyl",
+        radius=5.0,
+        axis=2,
+        material_name="mat",
+        materials=materials,
+        partial_real_shape=(None, None, 20.0),
+    )
+    assert cyl.partial_real_shape[2] == pytest.approx(20.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/objects/static_material/test_cylinder.py
+++ b/tests/unit/objects/static_material/test_cylinder.py
@@ -195,3 +195,24 @@ class TestGetMaterialMapping:
         placed = _place(cyl, config, key, ((0, 10), (0, 10), (0, 5)))
         mapping = placed.get_material_mapping()
         assert bool(jnp.all(mapping == 0))
+
+
+# ---------------------------------------------------------------------------
+# partial_real_shape auto-compute
+# ---------------------------------------------------------------------------
+
+
+class TestAutoRealShape:
+    def test_cross_section_axes_set_to_diameter(self, two_materials):
+        axis_to_cross = {0: (1, 2), 1: (0, 2), 2: (0, 1)}
+        radius = 150e-9
+        for axis, (h, v) in axis_to_cross.items():
+            cyl = _make_cylinder(two_materials, axis=axis, radius=radius)
+            auto = cyl.get_geometry_size_hint()
+            assert auto[h] == pytest.approx(2.0 * radius)
+            assert auto[v] == pytest.approx(2.0 * radius)
+
+    def test_extrusion_axis_is_none(self, two_materials):
+        for axis in range(3):
+            cyl = _make_cylinder(two_materials, axis=axis)
+            assert cyl.get_geometry_size_hint()[axis] is None

--- a/tests/unit/objects/static_material/test_cylinder.py
+++ b/tests/unit/objects/static_material/test_cylinder.py
@@ -208,11 +208,10 @@ class TestAutoRealShape:
         radius = 150e-9
         for axis, (h, v) in axis_to_cross.items():
             cyl = _make_cylinder(two_materials, axis=axis, radius=radius)
-            auto = cyl.get_geometry_size_hint()
-            assert auto[h] == pytest.approx(2.0 * radius)
-            assert auto[v] == pytest.approx(2.0 * radius)
+            assert cyl.partial_real_shape[h] == pytest.approx(2.0 * radius)
+            assert cyl.partial_real_shape[v] == pytest.approx(2.0 * radius)
 
     def test_extrusion_axis_is_none(self, two_materials):
         for axis in range(3):
             cyl = _make_cylinder(two_materials, axis=axis)
-            assert cyl.get_geometry_size_hint()[axis] is None
+            assert cyl.partial_real_shape[axis] is None

--- a/tests/unit/objects/static_material/test_polygon.py
+++ b/tests/unit/objects/static_material/test_polygon.py
@@ -349,3 +349,34 @@ class TestExtrudedPolygonFromGdsPath:
             extruded_polygon_from_gds_path(
                 square_gds, "MISSING", layer=1, axis=2, material_name="si", materials=two_materials
             )
+
+
+# ---------------------------------------------------------------------------
+# partial_real_shape auto-compute
+# ---------------------------------------------------------------------------
+
+
+class TestAutoRealShape:
+    def test_cross_section_axes_set_from_vertices(self, two_materials):
+        verts = _square_vertices(half_side=100e-9)  # 200nm x 200nm bounding box
+        poly = _make_polygon(two_materials, axis=2, vertices=verts)
+        auto = poly.get_geometry_size_hint()
+        assert auto[0] == pytest.approx(200e-9)
+        assert auto[1] == pytest.approx(200e-9)
+
+    def test_extrusion_axis_is_none(self, two_materials):
+        for axis in range(3):
+            poly = _make_polygon(two_materials, axis=axis)
+            assert poly.get_geometry_size_hint()[axis] is None
+
+    def test_asymmetric_polygon_bounding_box(self, two_materials):
+        verts = np.array([[-150e-9, -50e-9], [150e-9, -50e-9], [150e-9, 50e-9], [-150e-9, 50e-9]])
+        poly = ExtrudedPolygon(
+            materials=two_materials,
+            axis=2,
+            material_name="si",
+            vertices=verts,
+        )
+        auto = poly.get_geometry_size_hint()
+        assert auto[0] == pytest.approx(300e-9)
+        assert auto[1] == pytest.approx(100e-9)

--- a/tests/unit/objects/static_material/test_polygon.py
+++ b/tests/unit/objects/static_material/test_polygon.py
@@ -360,14 +360,13 @@ class TestAutoRealShape:
     def test_cross_section_axes_set_from_vertices(self, two_materials):
         verts = _square_vertices(half_side=100e-9)  # 200nm x 200nm bounding box
         poly = _make_polygon(two_materials, axis=2, vertices=verts)
-        auto = poly.get_geometry_size_hint()
-        assert auto[0] == pytest.approx(200e-9)
-        assert auto[1] == pytest.approx(200e-9)
+        assert poly.partial_real_shape[0] == pytest.approx(200e-9)
+        assert poly.partial_real_shape[1] == pytest.approx(200e-9)
 
     def test_extrusion_axis_is_none(self, two_materials):
         for axis in range(3):
             poly = _make_polygon(two_materials, axis=axis)
-            assert poly.get_geometry_size_hint()[axis] is None
+            assert poly.partial_real_shape[axis] is None
 
     def test_asymmetric_polygon_bounding_box(self, two_materials):
         verts = np.array([[-150e-9, -50e-9], [150e-9, -50e-9], [150e-9, 50e-9], [-150e-9, 50e-9]])
@@ -377,6 +376,5 @@ class TestAutoRealShape:
             material_name="si",
             vertices=verts,
         )
-        auto = poly.get_geometry_size_hint()
-        assert auto[0] == pytest.approx(300e-9)
-        assert auto[1] == pytest.approx(100e-9)
+        assert poly.partial_real_shape[0] == pytest.approx(300e-9)
+        assert poly.partial_real_shape[1] == pytest.approx(100e-9)

--- a/tests/unit/objects/static_material/test_sphere.py
+++ b/tests/unit/objects/static_material/test_sphere.py
@@ -172,3 +172,24 @@ class TestGetMaterialMapping:
         placed = _place(sphere, config, key)
         mapping = placed.get_material_mapping()
         assert bool(jnp.all(mapping == mapping[0, 0, 0]))
+
+
+# ---------------------------------------------------------------------------
+# partial_real_shape auto-compute
+# ---------------------------------------------------------------------------
+
+
+class TestAutoRealShape:
+    def test_all_axes_set_to_diameter(self, two_materials):
+        radius = 200e-9
+        sphere = _make_sphere(two_materials, radius=radius)
+        auto = sphere.get_geometry_size_hint()
+        for ax in range(3):
+            assert auto[ax] == pytest.approx(2.0 * radius)
+
+    def test_per_axis_radii_override_default(self, two_materials):
+        sphere = _make_sphere(two_materials, radius=100e-9, radius_x=200e-9, radius_y=150e-9, radius_z=50e-9)
+        auto = sphere.get_geometry_size_hint()
+        assert auto[0] == pytest.approx(2 * 200e-9)
+        assert auto[1] == pytest.approx(2 * 150e-9)
+        assert auto[2] == pytest.approx(2 * 50e-9)

--- a/tests/unit/objects/static_material/test_sphere.py
+++ b/tests/unit/objects/static_material/test_sphere.py
@@ -175,7 +175,7 @@ class TestGetMaterialMapping:
 
 
 # ---------------------------------------------------------------------------
-# partial_real_shape auto-compute
+# partial_real_shape auto-derived via __post_init__
 # ---------------------------------------------------------------------------
 
 
@@ -183,13 +183,47 @@ class TestAutoRealShape:
     def test_all_axes_set_to_diameter(self, two_materials):
         radius = 200e-9
         sphere = _make_sphere(two_materials, radius=radius)
-        auto = sphere.get_geometry_size_hint()
         for ax in range(3):
-            assert auto[ax] == pytest.approx(2.0 * radius)
+            assert sphere.partial_real_shape[ax] == pytest.approx(2.0 * radius)
 
     def test_per_axis_radii_override_default(self, two_materials):
         sphere = _make_sphere(two_materials, radius=100e-9, radius_x=200e-9, radius_y=150e-9, radius_z=50e-9)
-        auto = sphere.get_geometry_size_hint()
-        assert auto[0] == pytest.approx(2 * 200e-9)
-        assert auto[1] == pytest.approx(2 * 150e-9)
-        assert auto[2] == pytest.approx(2 * 50e-9)
+        assert sphere.partial_real_shape[0] == pytest.approx(2 * 200e-9)
+        assert sphere.partial_real_shape[1] == pytest.approx(2 * 150e-9)
+        assert sphere.partial_real_shape[2] == pytest.approx(2 * 50e-9)
+
+
+# ---------------------------------------------------------------------------
+# Private shape fields (Sphere should not accept partial_real/grid_shape)
+# ---------------------------------------------------------------------------
+
+
+class TestPrivateShapeFields:
+    def test_partial_real_shape_not_a_constructor_param(self, two_materials):
+        """Sphere does not expose partial_real_shape in its __init__."""
+        with pytest.raises(TypeError):
+            Sphere(
+                materials=two_materials,
+                radius=200e-9,
+                material_name="si",
+                partial_real_shape=(400e-9, 400e-9, 400e-9),
+            )
+
+    def test_partial_grid_shape_not_a_constructor_param(self, two_materials):
+        """Sphere does not expose partial_grid_shape in its __init__."""
+        with pytest.raises(TypeError):
+            Sphere(
+                materials=two_materials,
+                radius=200e-9,
+                material_name="si",
+                partial_grid_shape=(10, 10, 10),
+            )
+
+    def test_partial_real_shape_is_derived_from_radius(self, two_materials):
+        """Sphere's partial_real_shape is set from radius, not left as UNDEFINED_SHAPE_3D."""
+        from fdtdx.typing import UNDEFINED_SHAPE_3D
+
+        sphere = _make_sphere(two_materials, radius=200e-9)
+        assert sphere.partial_real_shape != UNDEFINED_SHAPE_3D
+        assert all(v == pytest.approx(400e-9) for v in sphere.partial_real_shape)
+        assert sphere.partial_grid_shape == UNDEFINED_SHAPE_3D


### PR DESCRIPTION
Addresses https://github.com/ymahlau/fdtdx/issues/280
                                                                                                                                                                                                                    
## Summary                                                                                                                                                                                                                                
                                                                                                                                                                                                                                          
- Adds `get_geometry_size_hint()` to `StaticMultiMaterialObject` — subclasses return
- `Cylinder` fills the two cross-section axes from its `radius`; `Sphere` fills all three axes from its radius/per-axis radii; `ExtrudedPolygon` fills the two cross-section axes from the vertex bounding box. The extrusion axis remains `None` in all cases (still constraint-driven).                                                                                                                                          
- The initialization system (`_resolve_static_shapes`) collects these hints and tracks which `shape_dict` entries were auto-filled (`auto_shape_axes`). Explicit constraints always win: conflicts on auto-filled axes are silently resolved in favor of the constraint; conflicts on user-specified axes continue to raise `Inconsistent grid shape` errors as before.                                                                                                                                                       
                                                                                                                                                                                                                                          
Users can now write:                                                                                                                                                                                                                      
                                                                                                                                                                                                                                          
```python                                                                                                                                                                                                                                 
Cylinder(radius=100e-9, axis=2, material_name="core", materials=mats)                                                                                                                                                                     
```                                                                                                                                                                                                                                
instead of also supplying partial_real_shape=(200e-9, 200e-9, None).                                                                                                                                                                      
                                                                
Test plan                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                      
- New unit tests: TestAutoRealShape in test_cylinder.py, test_sphere.py, test_polygon.py
- New integration tests in test_constraint_placement.py covering Cylinder, Sphere, and ExtrudedPolygon without explicit partial_real_shape, plus a test verifying that an explicit constraint correctly overrides the auto-inferred size   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cylindrical, spherical, and extruded polygon shapes now automatically infer cross-section dimensions directly from their geometry parameters (radius values and vertex bounding boxes), eliminating the need for manual specification in most cases.

* **Improvements**
  * Enhanced error reporting for geometry constraint conflicts, providing clearer and more descriptive messages when dimension mismatches occur.

* **Tests**
  * Added comprehensive unit and integration test coverage for automatic shape dimension calculations and verification of constraint override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->