### PR TITLE
multi-frequency mode solving with continuity tracking in ModeOverlapDetector

### DIFF
--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -27,7 +27,6 @@ from fdtdx.core.jax.pytrees import (
 )
 from fdtdx.core.physics.losses import metric_efficiency
 from fdtdx.core.physics.metrics import (
-    bidirectional_mode_overlap,
     compute_energy,
     compute_poynting_flux,
     normalize_by_energy,
@@ -223,7 +222,6 @@ __all__ = [
     "WaveCharacter",
     "apply_params",
     "autoinit",
-    "bidirectional_mode_overlap",
     "boundary_objects_from_config",
     "calculate_sparam",
     "calculate_sparams",

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -32,7 +32,7 @@ from fdtdx.core.physics.metrics import (
     normalize_by_energy,
     normalize_by_poynting_flux,
 )
-from fdtdx.core.physics.modes import compute_mode, compute_modes_tracked
+from fdtdx.core.physics.modes import compute_mode
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.dispersion import (

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -27,12 +27,13 @@ from fdtdx.core.jax.pytrees import (
 )
 from fdtdx.core.physics.losses import metric_efficiency
 from fdtdx.core.physics.metrics import (
+    bidirectional_mode_overlap,
     compute_energy,
     compute_poynting_flux,
     normalize_by_energy,
     normalize_by_poynting_flux,
 )
-from fdtdx.core.physics.modes import compute_mode
+from fdtdx.core.physics.modes import compute_mode, compute_modes_multi_freq
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.dispersion import (
@@ -222,6 +223,7 @@ __all__ = [
     "WaveCharacter",
     "apply_params",
     "autoinit",
+    "bidirectional_mode_overlap",
     "boundary_objects_from_config",
     "calculate_sparam",
     "calculate_sparams",
@@ -230,6 +232,7 @@ __all__ = [
     "compute_eps_spectrum_from_coefficients",
     "compute_impedance_corrected_temporal_profile",
     "compute_mode",
+    "compute_modes_multi_freq",
     "compute_pole_coefficients",
     "compute_poynting_flux",
     "constants",

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -33,7 +33,7 @@ from fdtdx.core.physics.metrics import (
     normalize_by_energy,
     normalize_by_poynting_flux,
 )
-from fdtdx.core.physics.modes import compute_mode, compute_modes_multi_freq
+from fdtdx.core.physics.modes import compute_mode
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.dispersion import (
@@ -232,7 +232,6 @@ __all__ = [
     "compute_eps_spectrum_from_coefficients",
     "compute_impedance_corrected_temporal_profile",
     "compute_mode",
-    "compute_modes_multi_freq",
     "compute_pole_coefficients",
     "compute_poynting_flux",
     "constants",

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -32,7 +32,7 @@ from fdtdx.core.physics.metrics import (
     normalize_by_energy,
     normalize_by_poynting_flux,
 )
-from fdtdx.core.physics.modes import compute_mode_multiple_frequencies, compute_mode_one_frequency
+from fdtdx.core.physics.modes import compute_mode
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.dispersion import (
@@ -229,8 +229,7 @@ __all__ = [
     "compute_energy",
     "compute_eps_spectrum_from_coefficients",
     "compute_impedance_corrected_temporal_profile",
-    "compute_mode_multiple_frequencies",
-    "compute_mode_one_frequency",
+    "compute_mode",
     "compute_pole_coefficients",
     "compute_poynting_flux",
     "constants",

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -32,7 +32,7 @@ from fdtdx.core.physics.metrics import (
     normalize_by_energy,
     normalize_by_poynting_flux,
 )
-from fdtdx.core.physics.modes import compute_mode
+from fdtdx.core.physics.modes import compute_mode_multiple_frequencies, compute_mode_one_frequency
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.dispersion import (
@@ -229,7 +229,8 @@ __all__ = [
     "compute_energy",
     "compute_eps_spectrum_from_coefficients",
     "compute_impedance_corrected_temporal_profile",
-    "compute_mode",
+    "compute_mode_multiple_frequencies",
+    "compute_mode_one_frequency",
     "compute_pole_coefficients",
     "compute_poynting_flux",
     "constants",

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -32,7 +32,7 @@ from fdtdx.core.physics.metrics import (
     normalize_by_energy,
     normalize_by_poynting_flux,
 )
-from fdtdx.core.physics.modes import compute_mode
+from fdtdx.core.physics.modes import compute_mode, compute_modes_tracked
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.dispersion import (

--- a/src/fdtdx/core/grid.py
+++ b/src/fdtdx/core/grid.py
@@ -535,23 +535,15 @@ class RectilinearGrid(TreeClass):
         Returns:
             ``(area_EuHv, area_EvHu)`` each broadcast to the 3D slice shape.
         """
-        u, v = [a for a in range(3) if a != propagation_axis]
+        u, v = [(1, 2), (2, 0), (0, 1)][propagation_axis]
         u_lo, u_hi = slice_tuple[u]
         v_lo, v_hi = slice_tuple[v]
-
-        primal_u = self.cell_widths(u)[u_lo:u_hi]
-        primal_v = self.cell_widths(v)[v_lo:v_hi]
-        dual_u = self.dual_widths(u, u_lo, u_hi)
-        dual_v = self.dual_widths(v, v_lo, v_hi)
-
-        def _broadcast(a1d_row, a1d_col):
-            area_2d = a1d_row[:, None] * a1d_col[None, :]
-            shape = [1, 1, 1]
-            shape[u] = area_2d.shape[0]
-            shape[v] = area_2d.shape[1]
-            return area_2d.reshape(shape)
-
-        return _broadcast(primal_u, dual_v), _broadcast(dual_u, primal_v)
+        return yee_face_areas_from_edges(
+            edges_u=self.edges(u)[u_lo : u_hi + 1],
+            edges_v=self.edges(v)[v_lo : v_hi + 1],
+            u_axis=u,
+            v_axis=v,
+        )
 
     def cell_volume(self, slice_tuple: tuple[tuple[int, int], tuple[int, int], tuple[int, int]]) -> jax.Array:
         """Return per-cell volume weights broadcast to a 3D slice shape."""
@@ -559,6 +551,52 @@ class RectilinearGrid(TreeClass):
         y0, y1 = slice_tuple[1]
         z0, z1 = slice_tuple[2]
         return self.dx[x0:x1, None, None] * self.dy[None, y0:y1, None] * self.dz[None, None, z0:z1]
+
+
+def yee_face_areas_from_edges(
+    edges_u: jax.Array,
+    edges_v: jax.Array,
+    u_axis: int,
+    v_axis: int,
+    dtype: jnp.dtype | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    """Return Yee-staggered face-area arrays from physical edge coordinates.
+
+    Computes the same quantities as :meth:`RectilinearGrid.yee_face_areas` but
+    accepts raw edge arrays rather than a grid slice, which is necessary when
+    a full ``RectilinearGrid`` is not available (e.g. inside the mode solver).
+
+    Args:
+        edges_u: Edge coordinates (m) along the u transverse axis, length ``n_u + 1``.
+        edges_v: Edge coordinates (m) along the v transverse axis, length ``n_v + 1``.
+        u_axis: Physical axis index (0/1/2) for the u direction.
+        v_axis: Physical axis index (0/1/2) for the v direction.
+        dtype: Optional output dtype; defaults to the input array dtype.
+
+    Returns:
+        ``(area_EuHv, area_EvHu)`` broadcast-ready to a 3D spatial shape with a
+        singleton along the propagation axis.
+    """
+    edges_u = jnp.asarray(edges_u)
+    edges_v = jnp.asarray(edges_v)
+
+    primal_u = jnp.diff(edges_u)
+    primal_v = jnp.diff(edges_v)
+    centers_u = 0.5 * (edges_u[:-1] + edges_u[1:])
+    centers_v = 0.5 * (edges_v[:-1] + edges_v[1:])
+    # Boundary dual width: distance from first edge to first cell center (same rule as dual_widths at lo=0)
+    dual_u = jnp.concatenate([jnp.array([centers_u[0] - edges_u[0]]), jnp.diff(centers_u)])
+    dual_v = jnp.concatenate([jnp.array([centers_v[0] - edges_v[0]]), jnp.diff(centers_v)])
+
+    def _broadcast(a1d: jax.Array, axis: int) -> jax.Array:
+        shape = [1, 1, 1]
+        shape[axis] = a1d.shape[0]
+        arr = a1d.reshape(shape)
+        return arr.astype(dtype) if dtype is not None else arr
+
+    area_EuHv = _broadcast(primal_u, u_axis) * _broadcast(dual_v, v_axis)
+    area_EvHu = _broadcast(dual_u, u_axis) * _broadcast(primal_v, v_axis)
+    return area_EuHv, area_EvHu
 
 
 def calculate_spatial_offsets_yee() -> tuple[jax.Array, jax.Array]:

--- a/src/fdtdx/core/grid.py
+++ b/src/fdtdx/core/grid.py
@@ -487,6 +487,72 @@ class RectilinearGrid(TreeClass):
         shape[transverse_axes[1]] = area_2d.shape[1]
         return area_2d.reshape(shape)
 
+    def dual_widths(self, axis: int, lo: int, hi: int) -> jax.Array:
+        """Return dual-mesh cell widths for ``axis[lo:hi]``.
+
+        On a Yee grid the dual mesh is centred on primal cell edges.  Dual
+        width at index ``i`` is the distance between the centres of primal
+        cells ``i-1`` and ``i``.  At the domain boundary the adjacent primal
+        width is used as a zero-order approximation.
+
+        Args:
+            axis: Grid axis.
+            lo: Lower edge index of the slice.
+            hi: Upper edge index of the slice (exclusive).
+
+        Returns:
+            Array of dual widths with shape ``(hi - lo,)``.
+        """
+        edges = self.edges(axis)
+        # cell centers for the full domain
+        centers = 0.5 * (edges[:-1] + edges[1:])
+        left = edges[lo] if lo == 0 else centers[lo - 1]
+        dual = jnp.concatenate(
+            [
+                jnp.asarray([centers[lo] - left]),
+                centers[lo + 1 : hi] - centers[lo : hi - 1],
+            ]
+        )
+        return dual
+
+    def yee_face_areas(
+        self, propagation_axis: int, slice_tuple: tuple[tuple[int, int], tuple[int, int], tuple[int, int]]
+    ) -> tuple[jax.Array, jax.Array]:
+        """Return the two Yee-staggered face-area weight arrays for a detector plane.
+
+        On the Yee lattice the two tangential field cross-terms sit at different
+        physical locations and require different area elements on non-uniform grids:
+
+        * ``area_EuHv[i, j] = primal_u[i] * dual_v[j]``  — for the Eu x Hv term
+        * ``area_EvHu[i, j] = dual_u[i] * primal_v[j]``  — for the Ev x Hu term
+
+        On a uniform grid both arrays are identical and equal to ``dx * dy``.
+
+        Args:
+            propagation_axis: Normal axis of the detector plane.
+            slice_tuple: Grid slice of the detector.
+
+        Returns:
+            ``(area_EuHv, area_EvHu)`` each broadcast to the 3D slice shape.
+        """
+        u, v = [a for a in range(3) if a != propagation_axis]
+        u_lo, u_hi = slice_tuple[u]
+        v_lo, v_hi = slice_tuple[v]
+
+        primal_u = self.cell_widths(u)[u_lo:u_hi]
+        primal_v = self.cell_widths(v)[v_lo:v_hi]
+        dual_u = self.dual_widths(u, u_lo, u_hi)
+        dual_v = self.dual_widths(v, v_lo, v_hi)
+
+        def _broadcast(a1d_row, a1d_col):
+            area_2d = a1d_row[:, None] * a1d_col[None, :]
+            shape = [1, 1, 1]
+            shape[u] = area_2d.shape[0]
+            shape[v] = area_2d.shape[1]
+            return area_2d.reshape(shape)
+
+        return _broadcast(primal_u, dual_v), _broadcast(dual_u, primal_v)
+
     def cell_volume(self, slice_tuple: tuple[tuple[int, int], tuple[int, int], tuple[int, int]]) -> jax.Array:
         """Return per-cell volume weights broadcast to a 3D slice shape."""
         x0, x1 = slice_tuple[0]

--- a/src/fdtdx/core/physics/metrics.py
+++ b/src/fdtdx/core/physics/metrics.py
@@ -122,6 +122,8 @@ def normalize_by_poynting_flux(
     H: jax.Array,
     axis: int,
     area_weights: jax.Array | None = None,
+    area_EuHv: jax.Array | None = None,
+    area_EvHu: jax.Array | None = None,
 ) -> tuple[jax.Array, jax.Array]:
     """Normalize fields so the integrated Poynting flux along ``axis`` is one.
 
@@ -129,21 +131,30 @@ def normalize_by_poynting_flux(
         E: Electric field array with component axis first.
         H: Magnetic field array with component axis first.
         axis: Physical propagation axis whose Poynting component is integrated.
-        area_weights: Optional detector-plane area weights broadcastable to
-            ``E[axis]``.  Uniform-grid callers may omit this for the historical
-            raw-sum normalization; non-uniform callers should provide weights so
-            refinement alone does not change the normalization.
+        area_weights: Single area-weight array for both Poynting cross-terms.
+            Used on uniform grids where both Yee positions share the same area.
+            Ignored when ``area_EuHv`` is provided.
+        area_EuHv: Yee-staggered area for the Eu x Hv cross-term.  When
+            provided, enables the Yee-split power computation that is consistent
+            with :func:`bidirectional_mode_overlap`.
+        area_EvHu: Yee-staggered area for the Ev x Hu cross-term.  Defaults to
+            ``area_EuHv`` when ``None``.
     """
-    # Compute Poynting vector components
-    S_complex = jnp.cross(jnp.conj(E), H, axisa=0, axisb=0, axisc=0)
-    S_real = 0.5 * jnp.real(S_complex[axis])  # power flow in desired direction
-    if area_weights is not None:
-        S_real = S_real * area_weights
+    if area_EuHv is not None:
+        # Yee-split path: use separate area weights for each cross-term so that
+        # the power estimate is consistent with bidirectional_mode_overlap.
+        u, v = [(1, 2), (2, 0), (0, 1)][axis]
+        _area_EvHu = area_EvHu if area_EvHu is not None else area_EuHv
+        S_EuHv = 0.5 * jnp.real(jnp.conj(E[u]) * H[v]) * area_EuHv
+        S_EvHu = 0.5 * jnp.real(jnp.conj(E[v]) * H[u]) * _area_EvHu
+        power = jnp.abs(jnp.sum(S_EuHv - S_EvHu))
+    else:
+        S_complex = jnp.cross(jnp.conj(E), H, axisa=0, axisb=0, axisc=0)
+        S_real = 0.5 * jnp.real(S_complex[axis])
+        if area_weights is not None:
+            S_real = S_real * area_weights
+        power = jnp.abs(jnp.sum(S_real))
 
-    # Integrate over transverse plane (axis orthogonal to `axis`)
-    power = jnp.abs(jnp.sum(S_real))
-
-    # Normalize
     norm_factor = jnp.sqrt(power)
     E_norm = E / norm_factor
     H_norm = H / norm_factor

--- a/src/fdtdx/core/physics/metrics.py
+++ b/src/fdtdx/core/physics/metrics.py
@@ -150,6 +150,60 @@ def normalize_by_poynting_flux(
     return E_norm, H_norm
 
 
+def bidirectional_mode_overlap(
+    mode_E: jax.Array,
+    mode_H: jax.Array,
+    sim_E: jax.Array,
+    sim_H: jax.Array,
+    propagation_axis: int,
+    area_EuHv: jax.Array | None = None,
+    area_EvHu: jax.Array | None = None,
+) -> jax.Array:
+    """Compute the bidirectional mode-overlap integral.
+
+    Returns ``sum((mode_E x sim_H* + sim_E* x mode_H) · ẑ * dA)``, where ẑ is
+    the unit vector along ``propagation_axis``.
+
+    On a Yee lattice the cross product decomposes into two independent terms
+    that sit at different spatial locations and therefore require separate area
+    weights on non-uniform grids:
+
+    * ``(mode_Eu x sim_Hv* + sim_Eu* x mode_Hv) * area_EuHv``
+    * ``-(mode_Ev x sim_Hu* + sim_Ev* x mode_Hu) * area_EvHu``
+
+    where ``(u, v)`` are the two transverse axes.  On a uniform grid
+    ``area_EuHv == area_EvHu`` and a single weight is sufficient.
+
+    Args:
+        mode_E: Mode electric field, shape ``(3, *spatial)``.
+        mode_H: Mode magnetic field, shape ``(3, *spatial)``.
+        sim_E: Simulation phasor electric field, shape ``(3, *spatial)``.
+        sim_H: Simulation phasor magnetic field, shape ``(3, *spatial)``.
+        propagation_axis: Physical axis (0, 1, or 2) of mode propagation.
+        area_EuHv: Per-cell area for the Eu/Hv cross term.  ``None`` treats
+            every cell as having unit area (uniform-grid raw sum).
+        area_EvHu: Per-cell area for the Ev/Hu cross term.  Defaults to
+            ``area_EuHv`` when ``None``.
+
+    Returns:
+        Complex scalar overlap coefficient (before the 1/4 prefactor).
+    """
+    # cyclic transverse axes for the given propagation axis
+    u, v = [(1, 2), (2, 0), (0, 1)][propagation_axis]
+
+    EuHv = mode_E[u] * jnp.conj(sim_H[v]) + jnp.conj(sim_E[u]) * mode_H[v]
+    EvHu = mode_E[v] * jnp.conj(sim_H[u]) + jnp.conj(sim_E[v]) * mode_H[u]
+
+    if area_EuHv is not None:
+        EuHv = EuHv * area_EuHv
+    if area_EvHu is not None:
+        EvHu = EvHu * area_EvHu
+    elif area_EuHv is not None:
+        EvHu = EvHu * area_EuHv
+
+    return jnp.sum(EuHv - EvHu)
+
+
 def resample_to_uniform_2d(
     field: jax.Array,
     x_centers: jax.Array,

--- a/src/fdtdx/core/physics/metrics.py
+++ b/src/fdtdx/core/physics/metrics.py
@@ -133,13 +133,16 @@ def normalize_by_poynting_flux(
         axis: Physical propagation axis whose Poynting component is integrated.
         area_weights: Single area-weight array for both Poynting cross-terms.
             Used on uniform grids where both Yee positions share the same area.
-            Ignored when ``area_EuHv`` is provided.
+            Mutually exclusive with ``area_EuHv``.
         area_EuHv: Yee-staggered area for the Eu x Hv cross-term.  When
             provided, enables the Yee-split power computation that is consistent
-            with :func:`bidirectional_mode_overlap`.
+            with :func:`bidirectional_mode_overlap`.  Mutually exclusive with
+            ``area_weights``.
         area_EvHu: Yee-staggered area for the Ev x Hu cross-term.  Defaults to
             ``area_EuHv`` when ``None``.
     """
+    if area_EuHv is not None and area_weights is not None:
+        raise ValueError("area_weights and area_EuHv are mutually exclusive")
     if area_EuHv is not None:
         # Yee-split path: use separate area weights for each cross-term so that
         # the power estimate is consistent with bidirectional_mode_overlap.
@@ -172,15 +175,16 @@ def bidirectional_mode_overlap(
 ) -> jax.Array:
     """Compute the bidirectional mode-overlap integral.
 
-    Returns ``sum((mode_E x sim_H* + sim_E* x mode_H) · ẑ * dA)``, where ẑ is
-    the unit vector along ``propagation_axis``.
+    Returns ``0.25 * sum((mode_E* x sim_H + sim_E x mode_H*) · ẑ * dA)``, where ẑ is
+    the unit vector along ``propagation_axis``.  The mode fields are conjugated,
+    matching tidy3d's ``_dot_numpy(conjugate=True)`` convention exactly.
 
     On a Yee lattice the cross product decomposes into two independent terms
     that sit at different spatial locations and therefore require separate area
     weights on non-uniform grids:
 
-    * ``(mode_Eu x sim_Hv* + sim_Eu* x mode_Hv) * area_EuHv``
-    * ``-(mode_Ev x sim_Hu* + sim_Ev* x mode_Hu) * area_EvHu``
+    * ``(conj(mode_Eu) * sim_Hv + sim_Eu * conj(mode_Hv)) * area_EuHv``
+    * ``-(conj(mode_Ev) * sim_Hu + sim_Ev * conj(mode_Hu)) * area_EvHu``
 
     where ``(u, v)`` are the two transverse axes.  On a uniform grid
     ``area_EuHv == area_EvHu`` and a single weight is sufficient.
@@ -194,16 +198,20 @@ def bidirectional_mode_overlap(
         area_EuHv: Per-cell area for the Eu/Hv cross term.  ``None`` treats
             every cell as having unit area (uniform-grid raw sum).
         area_EvHu: Per-cell area for the Ev/Hu cross term.  Defaults to
-            ``area_EuHv`` when ``None``.
+            ``area_EuHv`` when ``None``.  Must not be set without ``area_EuHv``.
 
     Returns:
-        Complex scalar overlap coefficient (before the 1/4 prefactor).
+        Complex scalar overlap coefficient.  Equals 1 for a self-overlap of a
+        unit-power-normalised mode, matching the tidy3d ``_dot_numpy`` convention.
     """
+    if area_EvHu is not None and area_EuHv is None:
+        raise ValueError("area_EvHu requires area_EuHv to also be provided")
+
     # cyclic transverse axes for the given propagation axis
     u, v = [(1, 2), (2, 0), (0, 1)][propagation_axis]
 
-    EuHv = mode_E[u] * jnp.conj(sim_H[v]) + jnp.conj(sim_E[u]) * mode_H[v]
-    EvHu = mode_E[v] * jnp.conj(sim_H[u]) + jnp.conj(sim_E[v]) * mode_H[u]
+    EuHv = jnp.conj(mode_E[u]) * sim_H[v] + sim_E[u] * jnp.conj(mode_H[v])
+    EvHu = jnp.conj(mode_E[v]) * sim_H[u] + sim_E[v] * jnp.conj(mode_H[u])
 
     if area_EuHv is not None:
         EuHv = EuHv * area_EuHv
@@ -212,7 +220,7 @@ def bidirectional_mode_overlap(
     elif area_EuHv is not None:
         EvHu = EvHu * area_EuHv
 
-    return jnp.sum(EuHv - EvHu)
+    return 0.25 * jnp.sum(EuHv - EvHu)
 
 
 def resample_to_uniform_2d(

--- a/src/fdtdx/core/physics/metrics.py
+++ b/src/fdtdx/core/physics/metrics.py
@@ -176,8 +176,7 @@ def bidirectional_mode_overlap(
     """Compute the bidirectional mode-overlap integral.
 
     Returns ``0.25 * sum((mode_E* x sim_H + sim_E x mode_H*) · ẑ * dA)``, where ẑ is
-    the unit vector along ``propagation_axis``.  The mode fields are conjugated,
-    matching tidy3d's ``_dot_numpy(conjugate=True)`` convention exactly.
+    the unit vector along ``propagation_axis``.
 
     On a Yee lattice the cross product decomposes into two independent terms
     that sit at different spatial locations and therefore require separate area
@@ -202,7 +201,7 @@ def bidirectional_mode_overlap(
 
     Returns:
         Complex scalar overlap coefficient.  Equals 1 for a self-overlap of a
-        unit-power-normalised mode, matching the tidy3d ``_dot_numpy`` convention.
+        unit-power-normalised mode.
     """
     if area_EvHu is not None and area_EuHv is None:
         raise ValueError("area_EvHu requires area_EuHv to also be provided")

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -29,19 +29,115 @@ Attributes:
 
 
 def _perm_mode_E(m: ModeTupleType, propagation_axis: int, dtype) -> np.ndarray:
-    """Permute tidy3d mode E-field components into fdtdx physical axis order.
-
-    tidy3d always places propagation along z; this maps fields to the fdtdx
-    convention where the propagation axis may be 0, 1, or 2.  Returns a
-    (3, n0, n1) array — the propagation-axis singleton is NOT included here;
-    callers that need the full 4-D shape should add it with ``np.expand_dims``.
-    """
+    """Permute tidy3d E-field into fdtdx axis order. Returns (3, n0, n1) without propagation singleton."""
     if propagation_axis == 0:
         return np.stack([m.Ez, m.Ex, m.Ey], axis=0).astype(dtype)
     elif propagation_axis == 1:
         return np.stack([m.Ex, m.Ez, m.Ey], axis=0).astype(dtype)
     else:
         return np.stack([m.Ex, m.Ey, m.Ez], axis=0).astype(dtype)
+
+
+def _perm_mode_H(m: ModeTupleType, propagation_axis: int, dtype) -> np.ndarray:
+    """Permute tidy3d H-field into fdtdx axis order. Returns (3, n0, n1) without propagation singleton."""
+    if propagation_axis == 0:
+        return np.stack([m.Hz, m.Hx, m.Hy], axis=0).astype(dtype)
+    elif propagation_axis == 1:
+        return -np.stack([m.Hx, m.Hz, m.Hy], axis=0).astype(dtype)
+    else:
+        return np.stack([m.Hx, m.Hy, m.Hz], axis=0).astype(dtype)
+
+
+def _axis_perm_indices(propagation_axis: int) -> tuple[list[int], list[int]]:
+    """Component permutation indices for rotating into tidy3d's z-propagation frame."""
+    return [
+        ([1, 2, 0], [4, 5, 3, 7, 8, 6, 1, 2, 0]),  # x-propagation
+        ([0, 2, 1], [0, 2, 1, 6, 8, 7, 3, 5, 4]),  # y-propagation
+        ([0, 1, 2], [0, 1, 2, 3, 4, 5, 6, 7, 8]),  # z-propagation
+    ][propagation_axis]
+
+
+def _prepare_permittivity(
+    inv_perm: np.ndarray,
+    propagation_axis: int,
+    perm_idx: list[int],
+    perm_idx_9: list[int],
+) -> np.ndarray:
+    """Invert, squeeze the propagation axis, and rotate into tidy3d's z-propagation frame.
+
+    Input: (K, nx, ny, nz) with K ∈ {1, 3, 9} and exactly one spatial dim == 1.
+    Output: (K, n0, n1) — the two non-propagation transverse dimensions.
+    """
+    if inv_perm.shape[0] == 9:
+        m = inv_perm.reshape(3, 3, *inv_perm.shape[1:])
+        fwd, back = (2, 3, 4, 0, 1), (3, 4, 0, 1, 2)
+        perm = np.linalg.inv(m.transpose(fwd)).transpose(back).reshape(9, *inv_perm.shape[1:])
+    else:
+        perm = 1.0 / inv_perm
+    sq = np.asarray(np.squeeze(perm, axis=propagation_axis + 1))
+    if sq.shape[0] == 3:
+        return sq[perm_idx, :, :]
+    if sq.shape[0] == 9:
+        return sq[perm_idx_9, :, :]
+    return sq
+
+
+def _process_permeability(
+    inv_permeabilities: jax.Array | float,
+    propagation_axis: int,
+    perm_idx: list[int],
+    perm_idx_9: list[int],
+) -> jax.Array | float:
+    """Invert, squeeze, and rotate permeability in JAX (runs outside callback, frequency-independent)."""
+    if not (isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0):
+        return 1.0 / inv_permeabilities
+    if inv_permeabilities.shape[0] == 9:
+        mu = expand_to_3x3(inv_permeabilities)
+        fwd, back = (2, 3, 4, 0, 1), (3, 4, 0, 1, 2)
+        perms = jnp.linalg.inv(mu.transpose(fwd)).transpose(back).reshape(9, *inv_permeabilities.shape[1:])
+    else:
+        perms = 1.0 / inv_permeabilities
+    sq = jnp.take(perms, indices=0, axis=propagation_axis + 1)
+    if sq.shape[0] == 3:
+        return sq[jnp.array(perm_idx)]
+    if sq.shape[0] == 9:
+        return sq[jnp.array(perm_idx_9)]
+    return sq
+
+
+def _build_transverse_coords(
+    sample_shape: tuple[int, ...],
+    propagation_axis: int,
+    other_axes: list[int],
+    resolution: float | None,
+    transverse_coords: Sequence[jax.Array] | None,
+    dtype: jnp.dtype,
+) -> tuple[jax.Array, jax.Array, jax.Array | None, jax.Array | None]:
+    """Build tidy3d coordinate arrays (µm) and optional Yee area weights.
+
+    Returns (c0_um, c1_um, area_EuHv, area_EvHu); area_* are None on uniform grids.
+    """
+    if transverse_coords is None:
+        if resolution is None:
+            raise ValueError("resolution is required when transverse_coords is not provided")
+        c0_um = jnp.asarray(np.arange(sample_shape[other_axes[0]] + 1) * resolution / 1e-6)
+        c1_um = jnp.asarray(np.arange(sample_shape[other_axes[1]] + 1) * resolution / 1e-6)
+        return c0_um, c1_um, None, None
+
+    if len(transverse_coords) != 2:
+        raise ValueError(f"transverse_coords must have exactly 2 arrays, got {len(transverse_coords)}")
+    for i, (coord, expected) in enumerate(zip(transverse_coords, [sample_shape[a] + 1 for a in other_axes])):
+        if coord.ndim != 1 or coord.shape[0] != expected:
+            raise ValueError(f"transverse_coords[{i}] must be 1D with length {expected}, got {coord.shape}")
+
+    c0_um = jnp.asarray(transverse_coords[0]) / 1e-6
+    c1_um = jnp.asarray(transverse_coords[1]) / 1e-6
+    u, v = [(1, 2), (2, 0), (0, 1)][propagation_axis]
+    phys_axis_0 = other_axes[0] - 1
+    edges_u = jnp.asarray(transverse_coords[0] if phys_axis_0 == u else transverse_coords[1])
+    edges_v = jnp.asarray(transverse_coords[1] if phys_axis_0 == u else transverse_coords[0])
+    area_EuHv, area_EvHu = yee_face_areas_from_edges(edges_u=edges_u, edges_v=edges_v, u_axis=u, v_axis=v, dtype=dtype)
+    return c0_um, c1_um, area_EuHv, area_EvHu
 
 
 def compute_mode_polarization_fraction(
@@ -108,8 +204,8 @@ def sort_modes(
 
 
 def compute_mode(
-    frequency: float,
-    inv_permittivities: jax.Array,  # shape (nx, ny, nz)
+    frequency: float | list[float],
+    inv_permittivities: jax.Array,
     inv_permeabilities: jax.Array | float,
     resolution: float | None = None,
     direction: Literal["+", "-"] = "+",
@@ -122,466 +218,105 @@ def compute_mode(
     transverse_coords: Sequence[jax.Array] | None = None,
     target_neff: float | None = None,
     reference_E: np.ndarray | None = None,
-) -> tuple[
-    jax.Array,  # E
-    jax.Array,  # H
-    jax.Array,  # complex effective index
-]:
+) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Compute optical modes of a waveguide cross-section.
 
-    This function uses the Tidy3D mode solver to compute the optical modes of a given waveguide cross-section defined
-    by its permittivity distribution.
+    Scalar ``frequency`` with ``inv_permittivities`` shape ``(K, nx, ny, nz)`` returns
+    ``(mode_E, mode_H, neff)`` with shapes ``(3, nx, ny, nz)`` and scalar ``neff``.
 
-    By default modes are sorted by their effective index. The mode_index argument indexes this sorted list of modes and
-    returns the desired mode. With filter_pol, it is also possible to only index a specific polarization.
+    List ``frequency`` with ``inv_permittivities`` shape ``(N, K, nx, ny, nz)`` returns
+    stacked ``(mode_Es, mode_Hs, neffs)`` with shapes ``(N, 3, nx, ny, nz)`` and ``(N,)``.
+    Field-overlap tracking runs automatically between consecutive frequencies, preventing
+    mode hopping at neff branch crossings.
 
-    Args:
-        frequency (float): Operating frequency in Hz
-        inv_permittivities (jax.Array): 3D array of inverse relative permittivity values
-        inv_permeabilities (jax.Array | float): 3D array of inverse relative permittivity values or single float for
-            uniform permeability distribution.
-        resolution (float | None): Uniform-grid spacing in metres. Required when ``transverse_coords`` is not
-            provided (uniform-grid path). Ignored when ``transverse_coords`` is given. Defaults to None.
-        direction (Literal["+", "-"]): Propagation direction, either "+" or "-".
-        mode_index (int, optional): Index of the mode to compute. Defaults to 0.
-        filter_pol (Literal["te", "tm"] | None, optional). If not None, modes are filtered by polarization.
-        dtype (jnp.dtype, optional): Float dtype of the simulation. Controls whether mode fields are returned
-            as complex64 (float32) or complex128 (float64). Defaults to jnp.float32.
-        bend_radius (float | None, optional): Bend radius of the waveguide in meters. Must be set together with
-            bend_axis. When set, the mode solver uses a conformal transformation to account for the bend. Defaults to
-            None (straight waveguide).
-        bend_axis (int | None, optional): Physical axis index (0/1/2) pointing from the waveguide toward the center
-            of curvature. Must differ from the propagation axis. Required when bend_radius is set. Defaults to None.
-        symmetry (tuple[int, int], optional): Symmetry-plane condition at the *min* edge of each transverse axis,
-            in the order of the two non-propagation physical axes (increasing index). ``0`` imposes a PEC mirror
-            (electric wall — the tidy3d default), ``1`` imposes a PMC mirror (magnetic wall). Use this when the
-            waveguide sits on a symmetry plane of a reduced (half/quarter) domain so the mode solver reproduces the
-            same boundary the FDTD uses there. For a +x-propagating TE mode on a y/z quarter domain with PEC at y=0
-            and PMC at the z Si-mid plane, pass ``(0, 1)``. Defaults to ``(0, 0)`` (PEC on both, i.e. no symmetry).
-        transverse_coords: Optional pair of physical edge-coordinate arrays, in metres, for the two axes transverse
-            to propagation. Each array must have one more entry than the corresponding transverse cell count.
-            When provided, the Tidy3D mode solver receives the non-uniform rectilinear grid directly.
-            JAX arrays are accepted; the numpy conversion happens inside the tidy3d callback so the function
-            remains compatible with ``jax.jit``.
-        target_neff: When set, selects the mode whose ``real(neff)`` is closest to this
-            value.  Useful for picking a specific mode by effective index at a single
-            frequency.  Overridden by ``reference_E`` when both are provided.
-        reference_E: When set, selects the mode with the highest field dot-product overlap
-            with this reference electric field (shape ``(3, nx, ny, nz)`` in fdtdx axis
-            order, with the propagation-axis dimension equal to 1).  Takes full precedence
-            over both ``target_neff`` and ``mode_index``.  Pass ``np.array(mode_E)`` from
-            the previous frequency's call to track the same physical mode across a sweep.
-
-    Returns:
-        Tuple[jax.Array, jax.Array, jax.Array]:
-            Tuple of (E field, H field, effective index) as complex-valued jax arrays.
-            Fields are Poynting-flux normalised to unit power.
-    """
-    # Input validation
-    if (
-        not (inv_permittivities.ndim == 4 and inv_permittivities.shape[0] in [1, 3, 9])
-        or sum(dim == 1 for dim in inv_permittivities.shape[1:]) != 1
-    ):
-        raise Exception(f"Invalid shape of inv_permittivities: {inv_permittivities.shape}")
-    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
-        if (
-            not (inv_permeabilities.ndim == 4 and inv_permeabilities.shape[0] in [1, 3, 9])
-            or sum(dim == 1 for dim in inv_permeabilities.shape[1:]) != 1
-        ):
-            raise Exception(f"Invalid shape of inv_permeabilities: {inv_permeabilities.shape}")
-    if (bend_radius is None) != (bend_axis is None):
-        raise ValueError("bend_radius and bend_axis must both be set or both be None")
-    if reference_E is not None and target_neff is not None:
-        raise ValueError("reference_E and target_neff are mutually exclusive")
-
-    np_complex_dtype = np.complex128 if dtype == jnp.float64 else np.complex64
-
-    def mode_helper(permittivity, permeability, c0_um, c1_um):
-        # c0_um, c1_um are concrete numpy arrays here (materialised by pure_callback)
-        coords = [np.asarray(c0_um), np.asarray(c1_um)]
-        if bend_radius is not None:
-            assert bend_axis is not None
-            transverse_axes = get_transverse_axes(propagation_axis)
-            tidy3d_bend_axis = transverse_axes.index(bend_axis)
-            bend_radius_um = bend_radius / 1e-6
-            plane_center = (float(0.5 * (coords[0][0] + coords[0][-1])), float(0.5 * (coords[1][0] + coords[1][-1])))
-        else:
-            tidy3d_bend_axis = None
-            bend_radius_um = None
-            plane_center = None
-        modes = tidy3d_mode_computation_wrapper(
-            frequency=frequency,
-            permittivity_cross_section=permittivity,
-            permeability_cross_section=permeability,
-            coords=coords,
-            direction=direction,
-            num_modes=2 * (mode_index + 1) + 10,
-            bend_radius=bend_radius_um,
-            bend_axis=tidy3d_bend_axis,
-            plane_center=plane_center,
-            symmetry=symmetry,
-            target_neff=target_neff,
-        )
-
-        # tidy3d assumes propagation in the z-direction; tangential axes are x and y.
-        sorted_modes = sort_modes(modes, filter_pol, (0, 1))
-        if reference_E is not None:
-            # Field-overlap selection: pick the candidate whose E field (converted to
-            # fdtdx axis order + propagation-axis singleton) has the highest dot-product
-            # magnitude with the reference field.
-            mode = max(
-                sorted_modes,
-                key=lambda m: float(
-                    np.abs(
-                        np.sum(
-                            np.conj(reference_E)
-                            * np.expand_dims(
-                                _perm_mode_E(m, propagation_axis, np_complex_dtype), axis=propagation_axis + 1
-                            )
-                        )
-                    )
-                ),
-            )
-        elif target_neff is not None:
-            mode = min(sorted_modes, key=lambda m: abs(float(np.real(m.neff)) - target_neff))
-        else:
-            mode = sorted_modes[mode_index]
-
-        mode_E = _perm_mode_E(mode, propagation_axis, np_complex_dtype)
-        if propagation_axis == 1:
-            mode_H = -np.stack([mode.Hx, mode.Hz, mode.Hy], axis=0).astype(np_complex_dtype)
-        elif propagation_axis == 0:
-            mode_H = np.stack([mode.Hz, mode.Hx, mode.Hy], axis=0).astype(np_complex_dtype)
-        else:
-            mode_H = np.stack([mode.Hx, mode.Hy, mode.Hz], axis=0).astype(np_complex_dtype)
-
-        neff = np.asarray(mode.neff).astype(np_complex_dtype)
-        return mode_E, mode_H, neff
-
-    # compute input to tidy3d Mode solver
-    if inv_permittivities.shape[0] == 9:
-        eps = expand_to_3x3(inv_permittivities)
-        # Invert the 3x3 matrix
-        perm = (2, 3, 4, 0, 1)  # (3, 3, nx, ny, nz) -> (nx, ny, nz, 3, 3)
-        inv_perm = (3, 4, 0, 1, 2)  # (nx, ny, nz, 3, 3) -> (3, 3, nx, ny, nz)
-        permittivities = (
-            jnp.linalg.inv(eps.transpose(perm)).transpose(inv_perm).reshape(9, *inv_permittivities.shape[1:])
-        )
-    else:
-        permittivities = 1 / inv_permittivities
-    other_axes = [a for a in range(1, 4) if permittivities.shape[a] != 1]
-    propagation_axis = permittivities.shape[1:].index(1)
-    if transverse_coords is None:
-        if resolution is None:
-            raise ValueError("resolution is required when transverse_coords is not provided")
-        # Uniform grid: build concrete coordinate arrays in µm and pass as callback args.
-        c0_um = jnp.asarray(np.arange(permittivities.shape[other_axes[0]] + 1) * resolution / 1e-6)
-        c1_um = jnp.asarray(np.arange(permittivities.shape[other_axes[1]] + 1) * resolution / 1e-6)
-        normalization_area_EuHv = None
-        normalization_area_EvHu = None
-    else:
-        if len(transverse_coords) != 2:
-            raise ValueError(
-                f"transverse_coords must contain exactly two coordinate arrays, got {len(transverse_coords)}"
-            )
-        # Shape validation uses .shape which is always concrete, even for JAX tracers.
-        expected_lengths = [permittivities.shape[dim] + 1 for dim in other_axes]
-        for axis_idx, (coord, expected_length) in enumerate(zip(transverse_coords, expected_lengths, strict=True)):
-            if coord.ndim != 1 or coord.shape[0] != expected_length:
-                raise ValueError(
-                    f"transverse_coords[{axis_idx}] must be 1D with length {expected_length}, got {coord.shape}"
-                )
-        # Convert to µm for tidy3d; keep as JAX arrays so jax.jit can trace through.
-        c0_um = jnp.asarray(transverse_coords[0]) / 1e-6
-        c1_um = jnp.asarray(transverse_coords[1]) / 1e-6
-        # Yee-staggered areas for normalization — consistent with bidirectional_mode_overlap.
-        # other_axes are tensor axes (1-indexed); subtract 1 to get physical axes (0-indexed).
-        # transverse_coords[i] corresponds to physical axis other_axes[i] - 1, which may not match
-        # the Yee u/v ordering, so we explicitly map to the correct edge arrays.
-        u, v = [(1, 2), (2, 0), (0, 1)][propagation_axis]
-        phys_axis_0 = other_axes[0] - 1
-        edges_u = jnp.asarray(transverse_coords[0] if phys_axis_0 == u else transverse_coords[1])
-        edges_v = jnp.asarray(transverse_coords[1] if phys_axis_0 == u else transverse_coords[0])
-        normalization_area_EuHv, normalization_area_EvHu = yee_face_areas_from_edges(
-            edges_u=edges_u,
-            edges_v=edges_v,
-            u_axis=u,
-            v_axis=v,
-            dtype=dtype,
-        )
-    permittivity_squeezed = jnp.take(
-        permittivities,
-        indices=0,
-        axis=propagation_axis + 1,
-    )
-
-    # Rotate permittivity components to match tidy3d coordinate system
-    # tidy3d assumes propagation along z, so we need to map physical axes to tidy3d axes:
-    # - tidy3d x → first transverse axis
-    # - tidy3d y → second transverse axis
-    # - tidy3d z → propagation axis
-    if propagation_axis == 0:
-        # propagation along x: tidy3d (x,y,z) → physical (y,z,x)
-        perm_idx = [1, 2, 0]
-        perm_idx_full_anisotropy = [4, 5, 3, 7, 8, 6, 1, 2, 0]
-    elif propagation_axis == 1:
-        # propagation along y: tidy3d (x,y,z) → physical (x,z,y)
-        perm_idx = [0, 2, 1]
-        perm_idx_full_anisotropy = [0, 2, 1, 6, 8, 7, 3, 5, 4]
-    else:  # propagation_axis == 2
-        # propagation along z: tidy3d (x,y,z) → physical (x,y,z)
-        perm_idx = [0, 1, 2]
-        perm_idx_full_anisotropy = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-
-    # Only apply rotation if anisotropic (3 components)
-    if permittivity_squeezed.shape[0] == 3:
-        permittivity_squeezed = permittivity_squeezed[jnp.array(perm_idx), :, :]
-    if permittivity_squeezed.shape[0] == 9:
-        permittivity_squeezed = permittivity_squeezed[jnp.array(perm_idx_full_anisotropy), :, :]
-
-    jnp_complex_dtype = jnp.complex128 if dtype == jnp.float64 else jnp.complex64
-    result_shape_dtype = (
-        jnp.zeros((3, *permittivity_squeezed.shape[1:]), dtype=jnp_complex_dtype),
-        jnp.zeros((3, *permittivity_squeezed.shape[1:]), dtype=jnp_complex_dtype),
-        jnp.zeros(shape=(), dtype=jnp_complex_dtype),
-    )
-
-    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0 and inv_permeabilities.shape[0] == 9:
-        mu = expand_to_3x3(inv_permeabilities)
-        # Invert the 3x3 matrix
-        perm = (2, 3, 4, 0, 1)  # (3, 3, nx, ny, nz) -> (nx, ny, nz, 3, 3)
-        inv_perm = (3, 4, 0, 1, 2)  # (nx, ny, nz, 3, 3) -> (3, 3, nx, ny, nz)
-        permeabilities = (
-            jnp.linalg.inv(mu.transpose(perm)).transpose(inv_perm).reshape(9, *inv_permeabilities.shape[1:])
-        )
-    else:
-        permeabilities = 1 / inv_permeabilities
-    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
-        permeability_squeezed = jnp.take(
-            permeabilities,
-            indices=0,
-            axis=propagation_axis + 1,
-        )
-        # Apply same rotation to permeability if anisotropic
-        if permeability_squeezed.shape[0] == 3:
-            permeability_squeezed = permeability_squeezed[jnp.array(perm_idx), :, :]
-        if permeability_squeezed.shape[0] == 9:
-            permeability_squeezed = permeability_squeezed[jnp.array(perm_idx_full_anisotropy), :, :]
-    else:  # float
-        permeability_squeezed = permeabilities
-
-    # pure callback to tidy3d is necessary to work in jitted environment.
-    # c0_um and c1_um are passed as explicit args so JAX materialises them to
-    # concrete numpy arrays before calling mode_helper, allowing np.asarray()
-    # inside the callback without raising TracerArrayConversionError.
-    mode_E_raw, mode_H_raw, eff_idx = jax.pure_callback(
-        mode_helper,
-        result_shape_dtype,
-        jax.lax.stop_gradient(permittivity_squeezed),
-        jax.lax.stop_gradient(permeability_squeezed),
-        jax.lax.stop_gradient(c0_um),
-        jax.lax.stop_gradient(c1_um),
-    )
-    mode_E = jnp.expand_dims(mode_E_raw, axis=propagation_axis + 1)
-    mode_H = jnp.expand_dims(mode_H_raw, axis=propagation_axis + 1)
-
-    # Tidy3D uses different scaling internally, so convert back
-    mode_H = mode_H * tidy3d.constants.ETA_0
-
-    mode_E_norm, mode_H_norm = normalize_by_poynting_flux(
-        mode_E,
-        mode_H,
-        axis=propagation_axis,
-        area_EuHv=normalization_area_EuHv,
-        area_EvHu=normalization_area_EvHu,
-    )
-
-    return mode_E_norm, mode_H_norm, eff_idx
-
-
-def compute_modes_tracked(
-    frequencies: list[float],
-    inv_permittivities_stack: jax.Array,
-    inv_permeabilities: jax.Array | float,
-    resolution: float | None = None,
-    direction: Literal["+", "-"] = "+",
-    mode_index: int = 0,
-    filter_pol: Literal["te", "tm"] | None = None,
-    dtype: jnp.dtype = jnp.float32,
-    bend_radius: float | None = None,
-    bend_axis: int | None = None,
-    symmetry: tuple[int, int] = (0, 0),
-    transverse_coords: Sequence[jax.Array] | None = None,
-) -> tuple[jax.Array, jax.Array, jax.Array]:
-    """Multi-frequency mode solving with field-overlap continuity tracking.
-
-    Runs all frequency solves inside a single ``jax.pure_callback``, making the
-    function fully compatible with ``jax.jit``.  Inside the callback all arrays
-    are concrete numpy, so the previous step's mode_E can be read and passed as
-    a reference to the next step without breaking JAX tracing.
-
-    Field-overlap tracking selects — among all ARPACK candidates — the mode with
-    the highest ``|<conj(prev_mode_E), candidate_E>|``.  The first frequency uses
-    ``mode_index`` as usual (no prior reference).
+    All solves run inside a single ``jax.pure_callback`` — safe under ``jax.jit``.
 
     Args:
-        frequencies: List of N operating frequencies in Hz.
-        inv_permittivities_stack: Stacked inverse permittivities, shape
-            ``(N, {1, 3, 9}, nx, ny, nz)`` where exactly one of nx/ny/nz is 1.
-            Slice ``i`` is used for ``frequencies[i]``.  Build this by stacking
-            per-frequency dispersive corrections before calling.
-        inv_permeabilities: Same as ``compute_mode`` — shared across all frequencies.
-        resolution: Uniform grid spacing in metres; required when
-            ``transverse_coords`` is ``None``.
+        frequency: Operating frequency in Hz, or a list of N frequencies.
+        inv_permittivities: Inverse relative permittivity.  Shape ``(K, nx, ny, nz)``
+            for scalar frequency, or ``(N, K, nx, ny, nz)`` for list frequency, where
+            ``K ∈ {1, 3, 9}`` and exactly one spatial dimension is 1 (the propagation axis).
+        inv_permeabilities: Inverse relative permeability — scalar float or array with the
+            same shape convention as ``inv_permittivities`` (shared across all frequencies).
+        resolution: Uniform grid spacing in metres.  Required when ``transverse_coords``
+            is not provided.
         direction: Propagation direction, ``"+"`` or ``"-"``.
-        mode_index: Index into neff-sorted candidate list for the first frequency.
+        mode_index: Index into neff-sorted candidate list.  Defaults to 0.
         filter_pol: Optional ``"te"`` / ``"tm"`` polarisation filter.
         dtype: Float dtype; controls complex64 vs complex128 output.
-        bend_radius: Waveguide bend radius in metres.
-        bend_axis: Physical axis toward the centre of curvature.
+        bend_radius: Waveguide bend radius in metres; requires ``bend_axis``.
+        bend_axis: Physical axis index toward the centre of curvature.
         symmetry: Per-transverse-axis symmetry condition at the min edge.
         transverse_coords: Optional pair of physical edge-coordinate arrays in metres.
+        target_neff: Selects the mode closest to this effective index.  Only valid for
+            scalar frequency.
+        reference_E: Selects the mode with the highest field dot-product overlap with this
+            reference E-field (shape ``(3, nx, ny, nz)``).  Only valid for scalar frequency.
 
     Returns:
-        Tuple of ``(mode_Es, mode_Hs, neffs)`` with shapes
-        ``(N, 3, nx, ny, nz)``, ``(N, 3, nx, ny, nz)``, ``(N,)``.
-        Fields are Poynting-flux normalised to unit power.
+        ``(mode_E, mode_H, neff)`` for scalar frequency, or ``(mode_Es, mode_Hs, neffs)``
+        for list frequency.  Fields are Poynting-flux normalised to unit power.
     """
-    num_freqs = len(frequencies)
-    if inv_permittivities_stack.shape[0] != num_freqs:
-        raise ValueError(
-            f"inv_permittivities_stack first dim must equal len(frequencies) ({num_freqs}), "
-            f"got {inv_permittivities_stack.shape[0]}"
-        )
-    sample = inv_permittivities_stack[0]
+    scalar_input = isinstance(frequency, (int, float))
+    frequencies = [float(frequency)] if scalar_input else [float(f) for f in frequency]
+    N = len(frequencies)
 
-    if not (sample.ndim == 4 and sample.shape[0] in [1, 3, 9]) or sum(dim == 1 for dim in sample.shape[1:]) != 1:
-        raise Exception(f"Invalid shape of inv_permittivities: {sample.shape}")
+    # Normalise to stacked (N, K, nx, ny, nz)
+    if scalar_input:
+        inv_perm_stack = jnp.expand_dims(inv_permittivities, 0)
+        sample = inv_permittivities
+    else:
+        inv_perm_stack = inv_permittivities
+        sample = inv_permittivities[0]
+
+    # Validate shapes
+    if not (sample.ndim == 4 and sample.shape[0] in [1, 3, 9]) or sum(s == 1 for s in sample.shape[1:]) != 1:
+        raise ValueError(f"Invalid inv_permittivities shape: {sample.shape}")
     if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
         if (
             not (inv_permeabilities.ndim == 4 and inv_permeabilities.shape[0] in [1, 3, 9])
-            or sum(dim == 1 for dim in inv_permeabilities.shape[1:]) != 1
+            or sum(s == 1 for s in inv_permeabilities.shape[1:]) != 1
         ):
-            raise Exception(f"Invalid shape of inv_permeabilities: {inv_permeabilities.shape}")
+            raise ValueError(f"Invalid inv_permeabilities shape: {inv_permeabilities.shape}")
     if (bend_radius is None) != (bend_axis is None):
         raise ValueError("bend_radius and bend_axis must both be set or both be None")
-
-    np_complex_dtype = np.complex128 if dtype == jnp.float64 else np.complex64
-    jnp_complex_dtype = jnp.complex128 if dtype == jnp.float64 else jnp.complex64
+    if not scalar_input and (target_neff is not None or reference_E is not None):
+        raise ValueError("target_neff and reference_E are only valid for scalar frequency")
+    if target_neff is not None and reference_E is not None:
+        raise ValueError("target_neff and reference_E are mutually exclusive")
 
     propagation_axis = sample.shape[1:].index(1)
     other_axes = [a for a in range(1, 4) if sample.shape[a] != 1]
+    perm_idx, perm_idx_9 = _axis_perm_indices(propagation_axis)
 
-    if propagation_axis == 0:
-        perm_idx = [1, 2, 0]
-        perm_idx_full_anisotropy = [4, 5, 3, 7, 8, 6, 1, 2, 0]
-    elif propagation_axis == 1:
-        perm_idx = [0, 2, 1]
-        perm_idx_full_anisotropy = [0, 2, 1, 6, 8, 7, 3, 5, 4]
-    else:
-        perm_idx = [0, 1, 2]
-        perm_idx_full_anisotropy = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-
-    if transverse_coords is None:
-        if resolution is None:
-            raise ValueError("resolution is required when transverse_coords is not provided")
-        c0_um = jnp.asarray(np.arange(sample.shape[other_axes[0]] + 1) * resolution / 1e-6)
-        c1_um = jnp.asarray(np.arange(sample.shape[other_axes[1]] + 1) * resolution / 1e-6)
-        normalization_area_EuHv = None
-        normalization_area_EvHu = None
-    else:
-        if len(transverse_coords) != 2:
-            raise ValueError(
-                f"transverse_coords must contain exactly two coordinate arrays, got {len(transverse_coords)}"
-            )
-        expected_lengths = [sample.shape[dim] + 1 for dim in other_axes]
-        for axis_idx, (coord, expected_length) in enumerate(zip(transverse_coords, expected_lengths, strict=True)):
-            if coord.ndim != 1 or coord.shape[0] != expected_length:
-                raise ValueError(
-                    f"transverse_coords[{axis_idx}] must be 1D with length {expected_length}, got {coord.shape}"
-                )
-        c0_um = jnp.asarray(transverse_coords[0]) / 1e-6
-        c1_um = jnp.asarray(transverse_coords[1]) / 1e-6
-        u, v = [(1, 2), (2, 0), (0, 1)][propagation_axis]
-        phys_axis_0 = other_axes[0] - 1
-        edges_u = jnp.asarray(transverse_coords[0] if phys_axis_0 == u else transverse_coords[1])
-        edges_v = jnp.asarray(transverse_coords[1] if phys_axis_0 == u else transverse_coords[0])
-        normalization_area_EuHv, normalization_area_EvHu = yee_face_areas_from_edges(
-            edges_u=edges_u,
-            edges_v=edges_v,
-            u_axis=u,
-            v_axis=v,
-            dtype=dtype,
-        )
-
-    # Process permeability once (frequency-independent) — mirrors compute_mode exactly.
-    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0 and inv_permeabilities.shape[0] == 9:
-        mu = expand_to_3x3(inv_permeabilities)
-        perm = (2, 3, 4, 0, 1)
-        inv_perm = (3, 4, 0, 1, 2)
-        permeabilities_mu = (
-            jnp.linalg.inv(mu.transpose(perm)).transpose(inv_perm).reshape(9, *inv_permeabilities.shape[1:])
-        )
-    else:
-        permeabilities_mu = 1 / inv_permeabilities
-    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
-        permeability_squeezed = jnp.take(permeabilities_mu, indices=0, axis=propagation_axis + 1)
-        if permeability_squeezed.shape[0] == 3:
-            permeability_squeezed = permeability_squeezed[jnp.array(perm_idx), :, :]
-        if permeability_squeezed.shape[0] == 9:
-            permeability_squeezed = permeability_squeezed[jnp.array(perm_idx_full_anisotropy), :, :]
-    else:
-        permeability_squeezed = permeabilities_mu
-
-    # Output shape: (N, 3, n0, n1) — propagation singleton added after callback.
-    spatial_2d = tuple(s for i, s in enumerate(sample.shape[1:]) if i != propagation_axis)
-    result_shape_dtype = (
-        jnp.zeros((num_freqs, 3, *spatial_2d), dtype=jnp_complex_dtype),
-        jnp.zeros((num_freqs, 3, *spatial_2d), dtype=jnp_complex_dtype),
-        jnp.zeros((num_freqs,), dtype=jnp_complex_dtype),
+    c0_um, c1_um, area_EuHv, area_EvHu = _build_transverse_coords(
+        sample.shape, propagation_axis, other_axes, resolution, transverse_coords, dtype
     )
+    permeability_squeezed = _process_permeability(inv_permeabilities, propagation_axis, perm_idx, perm_idx_9)
 
-    def multi_freq_helper(inv_perm_stack, perm_mu, c0_arr, c1_arr):
-        """All arrays are concrete numpy here (pure_callback materialises them)."""
+    np_complex_dtype = np.complex128 if dtype == jnp.float64 else np.complex64
+
+    def _solve_all(inv_perm_stack_np, perm_mu, c0_arr, c1_arr):
         coords = [np.asarray(c0_arr), np.asarray(c1_arr)]
         if bend_radius is not None:
-            assert bend_axis is not None
             transverse_axes = get_transverse_axes(propagation_axis)
-            tidy3d_bend_axis = transverse_axes.index(bend_axis)
             bend_radius_um = bend_radius / 1e-6
-            plane_center = (
-                float(0.5 * (coords[0][0] + coords[0][-1])),
-                float(0.5 * (coords[1][0] + coords[1][-1])),
-            )
+            tidy3d_bend_axis = transverse_axes.index(bend_axis)
+            plane_center = (float(0.5 * (coords[0][0] + coords[0][-1])), float(0.5 * (coords[1][0] + coords[1][-1])))
         else:
-            tidy3d_bend_axis = None
-            bend_radius_um = None
-            plane_center = None
+            bend_radius_um = tidy3d_bend_axis = plane_center = None
 
-        prev_mode_E_4d: np.ndarray | None = None
+        prev_E_4d: np.ndarray | None = reference_E
+
         all_Es: list[np.ndarray] = []
         all_Hs: list[np.ndarray] = []
         all_neffs: list[np.ndarray] = []
 
         for i, freq in enumerate(frequencies):
-            # Invert, squeeze, rotate permittivity for this frequency.
-            inv_perm_i = inv_perm_stack[i]
-            if inv_perm_i.shape[0] == 9:
-                reshaped = inv_perm_i.reshape(3, 3, *inv_perm_i.shape[1:])
-                t_fwd, t_back = (2, 3, 4, 0, 1), (3, 4, 0, 1, 2)
-                perm_i = np.linalg.inv(reshaped.transpose(t_fwd)).transpose(t_back)
-                perm_i = perm_i.reshape(9, *inv_perm_i.shape[1:])
-            else:
-                perm_i = 1.0 / inv_perm_i
-            perm_i_sq = np.squeeze(perm_i, axis=propagation_axis + 1)
-            if perm_i_sq.shape[0] == 3:
-                perm_i_sq = perm_i_sq[perm_idx, :, :]
-            elif perm_i_sq.shape[0] == 9:
-                perm_i_sq = perm_i_sq[perm_idx_full_anisotropy, :, :]
-
+            perm_sq = _prepare_permittivity(inv_perm_stack_np[i], propagation_axis, perm_idx, perm_idx_9)
             modes = tidy3d_mode_computation_wrapper(
                 frequency=freq,
-                permittivity_cross_section=perm_i_sq,
+                permittivity_cross_section=perm_sq,
                 permeability_cross_section=perm_mu,
                 coords=coords,
                 direction=direction,
@@ -590,70 +325,67 @@ def compute_modes_tracked(
                 bend_axis=tidy3d_bend_axis,
                 plane_center=plane_center,
                 symmetry=symmetry,
+                target_neff=target_neff if scalar_input else None,
             )
-
             sorted_modes = sort_modes(modes, filter_pol, (0, 1))
-            if prev_mode_E_4d is not None:
+
+            if prev_E_4d is not None:
                 mode = max(
                     sorted_modes,
                     key=lambda m: float(
                         np.abs(
                             np.sum(
-                                np.conj(prev_mode_E_4d)
+                                np.conj(prev_E_4d)
                                 * np.expand_dims(
-                                    _perm_mode_E(m, propagation_axis, np_complex_dtype),
-                                    axis=propagation_axis + 1,
+                                    _perm_mode_E(m, propagation_axis, np_complex_dtype), axis=propagation_axis + 1
                                 )
                             )
                         )
                     ),
                 )
+            elif scalar_input and target_neff is not None:
+                mode = min(sorted_modes, key=lambda m: abs(float(np.real(m.neff)) - target_neff))
             else:
                 mode = sorted_modes[mode_index]
 
-            mode_E_3d = _perm_mode_E(mode, propagation_axis, np_complex_dtype)
-            prev_mode_E_4d = np.expand_dims(mode_E_3d, axis=propagation_axis + 1)
+            mode_E = _perm_mode_E(mode, propagation_axis, np_complex_dtype)
+            mode_H = _perm_mode_H(mode, propagation_axis, np_complex_dtype)
+            prev_E_4d = np.expand_dims(mode_E, axis=propagation_axis + 1)
 
-            if propagation_axis == 1:
-                mode_H_3d = -np.stack([mode.Hx, mode.Hz, mode.Hy], axis=0).astype(np_complex_dtype)
-            elif propagation_axis == 0:
-                mode_H_3d = np.stack([mode.Hz, mode.Hx, mode.Hy], axis=0).astype(np_complex_dtype)
-            else:
-                mode_H_3d = np.stack([mode.Hx, mode.Hy, mode.Hz], axis=0).astype(np_complex_dtype)
-
-            all_Es.append(mode_E_3d)
-            all_Hs.append(mode_H_3d)
+            all_Es.append(mode_E)
+            all_Hs.append(mode_H)
             all_neffs.append(np.asarray(mode.neff).astype(np_complex_dtype))
 
-        return (
-            np.stack(all_Es, axis=0),
-            np.stack(all_Hs, axis=0),
-            np.array(all_neffs),
-        )
+        return np.stack(all_Es, 0), np.stack(all_Hs, 0), np.array(all_neffs)
+
+    jnp_complex_dtype = jnp.complex128 if dtype == jnp.float64 else jnp.complex64
+    spatial_2d = tuple(s for i, s in enumerate(sample.shape[1:]) if i != propagation_axis)
+    result_shape_dtype = (
+        jnp.zeros((N, 3, *spatial_2d), dtype=jnp_complex_dtype),
+        jnp.zeros((N, 3, *spatial_2d), dtype=jnp_complex_dtype),
+        jnp.zeros((N,), dtype=jnp_complex_dtype),
+    )
 
     mode_Es_raw, mode_Hs_raw, neffs = jax.pure_callback(
-        multi_freq_helper,
+        _solve_all,
         result_shape_dtype,
-        jax.lax.stop_gradient(inv_permittivities_stack),
+        jax.lax.stop_gradient(inv_perm_stack),
         jax.lax.stop_gradient(permeability_squeezed),
         jax.lax.stop_gradient(c0_um),
         jax.lax.stop_gradient(c1_um),
     )
 
-    # Add propagation-axis singleton (axis 0 is the frequency batch).
+    # Add propagation-axis singleton (axis 0 is the frequency batch)
     mode_Es = jnp.expand_dims(mode_Es_raw, axis=propagation_axis + 2)
     mode_Hs = jnp.expand_dims(mode_Hs_raw, axis=propagation_axis + 2) * tidy3d.constants.ETA_0
 
     def _normalize_one(E: jax.Array, H: jax.Array) -> tuple[jax.Array, jax.Array]:
-        return normalize_by_poynting_flux(
-            E,
-            H,
-            axis=propagation_axis,
-            area_EuHv=normalization_area_EuHv,
-            area_EvHu=normalization_area_EvHu,
-        )
+        return normalize_by_poynting_flux(E, H, axis=propagation_axis, area_EuHv=area_EuHv, area_EvHu=area_EvHu)
 
     mode_Es_norm, mode_Hs_norm = jax.vmap(_normalize_one)(mode_Es, mode_Hs)
+
+    if scalar_input:
+        return mode_Es_norm[0], mode_Hs_norm[0], neffs[0]
     return mode_Es_norm, mode_Hs_norm, neffs
 
 

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -209,6 +209,7 @@ def _validate_mode_inputs(
     bend_radius: float | None,
     bend_axis: int | None,
 ) -> None:
+    """Validate per-frequency permittivity slice, permeability, and bend arg consistency."""
     if not (sample.ndim == 4 and sample.shape[0] in [1, 3, 9]) or sum(s == 1 for s in sample.shape[1:]) != 1:
         raise ValueError(f"Invalid inv_permittivities shape: {sample.shape}")
     if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
@@ -227,6 +228,7 @@ def _build_bend_params(
     propagation_axis: int,
     coords: list[np.ndarray],
 ) -> tuple[float | None, int | None, tuple[float, float] | None]:
+    """Convert bend_radius/bend_axis to tidy3d units and frame; returns (None, None, None) when straight."""
     if bend_radius is None:
         return None, None, None
     transverse_axes = get_transverse_axes(propagation_axis)
@@ -242,6 +244,7 @@ def _select_by_field_overlap(
     propagation_axis: int,
     np_complex_dtype,
 ) -> ModeTupleType:
+    """Return the candidate with highest |<conj(ref_E_4d), candidate_E>| overlap."""
     return max(
         sorted_modes,
         key=lambda m: float(

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -203,6 +203,61 @@ def sort_modes(
     return matching_sorted + non_matching_sorted
 
 
+def _validate_mode_inputs(
+    sample: jax.Array,
+    inv_permeabilities: jax.Array | float,
+    bend_radius: float | None,
+    bend_axis: int | None,
+) -> None:
+    if not (sample.ndim == 4 and sample.shape[0] in [1, 3, 9]) or sum(s == 1 for s in sample.shape[1:]) != 1:
+        raise ValueError(f"Invalid inv_permittivities shape: {sample.shape}")
+    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
+        if (
+            not (inv_permeabilities.ndim == 4 and inv_permeabilities.shape[0] in [1, 3, 9])
+            or sum(s == 1 for s in inv_permeabilities.shape[1:]) != 1
+        ):
+            raise ValueError(f"Invalid inv_permeabilities shape: {inv_permeabilities.shape}")
+    if (bend_radius is None) != (bend_axis is None):
+        raise ValueError("bend_radius and bend_axis must both be set or both be None")
+
+
+def _build_bend_params(
+    bend_radius: float | None,
+    bend_axis: int | None,
+    propagation_axis: int,
+    coords: list[np.ndarray],
+) -> tuple[float | None, int | None, tuple[float, float] | None]:
+    if bend_radius is None:
+        return None, None, None
+    transverse_axes = get_transverse_axes(propagation_axis)
+    bend_radius_um = bend_radius / 1e-6
+    tidy3d_bend_axis = transverse_axes.index(bend_axis)
+    plane_center = (float(0.5 * (coords[0][0] + coords[0][-1])), float(0.5 * (coords[1][0] + coords[1][-1])))
+    return bend_radius_um, tidy3d_bend_axis, plane_center
+
+
+def _select_by_field_overlap(
+    sorted_modes: list[ModeTupleType],
+    ref_E_4d: np.ndarray,
+    propagation_axis: int,
+    np_complex_dtype,
+) -> ModeTupleType:
+    return max(
+        sorted_modes,
+        key=lambda m: float(
+            np.abs(
+                np.sum(
+                    np.conj(ref_E_4d)
+                    * np.expand_dims(
+                        _perm_mode_E(m, propagation_axis, np_complex_dtype),
+                        axis=propagation_axis + 1,
+                    )
+                )
+            )
+        ),
+    )
+
+
 _ModeSetup = namedtuple(
     "_ModeSetup",
     [
@@ -228,7 +283,7 @@ def _build_mode_setup(
     transverse_coords: Sequence[jax.Array] | None,
     dtype: jnp.dtype,
 ) -> "_ModeSetup":
-    """Derive geometry, coordinates and permeability — shared by both public mode solvers."""
+    """Derive geometry, coordinates and permeability from a single-frequency sample slice."""
     propagation_axis = sample.shape[1:].index(1)
     other_axes = [a for a in range(1, 4) if sample.shape[a] != 1]
     perm_idx, perm_idx_9 = _axis_perm_indices(propagation_axis)
@@ -272,137 +327,7 @@ def _postprocess_modes(
     return mode_Es_norm, mode_Hs_norm, neffs
 
 
-def compute_mode_one_frequency(
-    frequency: float,
-    inv_permittivities: jax.Array,
-    inv_permeabilities: jax.Array | float,
-    resolution: float | None = None,
-    direction: Literal["+", "-"] = "+",
-    mode_index: int = 0,
-    filter_pol: Literal["te", "tm"] | None = None,
-    dtype: jnp.dtype = jnp.float32,
-    bend_radius: float | None = None,
-    bend_axis: int | None = None,
-    symmetry: tuple[int, int] = (0, 0),
-    transverse_coords: Sequence[jax.Array] | None = None,
-    target_neff: float | None = None,
-    reference_E: np.ndarray | None = None,
-) -> tuple[jax.Array, jax.Array, jax.Array]:
-    """Compute one optical mode at a single frequency.
-
-    Args:
-        frequency: Operating frequency in Hz.
-        inv_permittivities: Inverse relative permittivity, shape ``(K, nx, ny, nz)``
-            where ``K ∈ {1, 3, 9}`` and exactly one spatial dimension is 1.
-        inv_permeabilities: Inverse relative permeability — scalar float or same-shape array.
-        resolution: Uniform grid spacing in metres; required when ``transverse_coords`` is not provided.
-        direction: Propagation direction, ``"+"`` or ``"-"``.
-        mode_index: Index into neff-sorted candidate list. Defaults to 0.
-        filter_pol: Optional ``"te"`` / ``"tm"`` polarisation filter.
-        dtype: Float dtype; controls complex64 vs complex128 output.
-        bend_radius: Waveguide bend radius in metres; requires ``bend_axis``.
-        bend_axis: Physical axis index toward the centre of curvature.
-        symmetry: Per-transverse-axis symmetry condition at the min edge.
-        transverse_coords: Optional pair of physical edge-coordinate arrays in metres.
-        target_neff: Selects the mode whose ``real(neff)`` is closest to this value.
-            Mutually exclusive with ``reference_E``.
-        reference_E: Selects the mode with the highest field dot-product overlap with this
-            reference field, shape ``(3, nx, ny, nz)``.  Pass the previous frequency's
-            mode_E to track the same physical mode across a manual sweep.
-            Mutually exclusive with ``target_neff``.
-
-    Returns:
-        ``(mode_E, mode_H, neff)`` — fields shaped ``(3, nx, ny, nz)``, scalar neff.
-        Fields are Poynting-flux normalised to unit power.
-    """
-    if (
-        not (inv_permittivities.ndim == 4 and inv_permittivities.shape[0] in [1, 3, 9])
-        or sum(s == 1 for s in inv_permittivities.shape[1:]) != 1
-    ):
-        raise ValueError(f"Invalid inv_permittivities shape: {inv_permittivities.shape}")
-    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
-        if (
-            not (inv_permeabilities.ndim == 4 and inv_permeabilities.shape[0] in [1, 3, 9])
-            or sum(s == 1 for s in inv_permeabilities.shape[1:]) != 1
-        ):
-            raise ValueError(f"Invalid inv_permeabilities shape: {inv_permeabilities.shape}")
-    if (bend_radius is None) != (bend_axis is None):
-        raise ValueError("bend_radius and bend_axis must both be set or both be None")
-    if target_neff is not None and reference_E is not None:
-        raise ValueError("target_neff and reference_E are mutually exclusive")
-
-    setup = _build_mode_setup(inv_permittivities, inv_permeabilities, resolution, transverse_coords, dtype)
-    inv_perm_stack = jnp.expand_dims(inv_permittivities, 0)
-
-    def _solve(inv_perm_np, perm_mu, c0_arr, c1_arr):
-        coords = [np.asarray(c0_arr), np.asarray(c1_arr)]
-        if bend_radius is not None:
-            transverse_axes = get_transverse_axes(setup.propagation_axis)
-            bend_radius_um = bend_radius / 1e-6
-            tidy3d_bend_axis = transverse_axes.index(bend_axis)
-            plane_center = (float(0.5 * (coords[0][0] + coords[0][-1])), float(0.5 * (coords[1][0] + coords[1][-1])))
-        else:
-            bend_radius_um = tidy3d_bend_axis = plane_center = None
-
-        perm_sq = _prepare_permittivity(inv_perm_np[0], setup.propagation_axis, setup.perm_idx, setup.perm_idx_9)
-        modes = tidy3d_mode_computation_wrapper(
-            frequency=float(frequency),
-            permittivity_cross_section=perm_sq,
-            permeability_cross_section=perm_mu,
-            coords=coords,
-            direction=direction,
-            num_modes=2 * (mode_index + 1) + 10,
-            bend_radius=bend_radius_um,
-            bend_axis=tidy3d_bend_axis,
-            plane_center=plane_center,
-            symmetry=symmetry,
-            target_neff=target_neff,
-        )
-        sorted_modes = sort_modes(modes, filter_pol, (0, 1))
-
-        if reference_E is not None:
-            mode = max(
-                sorted_modes,
-                key=lambda m: float(
-                    np.abs(
-                        np.sum(
-                            np.conj(reference_E)
-                            * np.expand_dims(
-                                _perm_mode_E(m, setup.propagation_axis, setup.np_complex_dtype),
-                                axis=setup.propagation_axis + 1,
-                            )
-                        )
-                    )
-                ),
-            )
-        elif target_neff is not None:
-            mode = min(sorted_modes, key=lambda m: abs(float(np.real(m.neff)) - target_neff))
-        else:
-            mode = sorted_modes[mode_index]
-
-        mode_E = _perm_mode_E(mode, setup.propagation_axis, setup.np_complex_dtype)
-        mode_H = _perm_mode_H(mode, setup.propagation_axis, setup.np_complex_dtype)
-        neff = np.asarray(mode.neff).astype(setup.np_complex_dtype)
-        return np.stack([mode_E], 0), np.stack([mode_H], 0), np.array([neff])
-
-    result_shape_dtype = (
-        jnp.zeros((1, 3, *setup.spatial_2d), dtype=setup.jnp_complex_dtype),
-        jnp.zeros((1, 3, *setup.spatial_2d), dtype=setup.jnp_complex_dtype),
-        jnp.zeros((1,), dtype=setup.jnp_complex_dtype),
-    )
-    mode_Es_raw, mode_Hs_raw, neffs = jax.pure_callback(
-        _solve,
-        result_shape_dtype,
-        jax.lax.stop_gradient(inv_perm_stack),
-        jax.lax.stop_gradient(setup.permeability_squeezed),
-        jax.lax.stop_gradient(setup.c0_um),
-        jax.lax.stop_gradient(setup.c1_um),
-    )
-    mode_Es_norm, mode_Hs_norm, neffs = _postprocess_modes(mode_Es_raw, mode_Hs_raw, neffs, setup)
-    return mode_Es_norm[0], mode_Hs_norm[0], neffs[0]
-
-
-def compute_mode_multiple_frequencies(
+def compute_mode(
     frequencies: list[float],
     inv_permittivities: jax.Array,
     inv_permeabilities: jax.Array | float,
@@ -421,7 +346,7 @@ def compute_mode_multiple_frequencies(
     Runs all N solves inside a single ``jax.pure_callback`` — safe under ``jax.jit``.
     Field-overlap tracking selects — at each frequency after the first — the ARPACK
     candidate with the highest ``|<conj(prev_E), candidate_E>|``, preventing mode
-    hopping at neff branch crossings.
+    hopping at neff branch crossings.  Pass a single-element list for one frequency.
 
     Args:
         frequencies: List of N operating frequencies in Hz.
@@ -446,29 +371,15 @@ def compute_mode_multiple_frequencies(
     """
     N = len(frequencies)
     sample = inv_permittivities[0]
-    if not (sample.ndim == 4 and sample.shape[0] in [1, 3, 9]) or sum(s == 1 for s in sample.shape[1:]) != 1:
-        raise ValueError(f"Invalid inv_permittivities shape: {sample.shape}")
-    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
-        if (
-            not (inv_permeabilities.ndim == 4 and inv_permeabilities.shape[0] in [1, 3, 9])
-            or sum(s == 1 for s in inv_permeabilities.shape[1:]) != 1
-        ):
-            raise ValueError(f"Invalid inv_permeabilities shape: {inv_permeabilities.shape}")
-    if (bend_radius is None) != (bend_axis is None):
-        raise ValueError("bend_radius and bend_axis must both be set or both be None")
+    _validate_mode_inputs(sample, inv_permeabilities, bend_radius, bend_axis)
 
     setup = _build_mode_setup(sample, inv_permeabilities, resolution, transverse_coords, dtype)
 
     def _solve(inv_perm_stack_np, perm_mu, c0_arr, c1_arr):
         coords = [np.asarray(c0_arr), np.asarray(c1_arr)]
-        if bend_radius is not None:
-            transverse_axes = get_transverse_axes(setup.propagation_axis)
-            bend_radius_um = bend_radius / 1e-6
-            tidy3d_bend_axis = transverse_axes.index(bend_axis)
-            plane_center = (float(0.5 * (coords[0][0] + coords[0][-1])), float(0.5 * (coords[1][0] + coords[1][-1])))
-        else:
-            bend_radius_um = tidy3d_bend_axis = plane_center = None
-
+        bend_radius_um, tidy3d_bend_axis, plane_center = _build_bend_params(
+            bend_radius, bend_axis, setup.propagation_axis, coords
+        )
         prev_E_4d: np.ndarray | None = None
         all_Es: list[np.ndarray] = []
         all_Hs: list[np.ndarray] = []
@@ -493,20 +404,7 @@ def compute_mode_multiple_frequencies(
             sorted_modes = sort_modes(modes, filter_pol, (0, 1))
 
             if prev_E_4d is not None:
-                mode = max(
-                    sorted_modes,
-                    key=lambda m: float(
-                        np.abs(
-                            np.sum(
-                                np.conj(prev_E_4d)
-                                * np.expand_dims(
-                                    _perm_mode_E(m, setup.propagation_axis, setup.np_complex_dtype),
-                                    axis=setup.propagation_axis + 1,
-                                )
-                            )
-                        )
-                    ),
-                )
+                mode = _select_by_field_overlap(sorted_modes, prev_E_4d, setup.propagation_axis, setup.np_complex_dtype)
             else:
                 mode = sorted_modes[mode_index]
 

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -148,10 +148,11 @@ def compute_mode(
     bend_axis: int | None = None,
     symmetry: tuple[int, int] = (0, 0),
     transverse_coords: Sequence[jax.Array] | None = None,
+    target_neff: float | None = None,
 ) -> tuple[
     jax.Array,  # E
     jax.Array,  # H
-    jax.Array,  # complex propagation constant
+    jax.Array,  # complex effective index
 ]:
     """Compute optical modes of a waveguide cross-section.
 
@@ -189,10 +190,14 @@ def compute_mode(
             When provided, the Tidy3D mode solver receives the non-uniform rectilinear grid directly.
             JAX arrays are accepted; the numpy conversion happens inside the tidy3d callback so the function
             remains compatible with ``jax.jit``.
+        target_neff: When provided, selects the mode whose real(neff) is closest to this value instead of using
+            ``mode_index`` from the sorted list.  Pass the neff returned by the previous frequency's call to
+            maintain mode continuity across a frequency sweep.  Defaults to None (use mode_index).
 
     Returns:
         Tuple[jax.Array, jax.Array, jax.Array]:
-            Tuple of E, H field and the effective index as complex-valued jax arrays.
+            Tuple of (E field, H field, effective index) as complex-valued jax arrays.
+            Fields are Poynting-flux normalised to unit power.
     """
     # Input validation
     if (
@@ -235,12 +240,16 @@ def compute_mode(
             bend_axis=tidy3d_bend_axis,
             plane_center=plane_center,
             symmetry=symmetry,
+            target_neff=target_neff,
         )
 
         # sort modes by polarization
         # tidy3d assumes propagation in the z-direction. The tangential axes are therefore x and y.
-        modes = sort_modes(modes, filter_pol, (0, 1))
-        mode = modes[mode_index]
+        sorted_modes = sort_modes(modes, filter_pol, (0, 1))
+        if target_neff is not None:
+            mode = min(sorted_modes, key=lambda m: abs(float(np.real(m.neff)) - target_neff))
+        else:
+            mode = sorted_modes[mode_index]
 
         if propagation_axis == 0:
             mode_E, mode_H = (
@@ -396,289 +405,6 @@ def compute_mode(
     )
 
     return mode_E_norm, mode_H_norm, eff_idx
-
-
-def compute_modes_multi_freq(
-    frequencies: list[float],
-    inv_permittivities: jax.Array,
-    inv_permeabilities: jax.Array | float,
-    resolution: float | None = None,
-    direction: Literal["+", "-"] = "+",
-    mode_index: int = 0,
-    filter_pol: Literal["te", "tm"] | None = None,
-    dtype: jnp.dtype = jnp.float32,
-    bend_radius: float | None = None,
-    bend_axis: int | None = None,
-    transverse_coords: Sequence[ArrayLike] | None = None,
-    inv_permittivities_per_freq: list[jax.Array] | None = None,
-) -> tuple[jax.Array, jax.Array, jax.Array]:
-    """Compute waveguide modes at multiple frequencies with continuity tracking.
-
-    Solves all frequencies in a single :func:`jax.pure_callback` call.  Modes are
-    tracked across frequencies by **neff-proximity**: the anchor mode is selected at the
-    first frequency using ``filter_pol`` and ``mode_index``; at each subsequent
-    frequency the candidate mode whose ``real(neff)`` is closest to the previously
-    tracked neff is chosen.
-
-    **Tracking limitations.**  Neff-proximity is correct for the common case of
-    well-separated, non-degenerate modes over a moderate frequency range.  It can
-    silently fail in these situations:
-
-    * *Mode crossings* — if two neff curves come within ~0.01 of each other between
-      consecutive frequencies, the tracker may latch onto the wrong physical mode.
-      The symptom is a discontinuous jump in ``_mode_neff`` between adjacent
-      frequencies.
-    * *Degenerate modes* — e.g. TE11/TM11 in a circular waveguide where both modes
-      share the same neff.  Proximity tracking is undefined in this regime.
-    * *Large frequency sweeps* — a big enough step can drift even without a crossing
-      if the mode neff changes substantially between samples.
-
-    Args:
-        frequencies: Operating frequencies in Hz.
-        inv_permittivities: 3D array of inverse relative permittivity values.
-        inv_permeabilities: 3D array of inverse relative permeability values or scalar
-            float for uniform permeability.
-        resolution: Uniform-grid spacing in metres.  Required when ``transverse_coords``
-            is not provided.
-        direction: Propagation direction, ``"+"`` or ``"-"``.
-        mode_index: Index into the sorted+filtered mode list at the anchor frequency.
-        filter_pol: Polarisation filter — ``"te"``, ``"tm"``, or ``None``.
-        dtype: Float dtype of the simulation (controls complex64 vs complex128 output).
-        bend_radius: Bend radius in metres.  Must be set together with ``bend_axis``.
-        bend_axis: Physical axis (0/1/2) pointing toward the centre of curvature.
-        transverse_coords: Optional pair of physical edge-coordinate arrays in metres.
-        inv_permittivities_per_freq: Optional list of ``num_freqs`` inverse-permittivity
-            arrays, each with the same shape as ``inv_permittivities``.  When provided,
-            each frequency is solved with its own permittivity (e.g. after dispersive
-            correction via :func:`fdtdx.dispersion.effective_inv_permittivity`).
-            When ``None``, every frequency uses the shared ``inv_permittivities``.
-
-    Returns:
-        Tuple ``(mode_Es, mode_Hs, mode_neffs)`` where ``mode_Es`` and ``mode_Hs``
-        have shape ``(num_freqs, 3, *spatial)`` and ``mode_neffs`` has shape
-        ``(num_freqs,)``.  The spatial dimensions include a singleton along the
-        propagation axis, matching :func:`compute_mode` output.
-    """
-    if (
-        not (inv_permittivities.ndim == 4 and inv_permittivities.shape[0] in [1, 3, 9])
-        or sum(dim == 1 for dim in inv_permittivities.shape[1:]) != 1
-    ):
-        raise Exception(f"Invalid shape of inv_permittivities: {inv_permittivities.shape}")
-    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
-        if (
-            not (inv_permeabilities.ndim == 4 and inv_permeabilities.shape[0] in [1, 3, 9])
-            or sum(dim == 1 for dim in inv_permeabilities.shape[1:]) != 1
-        ):
-            raise Exception(f"Invalid shape of inv_permeabilities: {inv_permeabilities.shape}")
-    if (bend_radius is None) != (bend_axis is None):
-        raise ValueError("bend_radius and bend_axis must both be set or both be None")
-    if not frequencies:
-        raise ValueError("frequencies must be non-empty")
-
-    num_freqs = len(frequencies)
-    np_complex_dtype = np.complex128 if dtype == jnp.float64 else np.complex64
-
-    # Permittivity setup — identical to compute_mode
-    if inv_permittivities.shape[0] == 9:
-        eps = expand_to_3x3(inv_permittivities)
-        perm = (2, 3, 4, 0, 1)
-        inv_perm = (3, 4, 0, 1, 2)
-        permittivities = (
-            jnp.linalg.inv(eps.transpose(perm)).transpose(inv_perm).reshape(9, *inv_permittivities.shape[1:])
-        )
-    else:
-        permittivities = 1 / inv_permittivities
-    other_axes = [a for a in range(1, 4) if permittivities.shape[a] != 1]
-    propagation_axis = permittivities.shape[1:].index(1)
-    if transverse_coords is None:
-        if resolution is None:
-            raise ValueError("resolution is required when transverse_coords is not provided")
-        coords = [np.arange(permittivities.shape[dim] + 1) * resolution / 1e-6 for dim in other_axes]
-        normalization_area_EuHv = None
-        normalization_area_EvHu = None
-    else:
-        if len(transverse_coords) != 2:
-            raise ValueError(
-                f"transverse_coords must contain exactly two coordinate arrays, got {len(transverse_coords)}"
-            )
-        coords_meter = [np.asarray(coord, dtype=np.float64) for coord in transverse_coords]
-        expected_lengths = [permittivities.shape[dim] + 1 for dim in other_axes]
-        for axis_idx, (coord, expected_length) in enumerate(zip(coords_meter, expected_lengths, strict=True)):
-            if coord.ndim != 1 or coord.shape[0] != expected_length:
-                raise ValueError(
-                    f"transverse_coords[{axis_idx}] must be 1D with length {expected_length}, got {coord.shape}"
-                )
-            if np.any(np.diff(coord) <= 0):
-                raise ValueError(f"transverse_coords[{axis_idx}] must be strictly increasing")
-        coords = [coord / 1e-6 for coord in coords_meter]
-        # Yee-staggered areas for normalization — consistent with bidirectional_mode_overlap.
-        normalization_area_EuHv, normalization_area_EvHu = _yee_areas_from_edges(
-            edges_0=jnp.asarray(coords_meter[0]),
-            edges_1=jnp.asarray(coords_meter[1]),
-            phys_axis_0=other_axes[0] - 1,
-            phys_axis_1=other_axes[1] - 1,
-            propagation_axis=propagation_axis,
-            dtype=dtype,
-        )
-    permittivity_squeezed = jnp.take(permittivities, indices=0, axis=propagation_axis + 1)
-
-    if propagation_axis == 0:
-        perm_idx = [1, 2, 0]
-        perm_idx_full_anisotropy = [4, 5, 3, 7, 8, 6, 1, 2, 0]
-    elif propagation_axis == 1:
-        perm_idx = [0, 2, 1]
-        perm_idx_full_anisotropy = [0, 2, 1, 6, 8, 7, 3, 5, 4]
-    else:
-        perm_idx = [0, 1, 2]
-        perm_idx_full_anisotropy = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-
-    if permittivity_squeezed.shape[0] == 3:
-        permittivity_squeezed = permittivity_squeezed[jnp.array(perm_idx), :, :]
-    if permittivity_squeezed.shape[0] == 9:
-        permittivity_squeezed = permittivity_squeezed[jnp.array(perm_idx_full_anisotropy), :, :]
-
-    # Per-frequency permittivity (for dispersive correction).  When not provided,
-    # broadcast the base permittivity so the callback always receives a uniform
-    # (num_freqs, comp, ny, nz) array — one slice per frequency.
-    if inv_permittivities_per_freq is not None:
-        if len(inv_permittivities_per_freq) != num_freqs:
-            raise ValueError(
-                f"inv_permittivities_per_freq must have length {num_freqs}, got {len(inv_permittivities_per_freq)}"
-            )
-
-        def _squeeze_rotate(inv_perm_i: jax.Array) -> jax.Array:
-            if inv_perm_i.shape[0] == 9:
-                eps_i = expand_to_3x3(inv_perm_i)
-                perm_t = (2, 3, 4, 0, 1)
-                inv_perm_t = (3, 4, 0, 1, 2)
-                perm_i = jnp.linalg.inv(eps_i.transpose(perm_t)).transpose(inv_perm_t).reshape(9, *inv_perm_i.shape[1:])
-            else:
-                perm_i = 1 / inv_perm_i
-            sq = jnp.take(perm_i, indices=0, axis=propagation_axis + 1)
-            if sq.shape[0] == 3:
-                sq = sq[jnp.array(perm_idx), :, :]
-            if sq.shape[0] == 9:
-                sq = sq[jnp.array(perm_idx_full_anisotropy), :, :]
-            return sq
-
-        permittivity_squeezed_per_freq = jnp.stack([_squeeze_rotate(p) for p in inv_permittivities_per_freq])
-    else:
-        permittivity_squeezed_per_freq = jnp.stack([permittivity_squeezed] * num_freqs)
-
-    jnp_complex_dtype = jnp.complex128 if dtype == jnp.float64 else jnp.complex64
-
-    # Permeability setup — identical to compute_mode
-    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0 and inv_permeabilities.shape[0] == 9:
-        mu = expand_to_3x3(inv_permeabilities)
-        perm_t = (2, 3, 4, 0, 1)
-        inv_perm_t = (3, 4, 0, 1, 2)
-        permeabilities = (
-            jnp.linalg.inv(mu.transpose(perm_t)).transpose(inv_perm_t).reshape(9, *inv_permeabilities.shape[1:])
-        )
-    else:
-        permeabilities = 1 / inv_permeabilities
-    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
-        permeability_squeezed = jnp.take(permeabilities, indices=0, axis=propagation_axis + 1)
-        if permeability_squeezed.shape[0] == 3:
-            permeability_squeezed = permeability_squeezed[jnp.array(perm_idx), :, :]
-        if permeability_squeezed.shape[0] == 9:
-            permeability_squeezed = permeability_squeezed[jnp.array(perm_idx_full_anisotropy), :, :]
-    else:
-        permeability_squeezed = permeabilities
-
-    def multi_freq_helper(permittivity_per_freq, permeability):
-        if bend_radius is not None:
-            assert bend_axis is not None
-            transverse_axes = [ax for ax in range(3) if ax != propagation_axis]
-            tidy3d_bend_axis = transverse_axes.index(bend_axis)
-            bend_radius_um = bend_radius / 1e-6
-            plane_center = (
-                float(0.5 * (coords[0][0] + coords[0][-1])),
-                float(0.5 * (coords[1][0] + coords[1][-1])),
-            )
-        else:
-            tidy3d_bend_axis = None
-            bend_radius_um = None
-            plane_center = None
-
-        num_modes = 2 * (mode_index + 1) + 10
-
-        # Solve all candidate modes at every frequency using the per-frequency permittivity
-        all_candidates = []
-        for i, freq in enumerate(frequencies):
-            modes = tidy3d_mode_computation_wrapper(
-                frequency=freq,
-                permittivity_cross_section=permittivity_per_freq[i],
-                permeability_cross_section=permeability,
-                coords=coords,
-                direction=direction,
-                num_modes=num_modes,
-                bend_radius=bend_radius_um,
-                bend_axis=tidy3d_bend_axis,
-                plane_center=plane_center,
-            )
-            all_candidates.append(modes)
-
-        # Anchor at first frequency: apply filter + sort, then select mode_index
-        anchor_candidates = sort_modes(all_candidates[0], filter_pol, (0, 1))
-        result_modes = [anchor_candidates[mode_index]]
-        prev_neff = float(np.real(anchor_candidates[mode_index].neff))
-
-        # Track subsequent frequencies by neff-proximity within filter_pol candidates
-        for candidates in all_candidates[1:]:
-            filtered = sort_modes(candidates, filter_pol, (0, 1))
-            mode = min(filtered, key=lambda m: abs(float(np.real(m.neff)) - prev_neff))
-            result_modes.append(mode)
-            prev_neff = float(np.real(mode.neff))
-
-        # Apply axis rotation (same as compute_mode's mode_helper) and stack
-        mode_Es, mode_Hs, mode_neffs = [], [], []
-        for mode in result_modes:
-            if propagation_axis == 0:
-                mode_E = np.stack([mode.Ez, mode.Ex, mode.Ey], axis=0).astype(np_complex_dtype)
-                mode_H = np.stack([mode.Hz, mode.Hx, mode.Hy], axis=0).astype(np_complex_dtype)
-            elif propagation_axis == 1:
-                mode_E = np.stack([mode.Ex, mode.Ez, mode.Ey], axis=0).astype(np_complex_dtype)
-                mode_H = -np.stack([mode.Hx, mode.Hz, mode.Hy], axis=0).astype(np_complex_dtype)
-            else:
-                mode_E = np.stack([mode.Ex, mode.Ey, mode.Ez], axis=0).astype(np_complex_dtype)
-                mode_H = np.stack([mode.Hx, mode.Hy, mode.Hz], axis=0).astype(np_complex_dtype)
-            mode_Es.append(mode_E)
-            mode_Hs.append(mode_H)
-            mode_neffs.append(np.asarray(mode.neff).astype(np_complex_dtype))
-
-        return np.stack(mode_Es), np.stack(mode_Hs), np.array(mode_neffs)
-
-    transverse_shape = permittivity_squeezed.shape[1:]
-    result_shape_dtype = (
-        jnp.zeros((num_freqs, 3, *transverse_shape), dtype=jnp_complex_dtype),
-        jnp.zeros((num_freqs, 3, *transverse_shape), dtype=jnp_complex_dtype),
-        jnp.zeros((num_freqs,), dtype=jnp_complex_dtype),
-    )
-
-    mode_Es_raw, mode_Hs_raw, eff_idxs = jax.pure_callback(
-        multi_freq_helper,
-        result_shape_dtype,
-        jax.lax.stop_gradient(permittivity_squeezed_per_freq),
-        jax.lax.stop_gradient(permeability_squeezed),
-    )
-
-    # normalize_by_poynting_flux cannot handle a batch dim — apply per frequency
-    mode_Es_norm, mode_Hs_norm = [], []
-    for i in range(num_freqs):
-        me = jnp.expand_dims(mode_Es_raw[i], axis=propagation_axis + 1)
-        mh = jnp.expand_dims(mode_Hs_raw[i], axis=propagation_axis + 1) * tidy3d.constants.ETA_0
-        me_n, mh_n = normalize_by_poynting_flux(
-            me,
-            mh,
-            axis=propagation_axis,
-            area_EuHv=normalization_area_EuHv,
-            area_EvHu=normalization_area_EvHu,
-        )
-        mode_Es_norm.append(me_n)
-        mode_Hs_norm.append(mh_n)
-
-    return jnp.stack(mode_Es_norm), jnp.stack(mode_Hs_norm), eff_idxs
 
 
 def tidy3d_mode_computation_wrapper(

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -350,6 +350,244 @@ def compute_mode(
     return mode_E_norm, mode_H_norm, eff_idx
 
 
+def compute_modes_multi_freq(
+    frequencies: list[float],
+    inv_permittivities: jax.Array,
+    inv_permeabilities: jax.Array | float,
+    resolution: float | None = None,
+    direction: Literal["+", "-"] = "+",
+    mode_index: int = 0,
+    filter_pol: Literal["te", "tm"] | None = None,
+    dtype: jnp.dtype = jnp.float32,
+    bend_radius: float | None = None,
+    bend_axis: int | None = None,
+    transverse_coords: Sequence[ArrayLike] | None = None,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Compute waveguide modes at multiple frequencies with continuity tracking.
+
+    Solves all frequencies in a single :func:`jax.pure_callback` call.  Modes are
+    tracked across frequencies by **neff-proximity**: the anchor mode is selected at the
+    first frequency using ``filter_pol`` and ``mode_index``; at each subsequent
+    frequency the candidate mode whose ``real(neff)`` is closest to the previously
+    tracked neff is chosen.
+
+    **Tracking limitations.**  Neff-proximity is correct for the common case of
+    well-separated, non-degenerate modes over a moderate frequency range.  It can
+    silently fail in these situations:
+
+    * *Mode crossings* — if two neff curves come within ~0.01 of each other between
+      consecutive frequencies, the tracker may latch onto the wrong physical mode.
+      The symptom is a discontinuous jump in ``_mode_neff`` between adjacent
+      frequencies.
+    * *Degenerate modes* — e.g. TE11/TM11 in a circular waveguide where both modes
+      share the same neff.  Proximity tracking is undefined in this regime.
+    * *Large frequency sweeps* — a big enough step can drift even without a crossing
+      if the mode neff changes substantially between samples.
+
+    Args:
+        frequencies: Operating frequencies in Hz.
+        inv_permittivities: 3D array of inverse relative permittivity values.
+        inv_permeabilities: 3D array of inverse relative permeability values or scalar
+            float for uniform permeability.
+        resolution: Uniform-grid spacing in metres.  Required when ``transverse_coords``
+            is not provided.
+        direction: Propagation direction, ``"+"`` or ``"-"``.
+        mode_index: Index into the sorted+filtered mode list at the anchor frequency.
+        filter_pol: Polarisation filter — ``"te"``, ``"tm"``, or ``None``.
+        dtype: Float dtype of the simulation (controls complex64 vs complex128 output).
+        bend_radius: Bend radius in metres.  Must be set together with ``bend_axis``.
+        bend_axis: Physical axis (0/1/2) pointing toward the centre of curvature.
+        transverse_coords: Optional pair of physical edge-coordinate arrays in metres.
+
+    Returns:
+        Tuple ``(mode_Es, mode_Hs, mode_neffs)`` where ``mode_Es`` and ``mode_Hs``
+        have shape ``(num_freqs, 3, *spatial)`` and ``mode_neffs`` has shape
+        ``(num_freqs,)``.  The spatial dimensions include a singleton along the
+        propagation axis, matching :func:`compute_mode` output.
+    """
+    if (
+        not (inv_permittivities.ndim == 4 and inv_permittivities.shape[0] in [1, 3, 9])
+        or sum(dim == 1 for dim in inv_permittivities.shape[1:]) != 1
+    ):
+        raise Exception(f"Invalid shape of inv_permittivities: {inv_permittivities.shape}")
+    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
+        if (
+            not (inv_permeabilities.ndim == 4 and inv_permeabilities.shape[0] in [1, 3, 9])
+            or sum(dim == 1 for dim in inv_permeabilities.shape[1:]) != 1
+        ):
+            raise Exception(f"Invalid shape of inv_permeabilities: {inv_permeabilities.shape}")
+    if (bend_radius is None) != (bend_axis is None):
+        raise ValueError("bend_radius and bend_axis must both be set or both be None")
+    if not frequencies:
+        raise ValueError("frequencies must be non-empty")
+
+    num_freqs = len(frequencies)
+    np_complex_dtype = np.complex128 if dtype == jnp.float64 else np.complex64
+
+    # Permittivity setup — identical to compute_mode
+    if inv_permittivities.shape[0] == 9:
+        eps = expand_to_3x3(inv_permittivities)
+        perm = (2, 3, 4, 0, 1)
+        inv_perm = (3, 4, 0, 1, 2)
+        permittivities = (
+            jnp.linalg.inv(eps.transpose(perm)).transpose(inv_perm).reshape(9, *inv_permittivities.shape[1:])
+        )
+    else:
+        permittivities = 1 / inv_permittivities
+    other_axes = [a for a in range(1, 4) if permittivities.shape[a] != 1]
+    propagation_axis = permittivities.shape[1:].index(1)
+    if transverse_coords is None:
+        if resolution is None:
+            raise ValueError("resolution is required when transverse_coords is not provided")
+        coords = [np.arange(permittivities.shape[dim] + 1) * resolution / 1e-6 for dim in other_axes]
+        normalization_area_weights = None
+    else:
+        if len(transverse_coords) != 2:
+            raise ValueError(
+                f"transverse_coords must contain exactly two coordinate arrays, got {len(transverse_coords)}"
+            )
+        coords_meter = [np.asarray(coord, dtype=np.float64) for coord in transverse_coords]
+        expected_lengths = [permittivities.shape[dim] + 1 for dim in other_axes]
+        for axis_idx, (coord, expected_length) in enumerate(zip(coords_meter, expected_lengths, strict=True)):
+            if coord.ndim != 1 or coord.shape[0] != expected_length:
+                raise ValueError(
+                    f"transverse_coords[{axis_idx}] must be 1D with length {expected_length}, got {coord.shape}"
+                )
+            if np.any(np.diff(coord) <= 0):
+                raise ValueError(f"transverse_coords[{axis_idx}] must be strictly increasing")
+        coords = [coord / 1e-6 for coord in coords_meter]
+        area_2d = jnp.asarray(np.diff(coords_meter[0])[:, None] * np.diff(coords_meter[1])[None, :], dtype=dtype)
+        weight_shape = [1, 1, 1]
+        weight_shape[other_axes[0] - 1] = area_2d.shape[0]
+        weight_shape[other_axes[1] - 1] = area_2d.shape[1]
+        normalization_area_weights = area_2d.reshape(weight_shape)
+    permittivity_squeezed = jnp.take(permittivities, indices=0, axis=propagation_axis + 1)
+
+    if propagation_axis == 0:
+        perm_idx = [1, 2, 0]
+        perm_idx_full_anisotropy = [4, 5, 3, 7, 8, 6, 1, 2, 0]
+    elif propagation_axis == 1:
+        perm_idx = [0, 2, 1]
+        perm_idx_full_anisotropy = [0, 2, 1, 6, 8, 7, 3, 5, 4]
+    else:
+        perm_idx = [0, 1, 2]
+        perm_idx_full_anisotropy = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+    if permittivity_squeezed.shape[0] == 3:
+        permittivity_squeezed = permittivity_squeezed[jnp.array(perm_idx), :, :]
+    if permittivity_squeezed.shape[0] == 9:
+        permittivity_squeezed = permittivity_squeezed[jnp.array(perm_idx_full_anisotropy), :, :]
+
+    jnp_complex_dtype = jnp.complex128 if dtype == jnp.float64 else jnp.complex64
+
+    # Permeability setup — identical to compute_mode
+    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0 and inv_permeabilities.shape[0] == 9:
+        mu = expand_to_3x3(inv_permeabilities)
+        perm_t = (2, 3, 4, 0, 1)
+        inv_perm_t = (3, 4, 0, 1, 2)
+        permeabilities = (
+            jnp.linalg.inv(mu.transpose(perm_t)).transpose(inv_perm_t).reshape(9, *inv_permeabilities.shape[1:])
+        )
+    else:
+        permeabilities = 1 / inv_permeabilities
+    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
+        permeability_squeezed = jnp.take(permeabilities, indices=0, axis=propagation_axis + 1)
+        if permeability_squeezed.shape[0] == 3:
+            permeability_squeezed = permeability_squeezed[jnp.array(perm_idx), :, :]
+        if permeability_squeezed.shape[0] == 9:
+            permeability_squeezed = permeability_squeezed[jnp.array(perm_idx_full_anisotropy), :, :]
+    else:
+        permeability_squeezed = permeabilities
+
+    def multi_freq_helper(permittivity, permeability):
+        if bend_radius is not None:
+            assert bend_axis is not None
+            transverse_axes = [ax for ax in range(3) if ax != propagation_axis]
+            tidy3d_bend_axis = transverse_axes.index(bend_axis)
+            bend_radius_um = bend_radius / 1e-6
+            plane_center = (
+                float(0.5 * (coords[0][0] + coords[0][-1])),
+                float(0.5 * (coords[1][0] + coords[1][-1])),
+            )
+        else:
+            tidy3d_bend_axis = None
+            bend_radius_um = None
+            plane_center = None
+
+        num_modes = 2 * (mode_index + 1) + 10
+
+        # Solve all candidate modes at every frequency
+        all_candidates = []
+        for freq in frequencies:
+            modes = tidy3d_mode_computation_wrapper(
+                frequency=freq,
+                permittivity_cross_section=permittivity,
+                permeability_cross_section=permeability,
+                coords=coords,
+                direction=direction,
+                num_modes=num_modes,
+                bend_radius=bend_radius_um,
+                bend_axis=tidy3d_bend_axis,
+                plane_center=plane_center,
+            )
+            all_candidates.append(modes)
+
+        # Anchor at first frequency: apply filter + sort, then select mode_index
+        anchor_candidates = sort_modes(all_candidates[0], filter_pol, (0, 1))
+        result_modes = [anchor_candidates[mode_index]]
+        prev_neff = float(np.real(anchor_candidates[mode_index].neff))
+
+        # Track subsequent frequencies by neff-proximity within filter_pol candidates
+        for candidates in all_candidates[1:]:
+            filtered = sort_modes(candidates, filter_pol, (0, 1))
+            mode = min(filtered, key=lambda m: abs(float(np.real(m.neff)) - prev_neff))
+            result_modes.append(mode)
+            prev_neff = float(np.real(mode.neff))
+
+        # Apply axis rotation (same as compute_mode's mode_helper) and stack
+        mode_Es, mode_Hs, mode_neffs = [], [], []
+        for mode in result_modes:
+            if propagation_axis == 0:
+                mode_E = np.stack([mode.Ez, mode.Ex, mode.Ey], axis=0).astype(np_complex_dtype)
+                mode_H = np.stack([mode.Hz, mode.Hx, mode.Hy], axis=0).astype(np_complex_dtype)
+            elif propagation_axis == 1:
+                mode_E = np.stack([mode.Ex, mode.Ez, mode.Ey], axis=0).astype(np_complex_dtype)
+                mode_H = -np.stack([mode.Hx, mode.Hz, mode.Hy], axis=0).astype(np_complex_dtype)
+            else:
+                mode_E = np.stack([mode.Ex, mode.Ey, mode.Ez], axis=0).astype(np_complex_dtype)
+                mode_H = np.stack([mode.Hx, mode.Hy, mode.Hz], axis=0).astype(np_complex_dtype)
+            mode_Es.append(mode_E)
+            mode_Hs.append(mode_H)
+            mode_neffs.append(np.asarray(mode.neff).astype(np_complex_dtype))
+
+        return np.stack(mode_Es), np.stack(mode_Hs), np.array(mode_neffs)
+
+    transverse_shape = permittivity_squeezed.shape[1:]
+    result_shape_dtype = (
+        jnp.zeros((num_freqs, 3, *transverse_shape), dtype=jnp_complex_dtype),
+        jnp.zeros((num_freqs, 3, *transverse_shape), dtype=jnp_complex_dtype),
+        jnp.zeros((num_freqs,), dtype=jnp_complex_dtype),
+    )
+
+    mode_Es_raw, mode_Hs_raw, eff_idxs = jax.pure_callback(
+        multi_freq_helper,
+        result_shape_dtype,
+        jax.lax.stop_gradient(permittivity_squeezed),
+        jax.lax.stop_gradient(permeability_squeezed),
+    )
+
+    # normalize_by_poynting_flux cannot handle a batch dim — apply per frequency
+    mode_Es_norm, mode_Hs_norm = [], []
+    for i in range(num_freqs):
+        me = jnp.expand_dims(mode_Es_raw[i], axis=propagation_axis + 1)
+        mh = jnp.expand_dims(mode_Hs_raw[i], axis=propagation_axis + 1) * tidy3d.constants.ETA_0
+        me_n, mh_n = normalize_by_poynting_flux(me, mh, axis=propagation_axis, area_weights=normalization_area_weights)
+        mode_Es_norm.append(me_n)
+        mode_Hs_norm.append(mh_n)
+
+    return jnp.stack(mode_Es_norm), jnp.stack(mode_Hs_norm), eff_idxs
+
+
 def tidy3d_mode_computation_wrapper(
     frequency: float,
     permittivity_cross_section: ArrayLike,

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -28,6 +28,22 @@ Attributes:
 """
 
 
+def _perm_mode_E(m: ModeTupleType, propagation_axis: int, dtype) -> np.ndarray:
+    """Permute tidy3d mode E-field components into fdtdx physical axis order.
+
+    tidy3d always places propagation along z; this maps fields to the fdtdx
+    convention where the propagation axis may be 0, 1, or 2.  Returns a
+    (3, n0, n1) array — the propagation-axis singleton is NOT included here;
+    callers that need the full 4-D shape should add it with ``np.expand_dims``.
+    """
+    if propagation_axis == 0:
+        return np.stack([m.Ez, m.Ex, m.Ey], axis=0).astype(dtype)
+    elif propagation_axis == 1:
+        return np.stack([m.Ex, m.Ez, m.Ey], axis=0).astype(dtype)
+    else:
+        return np.stack([m.Ex, m.Ey, m.Ez], axis=0).astype(dtype)
+
+
 def compute_mode_polarization_fraction(
     mode: ModeTupleType,
     tangential_axes: tuple[int, int],
@@ -105,6 +121,7 @@ def compute_mode(
     symmetry: tuple[int, int] = (0, 0),
     transverse_coords: Sequence[jax.Array] | None = None,
     target_neff: float | None = None,
+    reference_E: np.ndarray | None = None,
 ) -> tuple[
     jax.Array,  # E
     jax.Array,  # H
@@ -146,10 +163,14 @@ def compute_mode(
             When provided, the Tidy3D mode solver receives the non-uniform rectilinear grid directly.
             JAX arrays are accepted; the numpy conversion happens inside the tidy3d callback so the function
             remains compatible with ``jax.jit``.
-        target_neff: When set, selects the mode whose ``real(neff)`` is closest to this value.
-            Takes full precedence over ``mode_index`` — the index is ignored when ``target_neff``
-            is not ``None``.  Pass the neff returned by the previous frequency's call to maintain
-            mode continuity across a frequency sweep.
+        target_neff: When set, selects the mode whose ``real(neff)`` is closest to this
+            value.  Useful for picking a specific mode by effective index at a single
+            frequency.  Overridden by ``reference_E`` when both are provided.
+        reference_E: When set, selects the mode with the highest field dot-product overlap
+            with this reference electric field (shape ``(3, nx, ny, nz)`` in fdtdx axis
+            order, with the propagation-axis dimension equal to 1).  Takes full precedence
+            over both ``target_neff`` and ``mode_index``.  Pass ``np.array(mode_E)`` from
+            the previous frequency's call to track the same physical mode across a sweep.
 
     Returns:
         Tuple[jax.Array, jax.Array, jax.Array]:
@@ -170,6 +191,8 @@ def compute_mode(
             raise Exception(f"Invalid shape of inv_permeabilities: {inv_permeabilities.shape}")
     if (bend_radius is None) != (bend_axis is None):
         raise ValueError("bend_radius and bend_axis must both be set or both be None")
+    if reference_E is not None and target_neff is not None:
+        raise ValueError("reference_E and target_neff are mutually exclusive")
 
     np_complex_dtype = np.complex128 if dtype == jnp.float64 else np.complex64
 
@@ -202,28 +225,35 @@ def compute_mode(
 
         # tidy3d assumes propagation in the z-direction; tangential axes are x and y.
         sorted_modes = sort_modes(modes, filter_pol, (0, 1))
-        if target_neff is not None:
+        if reference_E is not None:
+            # Field-overlap selection: pick the candidate whose E field (converted to
+            # fdtdx axis order + propagation-axis singleton) has the highest dot-product
+            # magnitude with the reference field.
+            mode = max(
+                sorted_modes,
+                key=lambda m: float(
+                    np.abs(
+                        np.sum(
+                            np.conj(reference_E)
+                            * np.expand_dims(
+                                _perm_mode_E(m, propagation_axis, np_complex_dtype), axis=propagation_axis + 1
+                            )
+                        )
+                    )
+                ),
+            )
+        elif target_neff is not None:
             mode = min(sorted_modes, key=lambda m: abs(float(np.real(m.neff)) - target_neff))
         else:
             mode = sorted_modes[mode_index]
 
-        if propagation_axis == 0:
-            mode_E, mode_H = (
-                np.stack([mode.Ez, mode.Ex, mode.Ey], axis=0).astype(np_complex_dtype),
-                np.stack([mode.Hz, mode.Hx, mode.Hy], axis=0).astype(np_complex_dtype),
-            )
-        elif propagation_axis == 1:
-            mode_E, mode_H = (
-                np.stack([mode.Ex, mode.Ez, mode.Ey], axis=0).astype(np_complex_dtype),
-                -np.stack([mode.Hx, mode.Hz, mode.Hy], axis=0).astype(np_complex_dtype),
-            )
-        elif propagation_axis == 2:
-            mode_E, mode_H = (
-                np.stack([mode.Ex, mode.Ey, mode.Ez], axis=0).astype(np_complex_dtype),
-                np.stack([mode.Hx, mode.Hy, mode.Hz], axis=0).astype(np_complex_dtype),
-            )
+        mode_E = _perm_mode_E(mode, propagation_axis, np_complex_dtype)
+        if propagation_axis == 1:
+            mode_H = -np.stack([mode.Hx, mode.Hz, mode.Hy], axis=0).astype(np_complex_dtype)
+        elif propagation_axis == 0:
+            mode_H = np.stack([mode.Hz, mode.Hx, mode.Hy], axis=0).astype(np_complex_dtype)
         else:
-            raise Exception("This should never happen")
+            mode_H = np.stack([mode.Hx, mode.Hy, mode.Hz], axis=0).astype(np_complex_dtype)
 
         neff = np.asarray(mode.neff).astype(np_complex_dtype)
         return mode_E, mode_H, neff
@@ -367,6 +397,264 @@ def compute_mode(
     )
 
     return mode_E_norm, mode_H_norm, eff_idx
+
+
+def compute_modes_tracked(
+    frequencies: list[float],
+    inv_permittivities_stack: jax.Array,
+    inv_permeabilities: jax.Array | float,
+    resolution: float | None = None,
+    direction: Literal["+", "-"] = "+",
+    mode_index: int = 0,
+    filter_pol: Literal["te", "tm"] | None = None,
+    dtype: jnp.dtype = jnp.float32,
+    bend_radius: float | None = None,
+    bend_axis: int | None = None,
+    symmetry: tuple[int, int] = (0, 0),
+    transverse_coords: Sequence[jax.Array] | None = None,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Multi-frequency mode solving with field-overlap continuity tracking.
+
+    Runs all frequency solves inside a single ``jax.pure_callback``, making the
+    function fully compatible with ``jax.jit``.  Inside the callback all arrays
+    are concrete numpy, so the previous step's mode_E can be read and passed as
+    a reference to the next step without breaking JAX tracing.
+
+    Field-overlap tracking selects — among all ARPACK candidates — the mode with
+    the highest ``|<conj(prev_mode_E), candidate_E>|``.  The first frequency uses
+    ``mode_index`` as usual (no prior reference).
+
+    Args:
+        frequencies: List of N operating frequencies in Hz.
+        inv_permittivities_stack: Stacked inverse permittivities, shape
+            ``(N, {1, 3, 9}, nx, ny, nz)`` where exactly one of nx/ny/nz is 1.
+            Slice ``i`` is used for ``frequencies[i]``.  Build this by stacking
+            per-frequency dispersive corrections before calling.
+        inv_permeabilities: Same as ``compute_mode`` — shared across all frequencies.
+        resolution: Uniform grid spacing in metres; required when
+            ``transverse_coords`` is ``None``.
+        direction: Propagation direction, ``"+"`` or ``"-"``.
+        mode_index: Index into neff-sorted candidate list for the first frequency.
+        filter_pol: Optional ``"te"`` / ``"tm"`` polarisation filter.
+        dtype: Float dtype; controls complex64 vs complex128 output.
+        bend_radius: Waveguide bend radius in metres.
+        bend_axis: Physical axis toward the centre of curvature.
+        symmetry: Per-transverse-axis symmetry condition at the min edge.
+        transverse_coords: Optional pair of physical edge-coordinate arrays in metres.
+
+    Returns:
+        Tuple of ``(mode_Es, mode_Hs, neffs)`` with shapes
+        ``(N, 3, nx, ny, nz)``, ``(N, 3, nx, ny, nz)``, ``(N,)``.
+        Fields are Poynting-flux normalised to unit power.
+    """
+    num_freqs = len(frequencies)
+    if inv_permittivities_stack.shape[0] != num_freqs:
+        raise ValueError(
+            f"inv_permittivities_stack first dim must equal len(frequencies) ({num_freqs}), "
+            f"got {inv_permittivities_stack.shape[0]}"
+        )
+    sample = inv_permittivities_stack[0]
+
+    if not (sample.ndim == 4 and sample.shape[0] in [1, 3, 9]) or sum(dim == 1 for dim in sample.shape[1:]) != 1:
+        raise Exception(f"Invalid shape of inv_permittivities: {sample.shape}")
+    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
+        if (
+            not (inv_permeabilities.ndim == 4 and inv_permeabilities.shape[0] in [1, 3, 9])
+            or sum(dim == 1 for dim in inv_permeabilities.shape[1:]) != 1
+        ):
+            raise Exception(f"Invalid shape of inv_permeabilities: {inv_permeabilities.shape}")
+    if (bend_radius is None) != (bend_axis is None):
+        raise ValueError("bend_radius and bend_axis must both be set or both be None")
+
+    np_complex_dtype = np.complex128 if dtype == jnp.float64 else np.complex64
+    jnp_complex_dtype = jnp.complex128 if dtype == jnp.float64 else jnp.complex64
+
+    propagation_axis = sample.shape[1:].index(1)
+    other_axes = [a for a in range(1, 4) if sample.shape[a] != 1]
+
+    if propagation_axis == 0:
+        perm_idx = [1, 2, 0]
+        perm_idx_full_anisotropy = [4, 5, 3, 7, 8, 6, 1, 2, 0]
+    elif propagation_axis == 1:
+        perm_idx = [0, 2, 1]
+        perm_idx_full_anisotropy = [0, 2, 1, 6, 8, 7, 3, 5, 4]
+    else:
+        perm_idx = [0, 1, 2]
+        perm_idx_full_anisotropy = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+    if transverse_coords is None:
+        if resolution is None:
+            raise ValueError("resolution is required when transverse_coords is not provided")
+        c0_um = jnp.asarray(np.arange(sample.shape[other_axes[0]] + 1) * resolution / 1e-6)
+        c1_um = jnp.asarray(np.arange(sample.shape[other_axes[1]] + 1) * resolution / 1e-6)
+        normalization_area_EuHv = None
+        normalization_area_EvHu = None
+    else:
+        if len(transverse_coords) != 2:
+            raise ValueError(
+                f"transverse_coords must contain exactly two coordinate arrays, got {len(transverse_coords)}"
+            )
+        expected_lengths = [sample.shape[dim] + 1 for dim in other_axes]
+        for axis_idx, (coord, expected_length) in enumerate(zip(transverse_coords, expected_lengths, strict=True)):
+            if coord.ndim != 1 or coord.shape[0] != expected_length:
+                raise ValueError(
+                    f"transverse_coords[{axis_idx}] must be 1D with length {expected_length}, got {coord.shape}"
+                )
+        c0_um = jnp.asarray(transverse_coords[0]) / 1e-6
+        c1_um = jnp.asarray(transverse_coords[1]) / 1e-6
+        u, v = [(1, 2), (2, 0), (0, 1)][propagation_axis]
+        phys_axis_0 = other_axes[0] - 1
+        edges_u = jnp.asarray(transverse_coords[0] if phys_axis_0 == u else transverse_coords[1])
+        edges_v = jnp.asarray(transverse_coords[1] if phys_axis_0 == u else transverse_coords[0])
+        normalization_area_EuHv, normalization_area_EvHu = yee_face_areas_from_edges(
+            edges_u=edges_u,
+            edges_v=edges_v,
+            u_axis=u,
+            v_axis=v,
+            dtype=dtype,
+        )
+
+    # Process permeability once (frequency-independent) — mirrors compute_mode exactly.
+    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0 and inv_permeabilities.shape[0] == 9:
+        mu = expand_to_3x3(inv_permeabilities)
+        perm = (2, 3, 4, 0, 1)
+        inv_perm = (3, 4, 0, 1, 2)
+        permeabilities_mu = (
+            jnp.linalg.inv(mu.transpose(perm)).transpose(inv_perm).reshape(9, *inv_permeabilities.shape[1:])
+        )
+    else:
+        permeabilities_mu = 1 / inv_permeabilities
+    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
+        permeability_squeezed = jnp.take(permeabilities_mu, indices=0, axis=propagation_axis + 1)
+        if permeability_squeezed.shape[0] == 3:
+            permeability_squeezed = permeability_squeezed[jnp.array(perm_idx), :, :]
+        if permeability_squeezed.shape[0] == 9:
+            permeability_squeezed = permeability_squeezed[jnp.array(perm_idx_full_anisotropy), :, :]
+    else:
+        permeability_squeezed = permeabilities_mu
+
+    # Output shape: (N, 3, n0, n1) — propagation singleton added after callback.
+    spatial_2d = tuple(s for i, s in enumerate(sample.shape[1:]) if i != propagation_axis)
+    result_shape_dtype = (
+        jnp.zeros((num_freqs, 3, *spatial_2d), dtype=jnp_complex_dtype),
+        jnp.zeros((num_freqs, 3, *spatial_2d), dtype=jnp_complex_dtype),
+        jnp.zeros((num_freqs,), dtype=jnp_complex_dtype),
+    )
+
+    def multi_freq_helper(inv_perm_stack, perm_mu, c0_arr, c1_arr):
+        """All arrays are concrete numpy here (pure_callback materialises them)."""
+        coords = [np.asarray(c0_arr), np.asarray(c1_arr)]
+        if bend_radius is not None:
+            assert bend_axis is not None
+            transverse_axes = get_transverse_axes(propagation_axis)
+            tidy3d_bend_axis = transverse_axes.index(bend_axis)
+            bend_radius_um = bend_radius / 1e-6
+            plane_center = (
+                float(0.5 * (coords[0][0] + coords[0][-1])),
+                float(0.5 * (coords[1][0] + coords[1][-1])),
+            )
+        else:
+            tidy3d_bend_axis = None
+            bend_radius_um = None
+            plane_center = None
+
+        prev_mode_E_4d: np.ndarray | None = None
+        all_Es: list[np.ndarray] = []
+        all_Hs: list[np.ndarray] = []
+        all_neffs: list[np.ndarray] = []
+
+        for i, freq in enumerate(frequencies):
+            # Invert, squeeze, rotate permittivity for this frequency.
+            inv_perm_i = inv_perm_stack[i]
+            if inv_perm_i.shape[0] == 9:
+                reshaped = inv_perm_i.reshape(3, 3, *inv_perm_i.shape[1:])
+                t_fwd, t_back = (2, 3, 4, 0, 1), (3, 4, 0, 1, 2)
+                perm_i = np.linalg.inv(reshaped.transpose(t_fwd)).transpose(t_back)
+                perm_i = perm_i.reshape(9, *inv_perm_i.shape[1:])
+            else:
+                perm_i = 1.0 / inv_perm_i
+            perm_i_sq = np.squeeze(perm_i, axis=propagation_axis + 1)
+            if perm_i_sq.shape[0] == 3:
+                perm_i_sq = perm_i_sq[perm_idx, :, :]
+            elif perm_i_sq.shape[0] == 9:
+                perm_i_sq = perm_i_sq[perm_idx_full_anisotropy, :, :]
+
+            modes = tidy3d_mode_computation_wrapper(
+                frequency=freq,
+                permittivity_cross_section=perm_i_sq,
+                permeability_cross_section=perm_mu,
+                coords=coords,
+                direction=direction,
+                num_modes=2 * (mode_index + 1) + 10,
+                bend_radius=bend_radius_um,
+                bend_axis=tidy3d_bend_axis,
+                plane_center=plane_center,
+                symmetry=symmetry,
+            )
+
+            sorted_modes = sort_modes(modes, filter_pol, (0, 1))
+            if prev_mode_E_4d is not None:
+                mode = max(
+                    sorted_modes,
+                    key=lambda m: float(
+                        np.abs(
+                            np.sum(
+                                np.conj(prev_mode_E_4d)
+                                * np.expand_dims(
+                                    _perm_mode_E(m, propagation_axis, np_complex_dtype),
+                                    axis=propagation_axis + 1,
+                                )
+                            )
+                        )
+                    ),
+                )
+            else:
+                mode = sorted_modes[mode_index]
+
+            mode_E_3d = _perm_mode_E(mode, propagation_axis, np_complex_dtype)
+            prev_mode_E_4d = np.expand_dims(mode_E_3d, axis=propagation_axis + 1)
+
+            if propagation_axis == 1:
+                mode_H_3d = -np.stack([mode.Hx, mode.Hz, mode.Hy], axis=0).astype(np_complex_dtype)
+            elif propagation_axis == 0:
+                mode_H_3d = np.stack([mode.Hz, mode.Hx, mode.Hy], axis=0).astype(np_complex_dtype)
+            else:
+                mode_H_3d = np.stack([mode.Hx, mode.Hy, mode.Hz], axis=0).astype(np_complex_dtype)
+
+            all_Es.append(mode_E_3d)
+            all_Hs.append(mode_H_3d)
+            all_neffs.append(np.asarray(mode.neff).astype(np_complex_dtype))
+
+        return (
+            np.stack(all_Es, axis=0),
+            np.stack(all_Hs, axis=0),
+            np.array(all_neffs),
+        )
+
+    mode_Es_raw, mode_Hs_raw, neffs = jax.pure_callback(
+        multi_freq_helper,
+        result_shape_dtype,
+        jax.lax.stop_gradient(inv_permittivities_stack),
+        jax.lax.stop_gradient(permeability_squeezed),
+        jax.lax.stop_gradient(c0_um),
+        jax.lax.stop_gradient(c1_um),
+    )
+
+    # Add propagation-axis singleton (axis 0 is the frequency batch).
+    mode_Es = jnp.expand_dims(mode_Es_raw, axis=propagation_axis + 2)
+    mode_Hs = jnp.expand_dims(mode_Hs_raw, axis=propagation_axis + 2) * tidy3d.constants.ETA_0
+
+    def _normalize_one(E: jax.Array, H: jax.Array) -> tuple[jax.Array, jax.Array]:
+        return normalize_by_poynting_flux(
+            E,
+            H,
+            axis=propagation_axis,
+            area_EuHv=normalization_area_EuHv,
+            area_EvHu=normalization_area_EvHu,
+        )
+
+    mode_Es_norm, mode_Hs_norm = jax.vmap(_normalize_one)(mode_Es, mode_Hs)
+    return mode_Es_norm, mode_Hs_norm, neffs
 
 
 def tidy3d_mode_computation_wrapper(

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -190,9 +190,10 @@ def compute_mode(
             When provided, the Tidy3D mode solver receives the non-uniform rectilinear grid directly.
             JAX arrays are accepted; the numpy conversion happens inside the tidy3d callback so the function
             remains compatible with ``jax.jit``.
-        target_neff: When provided, selects the mode whose real(neff) is closest to this value instead of using
-            ``mode_index`` from the sorted list.  Pass the neff returned by the previous frequency's call to
-            maintain mode continuity across a frequency sweep.  Defaults to None (use mode_index).
+        target_neff: When set, selects the mode whose ``real(neff)`` is closest to this value.
+            Takes full precedence over ``mode_index`` — the index is ignored when ``target_neff``
+            is not ``None``.  Pass the neff returned by the previous frequency's call to maintain
+            mode continuity across a frequency sweep.
 
     Returns:
         Tuple[jax.Array, jax.Array, jax.Array]:
@@ -243,8 +244,7 @@ def compute_mode(
             target_neff=target_neff,
         )
 
-        # sort modes by polarization
-        # tidy3d assumes propagation in the z-direction. The tangential axes are therefore x and y.
+        # tidy3d assumes propagation in the z-direction; tangential axes are x and y.
         sorted_modes = sort_modes(modes, filter_pol, (0, 1))
         if target_neff is not None:
             mode = min(sorted_modes, key=lambda m: abs(float(np.real(m.neff)) - target_neff))

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -203,8 +203,77 @@ def sort_modes(
     return matching_sorted + non_matching_sorted
 
 
-def compute_mode(
-    frequency: float | list[float],
+_ModeSetup = namedtuple(
+    "_ModeSetup",
+    [
+        "propagation_axis",
+        "perm_idx",
+        "perm_idx_9",
+        "c0_um",
+        "c1_um",
+        "area_EuHv",
+        "area_EvHu",
+        "permeability_squeezed",
+        "np_complex_dtype",
+        "jnp_complex_dtype",
+        "spatial_2d",
+    ],
+)
+
+
+def _build_mode_setup(
+    sample: jax.Array,
+    inv_permeabilities: jax.Array | float,
+    resolution: float | None,
+    transverse_coords: Sequence[jax.Array] | None,
+    dtype: jnp.dtype,
+) -> "_ModeSetup":
+    """Derive geometry, coordinates and permeability — shared by both public mode solvers."""
+    propagation_axis = sample.shape[1:].index(1)
+    other_axes = [a for a in range(1, 4) if sample.shape[a] != 1]
+    perm_idx, perm_idx_9 = _axis_perm_indices(propagation_axis)
+    c0_um, c1_um, area_EuHv, area_EvHu = _build_transverse_coords(
+        sample.shape, propagation_axis, other_axes, resolution, transverse_coords, dtype
+    )
+    permeability_squeezed = _process_permeability(inv_permeabilities, propagation_axis, perm_idx, perm_idx_9)
+    np_complex_dtype = np.complex128 if dtype == jnp.float64 else np.complex64
+    jnp_complex_dtype = jnp.complex128 if dtype == jnp.float64 else jnp.complex64
+    spatial_2d = tuple(s for i, s in enumerate(sample.shape[1:]) if i != propagation_axis)
+    return _ModeSetup(
+        propagation_axis=propagation_axis,
+        perm_idx=perm_idx,
+        perm_idx_9=perm_idx_9,
+        c0_um=c0_um,
+        c1_um=c1_um,
+        area_EuHv=area_EuHv,
+        area_EvHu=area_EvHu,
+        permeability_squeezed=permeability_squeezed,
+        np_complex_dtype=np_complex_dtype,
+        jnp_complex_dtype=jnp_complex_dtype,
+        spatial_2d=spatial_2d,
+    )
+
+
+def _postprocess_modes(
+    mode_Es_raw: jax.Array,
+    mode_Hs_raw: jax.Array,
+    neffs: jax.Array,
+    setup: "_ModeSetup",
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Add propagation singleton, apply ETA_0, and Poynting-flux normalise."""
+    ax = setup.propagation_axis
+    mode_Es = jnp.expand_dims(mode_Es_raw, axis=ax + 2)
+    mode_Hs = jnp.expand_dims(mode_Hs_raw, axis=ax + 2) * tidy3d.constants.ETA_0
+
+    def _normalize_one(E: jax.Array, H: jax.Array) -> tuple[jax.Array, jax.Array]:
+        return normalize_by_poynting_flux(E, H, axis=ax, area_EuHv=setup.area_EuHv, area_EvHu=setup.area_EvHu)
+
+    mode_Es_norm, mode_Hs_norm = jax.vmap(_normalize_one)(mode_Es, mode_Hs)
+    return mode_Es_norm, mode_Hs_norm, neffs
+
+
+def compute_mode_one_frequency(
+    frequency: float,
     inv_permittivities: jax.Array,
     inv_permeabilities: jax.Array | float,
     resolution: float | None = None,
@@ -219,57 +288,164 @@ def compute_mode(
     target_neff: float | None = None,
     reference_E: np.ndarray | None = None,
 ) -> tuple[jax.Array, jax.Array, jax.Array]:
-    """Compute optical modes of a waveguide cross-section.
-
-    Scalar ``frequency`` with ``inv_permittivities`` shape ``(K, nx, ny, nz)`` returns
-    ``(mode_E, mode_H, neff)`` with shapes ``(3, nx, ny, nz)`` and scalar ``neff``.
-
-    List ``frequency`` with ``inv_permittivities`` shape ``(N, K, nx, ny, nz)`` returns
-    stacked ``(mode_Es, mode_Hs, neffs)`` with shapes ``(N, 3, nx, ny, nz)`` and ``(N,)``.
-    Field-overlap tracking runs automatically between consecutive frequencies, preventing
-    mode hopping at neff branch crossings.
-
-    All solves run inside a single ``jax.pure_callback`` — safe under ``jax.jit``.
+    """Compute one optical mode at a single frequency.
 
     Args:
-        frequency: Operating frequency in Hz, or a list of N frequencies.
-        inv_permittivities: Inverse relative permittivity.  Shape ``(K, nx, ny, nz)``
-            for scalar frequency, or ``(N, K, nx, ny, nz)`` for list frequency, where
-            ``K ∈ {1, 3, 9}`` and exactly one spatial dimension is 1 (the propagation axis).
-        inv_permeabilities: Inverse relative permeability — scalar float or array with the
-            same shape convention as ``inv_permittivities`` (shared across all frequencies).
-        resolution: Uniform grid spacing in metres.  Required when ``transverse_coords``
-            is not provided.
+        frequency: Operating frequency in Hz.
+        inv_permittivities: Inverse relative permittivity, shape ``(K, nx, ny, nz)``
+            where ``K ∈ {1, 3, 9}`` and exactly one spatial dimension is 1.
+        inv_permeabilities: Inverse relative permeability — scalar float or same-shape array.
+        resolution: Uniform grid spacing in metres; required when ``transverse_coords`` is not provided.
         direction: Propagation direction, ``"+"`` or ``"-"``.
-        mode_index: Index into neff-sorted candidate list.  Defaults to 0.
+        mode_index: Index into neff-sorted candidate list. Defaults to 0.
         filter_pol: Optional ``"te"`` / ``"tm"`` polarisation filter.
         dtype: Float dtype; controls complex64 vs complex128 output.
         bend_radius: Waveguide bend radius in metres; requires ``bend_axis``.
         bend_axis: Physical axis index toward the centre of curvature.
         symmetry: Per-transverse-axis symmetry condition at the min edge.
         transverse_coords: Optional pair of physical edge-coordinate arrays in metres.
-        target_neff: Selects the mode closest to this effective index.  Only valid for
-            scalar frequency.
+        target_neff: Selects the mode whose ``real(neff)`` is closest to this value.
+            Mutually exclusive with ``reference_E``.
         reference_E: Selects the mode with the highest field dot-product overlap with this
-            reference E-field (shape ``(3, nx, ny, nz)``).  Only valid for scalar frequency.
+            reference field, shape ``(3, nx, ny, nz)``.  Pass the previous frequency's
+            mode_E to track the same physical mode across a manual sweep.
+            Mutually exclusive with ``target_neff``.
 
     Returns:
-        ``(mode_E, mode_H, neff)`` for scalar frequency, or ``(mode_Es, mode_Hs, neffs)``
-        for list frequency.  Fields are Poynting-flux normalised to unit power.
+        ``(mode_E, mode_H, neff)`` — fields shaped ``(3, nx, ny, nz)``, scalar neff.
+        Fields are Poynting-flux normalised to unit power.
     """
-    scalar_input = isinstance(frequency, (int, float))
-    frequencies = [float(frequency)] if scalar_input else [float(f) for f in frequency]
+    if (
+        not (inv_permittivities.ndim == 4 and inv_permittivities.shape[0] in [1, 3, 9])
+        or sum(s == 1 for s in inv_permittivities.shape[1:]) != 1
+    ):
+        raise ValueError(f"Invalid inv_permittivities shape: {inv_permittivities.shape}")
+    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
+        if (
+            not (inv_permeabilities.ndim == 4 and inv_permeabilities.shape[0] in [1, 3, 9])
+            or sum(s == 1 for s in inv_permeabilities.shape[1:]) != 1
+        ):
+            raise ValueError(f"Invalid inv_permeabilities shape: {inv_permeabilities.shape}")
+    if (bend_radius is None) != (bend_axis is None):
+        raise ValueError("bend_radius and bend_axis must both be set or both be None")
+    if target_neff is not None and reference_E is not None:
+        raise ValueError("target_neff and reference_E are mutually exclusive")
+
+    setup = _build_mode_setup(inv_permittivities, inv_permeabilities, resolution, transverse_coords, dtype)
+    inv_perm_stack = jnp.expand_dims(inv_permittivities, 0)
+
+    def _solve(inv_perm_np, perm_mu, c0_arr, c1_arr):
+        coords = [np.asarray(c0_arr), np.asarray(c1_arr)]
+        if bend_radius is not None:
+            transverse_axes = get_transverse_axes(setup.propagation_axis)
+            bend_radius_um = bend_radius / 1e-6
+            tidy3d_bend_axis = transverse_axes.index(bend_axis)
+            plane_center = (float(0.5 * (coords[0][0] + coords[0][-1])), float(0.5 * (coords[1][0] + coords[1][-1])))
+        else:
+            bend_radius_um = tidy3d_bend_axis = plane_center = None
+
+        perm_sq = _prepare_permittivity(inv_perm_np[0], setup.propagation_axis, setup.perm_idx, setup.perm_idx_9)
+        modes = tidy3d_mode_computation_wrapper(
+            frequency=float(frequency),
+            permittivity_cross_section=perm_sq,
+            permeability_cross_section=perm_mu,
+            coords=coords,
+            direction=direction,
+            num_modes=2 * (mode_index + 1) + 10,
+            bend_radius=bend_radius_um,
+            bend_axis=tidy3d_bend_axis,
+            plane_center=plane_center,
+            symmetry=symmetry,
+            target_neff=target_neff,
+        )
+        sorted_modes = sort_modes(modes, filter_pol, (0, 1))
+
+        if reference_E is not None:
+            mode = max(
+                sorted_modes,
+                key=lambda m: float(
+                    np.abs(
+                        np.sum(
+                            np.conj(reference_E)
+                            * np.expand_dims(
+                                _perm_mode_E(m, setup.propagation_axis, setup.np_complex_dtype),
+                                axis=setup.propagation_axis + 1,
+                            )
+                        )
+                    )
+                ),
+            )
+        elif target_neff is not None:
+            mode = min(sorted_modes, key=lambda m: abs(float(np.real(m.neff)) - target_neff))
+        else:
+            mode = sorted_modes[mode_index]
+
+        mode_E = _perm_mode_E(mode, setup.propagation_axis, setup.np_complex_dtype)
+        mode_H = _perm_mode_H(mode, setup.propagation_axis, setup.np_complex_dtype)
+        neff = np.asarray(mode.neff).astype(setup.np_complex_dtype)
+        return np.stack([mode_E], 0), np.stack([mode_H], 0), np.array([neff])
+
+    result_shape_dtype = (
+        jnp.zeros((1, 3, *setup.spatial_2d), dtype=setup.jnp_complex_dtype),
+        jnp.zeros((1, 3, *setup.spatial_2d), dtype=setup.jnp_complex_dtype),
+        jnp.zeros((1,), dtype=setup.jnp_complex_dtype),
+    )
+    mode_Es_raw, mode_Hs_raw, neffs = jax.pure_callback(
+        _solve,
+        result_shape_dtype,
+        jax.lax.stop_gradient(inv_perm_stack),
+        jax.lax.stop_gradient(setup.permeability_squeezed),
+        jax.lax.stop_gradient(setup.c0_um),
+        jax.lax.stop_gradient(setup.c1_um),
+    )
+    mode_Es_norm, mode_Hs_norm, neffs = _postprocess_modes(mode_Es_raw, mode_Hs_raw, neffs, setup)
+    return mode_Es_norm[0], mode_Hs_norm[0], neffs[0]
+
+
+def compute_mode_multiple_frequencies(
+    frequencies: list[float],
+    inv_permittivities: jax.Array,
+    inv_permeabilities: jax.Array | float,
+    resolution: float | None = None,
+    direction: Literal["+", "-"] = "+",
+    mode_index: int = 0,
+    filter_pol: Literal["te", "tm"] | None = None,
+    dtype: jnp.dtype = jnp.float32,
+    bend_radius: float | None = None,
+    bend_axis: int | None = None,
+    symmetry: tuple[int, int] = (0, 0),
+    transverse_coords: Sequence[jax.Array] | None = None,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Compute optical modes at N frequencies with automatic field-overlap tracking.
+
+    Runs all N solves inside a single ``jax.pure_callback`` — safe under ``jax.jit``.
+    Field-overlap tracking selects — at each frequency after the first — the ARPACK
+    candidate with the highest ``|<conj(prev_E), candidate_E>|``, preventing mode
+    hopping at neff branch crossings.
+
+    Args:
+        frequencies: List of N operating frequencies in Hz.
+        inv_permittivities: Stacked inverse permittivity, shape ``(N, K, nx, ny, nz)``
+            where ``K ∈ {1, 3, 9}`` and exactly one spatial dimension is 1.
+            Slice ``i`` is used at ``frequencies[i]``.
+        inv_permeabilities: Inverse relative permeability — scalar float or same-shape
+            array shared across all frequencies.
+        resolution: Uniform grid spacing in metres; required when ``transverse_coords`` is not provided.
+        direction: Propagation direction, ``"+"`` or ``"-"``.
+        mode_index: Index into neff-sorted list for the first frequency. Defaults to 0.
+        filter_pol: Optional ``"te"`` / ``"tm"`` polarisation filter.
+        dtype: Float dtype; controls complex64 vs complex128 output.
+        bend_radius: Waveguide bend radius in metres; requires ``bend_axis``.
+        bend_axis: Physical axis index toward the centre of curvature.
+        symmetry: Per-transverse-axis symmetry condition at the min edge.
+        transverse_coords: Optional pair of physical edge-coordinate arrays in metres.
+
+    Returns:
+        ``(mode_Es, mode_Hs, neffs)`` with shapes ``(N, 3, nx, ny, nz)`` and ``(N,)``.
+        Fields are Poynting-flux normalised to unit power.
+    """
     N = len(frequencies)
-
-    # Normalise to stacked (N, K, nx, ny, nz)
-    if scalar_input:
-        inv_perm_stack = jnp.expand_dims(inv_permittivities, 0)
-        sample = inv_permittivities
-    else:
-        inv_perm_stack = inv_permittivities
-        sample = inv_permittivities[0]
-
-    # Validate shapes
+    sample = inv_permittivities[0]
     if not (sample.ndim == 4 and sample.shape[0] in [1, 3, 9]) or sum(s == 1 for s in sample.shape[1:]) != 1:
         raise ValueError(f"Invalid inv_permittivities shape: {sample.shape}")
     if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
@@ -280,40 +456,28 @@ def compute_mode(
             raise ValueError(f"Invalid inv_permeabilities shape: {inv_permeabilities.shape}")
     if (bend_radius is None) != (bend_axis is None):
         raise ValueError("bend_radius and bend_axis must both be set or both be None")
-    if not scalar_input and (target_neff is not None or reference_E is not None):
-        raise ValueError("target_neff and reference_E are only valid for scalar frequency")
-    if target_neff is not None and reference_E is not None:
-        raise ValueError("target_neff and reference_E are mutually exclusive")
 
-    propagation_axis = sample.shape[1:].index(1)
-    other_axes = [a for a in range(1, 4) if sample.shape[a] != 1]
-    perm_idx, perm_idx_9 = _axis_perm_indices(propagation_axis)
+    setup = _build_mode_setup(sample, inv_permeabilities, resolution, transverse_coords, dtype)
 
-    c0_um, c1_um, area_EuHv, area_EvHu = _build_transverse_coords(
-        sample.shape, propagation_axis, other_axes, resolution, transverse_coords, dtype
-    )
-    permeability_squeezed = _process_permeability(inv_permeabilities, propagation_axis, perm_idx, perm_idx_9)
-
-    np_complex_dtype = np.complex128 if dtype == jnp.float64 else np.complex64
-
-    def _solve_all(inv_perm_stack_np, perm_mu, c0_arr, c1_arr):
+    def _solve(inv_perm_stack_np, perm_mu, c0_arr, c1_arr):
         coords = [np.asarray(c0_arr), np.asarray(c1_arr)]
         if bend_radius is not None:
-            transverse_axes = get_transverse_axes(propagation_axis)
+            transverse_axes = get_transverse_axes(setup.propagation_axis)
             bend_radius_um = bend_radius / 1e-6
             tidy3d_bend_axis = transverse_axes.index(bend_axis)
             plane_center = (float(0.5 * (coords[0][0] + coords[0][-1])), float(0.5 * (coords[1][0] + coords[1][-1])))
         else:
             bend_radius_um = tidy3d_bend_axis = plane_center = None
 
-        prev_E_4d: np.ndarray | None = reference_E
-
+        prev_E_4d: np.ndarray | None = None
         all_Es: list[np.ndarray] = []
         all_Hs: list[np.ndarray] = []
         all_neffs: list[np.ndarray] = []
 
         for i, freq in enumerate(frequencies):
-            perm_sq = _prepare_permittivity(inv_perm_stack_np[i], propagation_axis, perm_idx, perm_idx_9)
+            perm_sq = _prepare_permittivity(
+                inv_perm_stack_np[i], setup.propagation_axis, setup.perm_idx, setup.perm_idx_9
+            )
             modes = tidy3d_mode_computation_wrapper(
                 frequency=freq,
                 permittivity_cross_section=perm_sq,
@@ -325,7 +489,6 @@ def compute_mode(
                 bend_axis=tidy3d_bend_axis,
                 plane_center=plane_center,
                 symmetry=symmetry,
-                target_neff=target_neff if scalar_input else None,
             )
             sorted_modes = sort_modes(modes, filter_pol, (0, 1))
 
@@ -337,56 +500,40 @@ def compute_mode(
                             np.sum(
                                 np.conj(prev_E_4d)
                                 * np.expand_dims(
-                                    _perm_mode_E(m, propagation_axis, np_complex_dtype), axis=propagation_axis + 1
+                                    _perm_mode_E(m, setup.propagation_axis, setup.np_complex_dtype),
+                                    axis=setup.propagation_axis + 1,
                                 )
                             )
                         )
                     ),
                 )
-            elif scalar_input and target_neff is not None:
-                mode = min(sorted_modes, key=lambda m: abs(float(np.real(m.neff)) - target_neff))
             else:
                 mode = sorted_modes[mode_index]
 
-            mode_E = _perm_mode_E(mode, propagation_axis, np_complex_dtype)
-            mode_H = _perm_mode_H(mode, propagation_axis, np_complex_dtype)
-            prev_E_4d = np.expand_dims(mode_E, axis=propagation_axis + 1)
+            mode_E = _perm_mode_E(mode, setup.propagation_axis, setup.np_complex_dtype)
+            mode_H = _perm_mode_H(mode, setup.propagation_axis, setup.np_complex_dtype)
+            prev_E_4d = np.expand_dims(mode_E, axis=setup.propagation_axis + 1)
 
             all_Es.append(mode_E)
             all_Hs.append(mode_H)
-            all_neffs.append(np.asarray(mode.neff).astype(np_complex_dtype))
+            all_neffs.append(np.asarray(mode.neff).astype(setup.np_complex_dtype))
 
         return np.stack(all_Es, 0), np.stack(all_Hs, 0), np.array(all_neffs)
 
-    jnp_complex_dtype = jnp.complex128 if dtype == jnp.float64 else jnp.complex64
-    spatial_2d = tuple(s for i, s in enumerate(sample.shape[1:]) if i != propagation_axis)
     result_shape_dtype = (
-        jnp.zeros((N, 3, *spatial_2d), dtype=jnp_complex_dtype),
-        jnp.zeros((N, 3, *spatial_2d), dtype=jnp_complex_dtype),
-        jnp.zeros((N,), dtype=jnp_complex_dtype),
+        jnp.zeros((N, 3, *setup.spatial_2d), dtype=setup.jnp_complex_dtype),
+        jnp.zeros((N, 3, *setup.spatial_2d), dtype=setup.jnp_complex_dtype),
+        jnp.zeros((N,), dtype=setup.jnp_complex_dtype),
     )
-
     mode_Es_raw, mode_Hs_raw, neffs = jax.pure_callback(
-        _solve_all,
+        _solve,
         result_shape_dtype,
-        jax.lax.stop_gradient(inv_perm_stack),
-        jax.lax.stop_gradient(permeability_squeezed),
-        jax.lax.stop_gradient(c0_um),
-        jax.lax.stop_gradient(c1_um),
+        jax.lax.stop_gradient(inv_permittivities),
+        jax.lax.stop_gradient(setup.permeability_squeezed),
+        jax.lax.stop_gradient(setup.c0_um),
+        jax.lax.stop_gradient(setup.c1_um),
     )
-
-    # Add propagation-axis singleton (axis 0 is the frequency batch)
-    mode_Es = jnp.expand_dims(mode_Es_raw, axis=propagation_axis + 2)
-    mode_Hs = jnp.expand_dims(mode_Hs_raw, axis=propagation_axis + 2) * tidy3d.constants.ETA_0
-
-    def _normalize_one(E: jax.Array, H: jax.Array) -> tuple[jax.Array, jax.Array]:
-        return normalize_by_poynting_flux(E, H, axis=propagation_axis, area_EuHv=area_EuHv, area_EvHu=area_EvHu)
-
-    mode_Es_norm, mode_Hs_norm = jax.vmap(_normalize_one)(mode_Es, mode_Hs)
-
-    if scalar_input:
-        return mode_Es_norm[0], mode_Hs_norm[0], neffs[0]
-    return mode_Es_norm, mode_Hs_norm, neffs
+    return _postprocess_modes(mode_Es_raw, mode_Hs_raw, neffs, setup)
 
 
 def tidy3d_mode_computation_wrapper(

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -13,6 +13,51 @@ from fdtdx.core.axis import get_transverse_axes
 from fdtdx.core.misc import expand_to_3x3
 from fdtdx.core.physics.metrics import normalize_by_poynting_flux
 
+
+def _yee_areas_from_edges(
+    edges_0: jax.Array,
+    edges_1: jax.Array,
+    phys_axis_0: int,
+    phys_axis_1: int,
+    propagation_axis: int,
+    dtype: jnp.dtype,
+) -> tuple[jax.Array, jax.Array]:
+    """Return Yee-staggered face-area arrays from physical edge coordinates.
+
+    Args:
+        edges_0: Edge coordinates (m) along the first transverse axis.
+        edges_1: Edge coordinates (m) along the second transverse axis.
+        phys_axis_0: Physical axis index (0/1/2) corresponding to edges_0.
+        phys_axis_1: Physical axis index (0/1/2) corresponding to edges_1.
+        propagation_axis: Physical propagation axis.
+        dtype: Output dtype.
+
+    Returns:
+        ``(area_EuHv, area_EvHu)`` broadcast-ready to 3D spatial shape with a
+        singleton along the propagation axis.
+    """
+    u, v = [(1, 2), (2, 0), (0, 1)][propagation_axis]
+    edges_u = jnp.asarray(edges_0) if phys_axis_0 == u else jnp.asarray(edges_1)
+    edges_v = jnp.asarray(edges_1) if phys_axis_0 == u else jnp.asarray(edges_0)
+
+    primal_u = jnp.diff(edges_u)
+    primal_v = jnp.diff(edges_v)
+    centers_u = 0.5 * (edges_u[:-1] + edges_u[1:])
+    centers_v = 0.5 * (edges_v[:-1] + edges_v[1:])
+    # Boundary approximation: half the first primal width (same as RectilinearGrid.dual_widths at lo=0)
+    dual_u = jnp.concatenate([jnp.array([centers_u[0] - edges_u[0]]), jnp.diff(centers_u)])
+    dual_v = jnp.concatenate([jnp.array([centers_v[0] - edges_v[0]]), jnp.diff(centers_v)])
+
+    def _expand(arr: jax.Array, phys_ax: int) -> jax.Array:
+        shape = [1, 1, 1]
+        shape[phys_ax] = arr.shape[0]
+        return arr.reshape(shape).astype(dtype)
+
+    area_EuHv = _expand(primal_u, u) * _expand(dual_v, v)
+    area_EvHu = _expand(dual_u, u) * _expand(primal_v, v)
+    return area_EuHv, area_EvHu
+
+
 ModeTupleType = namedtuple("ModeTupleType", ["neff", "Ex", "Ey", "Ez", "Hx", "Hy", "Hz"])
 """A named tuple containing the mode fields and effective index.
 
@@ -237,7 +282,8 @@ def compute_mode(
         # Uniform grid: build concrete coordinate arrays in µm and pass as callback args.
         c0_um = jnp.asarray(np.arange(permittivities.shape[other_axes[0]] + 1) * resolution / 1e-6)
         c1_um = jnp.asarray(np.arange(permittivities.shape[other_axes[1]] + 1) * resolution / 1e-6)
-        normalization_area_weights = None
+        normalization_area_EuHv = None
+        normalization_area_EvHu = None
     else:
         if len(transverse_coords) != 2:
             raise ValueError(
@@ -253,14 +299,15 @@ def compute_mode(
         # Convert to µm for tidy3d; keep as JAX arrays so jax.jit can trace through.
         c0_um = jnp.asarray(transverse_coords[0]) / 1e-6
         c1_um = jnp.asarray(transverse_coords[1]) / 1e-6
-        # area_2d in m²: use jnp.diff so this works with traced JAX arrays.
-        area_2d = (
-            jnp.diff(jnp.asarray(transverse_coords[0]))[:, None] * jnp.diff(jnp.asarray(transverse_coords[1]))[None, :]
-        ).astype(dtype)
-        weight_shape = [1, 1, 1]
-        weight_shape[other_axes[0] - 1] = area_2d.shape[0]
-        weight_shape[other_axes[1] - 1] = area_2d.shape[1]
-        normalization_area_weights = area_2d.reshape(weight_shape)
+        # Yee-staggered areas for normalization — consistent with bidirectional_mode_overlap.
+        normalization_area_EuHv, normalization_area_EvHu = _yee_areas_from_edges(
+            edges_0=jnp.asarray(transverse_coords[0]),
+            edges_1=jnp.asarray(transverse_coords[1]),
+            phys_axis_0=other_axes[0] - 1,
+            phys_axis_1=other_axes[1] - 1,
+            propagation_axis=propagation_axis,
+            dtype=dtype,
+        )
     permittivity_squeezed = jnp.take(
         permittivities,
         indices=0,
@@ -344,7 +391,8 @@ def compute_mode(
         mode_E,
         mode_H,
         axis=propagation_axis,
-        area_weights=normalization_area_weights,
+        area_EuHv=normalization_area_EuHv,
+        area_EvHu=normalization_area_EvHu,
     )
 
     return mode_E_norm, mode_H_norm, eff_idx
@@ -362,6 +410,7 @@ def compute_modes_multi_freq(
     bend_radius: float | None = None,
     bend_axis: int | None = None,
     transverse_coords: Sequence[ArrayLike] | None = None,
+    inv_permittivities_per_freq: list[jax.Array] | None = None,
 ) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Compute waveguide modes at multiple frequencies with continuity tracking.
 
@@ -398,6 +447,11 @@ def compute_modes_multi_freq(
         bend_radius: Bend radius in metres.  Must be set together with ``bend_axis``.
         bend_axis: Physical axis (0/1/2) pointing toward the centre of curvature.
         transverse_coords: Optional pair of physical edge-coordinate arrays in metres.
+        inv_permittivities_per_freq: Optional list of ``num_freqs`` inverse-permittivity
+            arrays, each with the same shape as ``inv_permittivities``.  When provided,
+            each frequency is solved with its own permittivity (e.g. after dispersive
+            correction via :func:`fdtdx.dispersion.effective_inv_permittivity`).
+            When ``None``, every frequency uses the shared ``inv_permittivities``.
 
     Returns:
         Tuple ``(mode_Es, mode_Hs, mode_neffs)`` where ``mode_Es`` and ``mode_Hs``
@@ -440,7 +494,8 @@ def compute_modes_multi_freq(
         if resolution is None:
             raise ValueError("resolution is required when transverse_coords is not provided")
         coords = [np.arange(permittivities.shape[dim] + 1) * resolution / 1e-6 for dim in other_axes]
-        normalization_area_weights = None
+        normalization_area_EuHv = None
+        normalization_area_EvHu = None
     else:
         if len(transverse_coords) != 2:
             raise ValueError(
@@ -456,11 +511,15 @@ def compute_modes_multi_freq(
             if np.any(np.diff(coord) <= 0):
                 raise ValueError(f"transverse_coords[{axis_idx}] must be strictly increasing")
         coords = [coord / 1e-6 for coord in coords_meter]
-        area_2d = jnp.asarray(np.diff(coords_meter[0])[:, None] * np.diff(coords_meter[1])[None, :], dtype=dtype)
-        weight_shape = [1, 1, 1]
-        weight_shape[other_axes[0] - 1] = area_2d.shape[0]
-        weight_shape[other_axes[1] - 1] = area_2d.shape[1]
-        normalization_area_weights = area_2d.reshape(weight_shape)
+        # Yee-staggered areas for normalization — consistent with bidirectional_mode_overlap.
+        normalization_area_EuHv, normalization_area_EvHu = _yee_areas_from_edges(
+            edges_0=jnp.asarray(coords_meter[0]),
+            edges_1=jnp.asarray(coords_meter[1]),
+            phys_axis_0=other_axes[0] - 1,
+            phys_axis_1=other_axes[1] - 1,
+            propagation_axis=propagation_axis,
+            dtype=dtype,
+        )
     permittivity_squeezed = jnp.take(permittivities, indices=0, axis=propagation_axis + 1)
 
     if propagation_axis == 0:
@@ -477,6 +536,34 @@ def compute_modes_multi_freq(
         permittivity_squeezed = permittivity_squeezed[jnp.array(perm_idx), :, :]
     if permittivity_squeezed.shape[0] == 9:
         permittivity_squeezed = permittivity_squeezed[jnp.array(perm_idx_full_anisotropy), :, :]
+
+    # Per-frequency permittivity (for dispersive correction).  When not provided,
+    # broadcast the base permittivity so the callback always receives a uniform
+    # (num_freqs, comp, ny, nz) array — one slice per frequency.
+    if inv_permittivities_per_freq is not None:
+        if len(inv_permittivities_per_freq) != num_freqs:
+            raise ValueError(
+                f"inv_permittivities_per_freq must have length {num_freqs}, got {len(inv_permittivities_per_freq)}"
+            )
+
+        def _squeeze_rotate(inv_perm_i: jax.Array) -> jax.Array:
+            if inv_perm_i.shape[0] == 9:
+                eps_i = expand_to_3x3(inv_perm_i)
+                perm_t = (2, 3, 4, 0, 1)
+                inv_perm_t = (3, 4, 0, 1, 2)
+                perm_i = jnp.linalg.inv(eps_i.transpose(perm_t)).transpose(inv_perm_t).reshape(9, *inv_perm_i.shape[1:])
+            else:
+                perm_i = 1 / inv_perm_i
+            sq = jnp.take(perm_i, indices=0, axis=propagation_axis + 1)
+            if sq.shape[0] == 3:
+                sq = sq[jnp.array(perm_idx), :, :]
+            if sq.shape[0] == 9:
+                sq = sq[jnp.array(perm_idx_full_anisotropy), :, :]
+            return sq
+
+        permittivity_squeezed_per_freq = jnp.stack([_squeeze_rotate(p) for p in inv_permittivities_per_freq])
+    else:
+        permittivity_squeezed_per_freq = jnp.stack([permittivity_squeezed] * num_freqs)
 
     jnp_complex_dtype = jnp.complex128 if dtype == jnp.float64 else jnp.complex64
 
@@ -499,7 +586,7 @@ def compute_modes_multi_freq(
     else:
         permeability_squeezed = permeabilities
 
-    def multi_freq_helper(permittivity, permeability):
+    def multi_freq_helper(permittivity_per_freq, permeability):
         if bend_radius is not None:
             assert bend_axis is not None
             transverse_axes = [ax for ax in range(3) if ax != propagation_axis]
@@ -516,12 +603,12 @@ def compute_modes_multi_freq(
 
         num_modes = 2 * (mode_index + 1) + 10
 
-        # Solve all candidate modes at every frequency
+        # Solve all candidate modes at every frequency using the per-frequency permittivity
         all_candidates = []
-        for freq in frequencies:
+        for i, freq in enumerate(frequencies):
             modes = tidy3d_mode_computation_wrapper(
                 frequency=freq,
-                permittivity_cross_section=permittivity,
+                permittivity_cross_section=permittivity_per_freq[i],
                 permeability_cross_section=permeability,
                 coords=coords,
                 direction=direction,
@@ -572,7 +659,7 @@ def compute_modes_multi_freq(
     mode_Es_raw, mode_Hs_raw, eff_idxs = jax.pure_callback(
         multi_freq_helper,
         result_shape_dtype,
-        jax.lax.stop_gradient(permittivity_squeezed),
+        jax.lax.stop_gradient(permittivity_squeezed_per_freq),
         jax.lax.stop_gradient(permeability_squeezed),
     )
 
@@ -581,7 +668,13 @@ def compute_modes_multi_freq(
     for i in range(num_freqs):
         me = jnp.expand_dims(mode_Es_raw[i], axis=propagation_axis + 1)
         mh = jnp.expand_dims(mode_Hs_raw[i], axis=propagation_axis + 1) * tidy3d.constants.ETA_0
-        me_n, mh_n = normalize_by_poynting_flux(me, mh, axis=propagation_axis, area_weights=normalization_area_weights)
+        me_n, mh_n = normalize_by_poynting_flux(
+            me,
+            mh,
+            axis=propagation_axis,
+            area_EuHv=normalization_area_EuHv,
+            area_EvHu=normalization_area_EvHu,
+        )
         mode_Es_norm.append(me_n)
         mode_Hs_norm.append(mh_n)
 

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -10,53 +10,9 @@ from jax.typing import ArrayLike
 from tidy3d.components.mode.solver import compute_modes as _compute_modes
 
 from fdtdx.core.axis import get_transverse_axes
+from fdtdx.core.grid import yee_face_areas_from_edges
 from fdtdx.core.misc import expand_to_3x3
 from fdtdx.core.physics.metrics import normalize_by_poynting_flux
-
-
-def _yee_areas_from_edges(
-    edges_0: jax.Array,
-    edges_1: jax.Array,
-    phys_axis_0: int,
-    phys_axis_1: int,
-    propagation_axis: int,
-    dtype: jnp.dtype,
-) -> tuple[jax.Array, jax.Array]:
-    """Return Yee-staggered face-area arrays from physical edge coordinates.
-
-    Args:
-        edges_0: Edge coordinates (m) along the first transverse axis.
-        edges_1: Edge coordinates (m) along the second transverse axis.
-        phys_axis_0: Physical axis index (0/1/2) corresponding to edges_0.
-        phys_axis_1: Physical axis index (0/1/2) corresponding to edges_1.
-        propagation_axis: Physical propagation axis.
-        dtype: Output dtype.
-
-    Returns:
-        ``(area_EuHv, area_EvHu)`` broadcast-ready to 3D spatial shape with a
-        singleton along the propagation axis.
-    """
-    u, v = [(1, 2), (2, 0), (0, 1)][propagation_axis]
-    edges_u = jnp.asarray(edges_0) if phys_axis_0 == u else jnp.asarray(edges_1)
-    edges_v = jnp.asarray(edges_1) if phys_axis_0 == u else jnp.asarray(edges_0)
-
-    primal_u = jnp.diff(edges_u)
-    primal_v = jnp.diff(edges_v)
-    centers_u = 0.5 * (edges_u[:-1] + edges_u[1:])
-    centers_v = 0.5 * (edges_v[:-1] + edges_v[1:])
-    # Boundary approximation: half the first primal width (same as RectilinearGrid.dual_widths at lo=0)
-    dual_u = jnp.concatenate([jnp.array([centers_u[0] - edges_u[0]]), jnp.diff(centers_u)])
-    dual_v = jnp.concatenate([jnp.array([centers_v[0] - edges_v[0]]), jnp.diff(centers_v)])
-
-    def _expand(arr: jax.Array, phys_ax: int) -> jax.Array:
-        shape = [1, 1, 1]
-        shape[phys_ax] = arr.shape[0]
-        return arr.reshape(shape).astype(dtype)
-
-    area_EuHv = _expand(primal_u, u) * _expand(dual_v, v)
-    area_EvHu = _expand(dual_u, u) * _expand(primal_v, v)
-    return area_EuHv, area_EvHu
-
 
 ModeTupleType = namedtuple("ModeTupleType", ["neff", "Ex", "Ey", "Ez", "Hx", "Hy", "Hz"])
 """A named tuple containing the mode fields and effective index.
@@ -309,12 +265,18 @@ def compute_mode(
         c0_um = jnp.asarray(transverse_coords[0]) / 1e-6
         c1_um = jnp.asarray(transverse_coords[1]) / 1e-6
         # Yee-staggered areas for normalization — consistent with bidirectional_mode_overlap.
-        normalization_area_EuHv, normalization_area_EvHu = _yee_areas_from_edges(
-            edges_0=jnp.asarray(transverse_coords[0]),
-            edges_1=jnp.asarray(transverse_coords[1]),
-            phys_axis_0=other_axes[0] - 1,
-            phys_axis_1=other_axes[1] - 1,
-            propagation_axis=propagation_axis,
+        # other_axes are tensor axes (1-indexed); subtract 1 to get physical axes (0-indexed).
+        # transverse_coords[i] corresponds to physical axis other_axes[i] - 1, which may not match
+        # the Yee u/v ordering, so we explicitly map to the correct edge arrays.
+        u, v = [(1, 2), (2, 0), (0, 1)][propagation_axis]
+        phys_axis_0 = other_axes[0] - 1
+        edges_u = jnp.asarray(transverse_coords[0] if phys_axis_0 == u else transverse_coords[1])
+        edges_v = jnp.asarray(transverse_coords[1] if phys_axis_0 == u else transverse_coords[0])
+        normalization_area_EuHv, normalization_area_EvHu = yee_face_areas_from_edges(
+            edges_u=edges_u,
+            edges_v=edges_v,
+            u_axis=u,
+            v_axis=v,
             dtype=dtype,
         )
     permittivity_squeezed = jnp.take(

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -8,7 +8,7 @@ from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.core.null import Null
 from fdtdx.core.physics.metrics import bidirectional_mode_overlap
-from fdtdx.core.physics.modes import compute_mode
+from fdtdx.core.physics.modes import compute_mode_multiple_frequencies
 from fdtdx.dispersion import effective_inv_permittivity
 from fdtdx.objects.detectors.detector import DetectorState
 from fdtdx.objects.detectors.phasor import PhasorDetector
@@ -137,7 +137,7 @@ class ModeOverlapDetector(PhasorDetector):
     def _mode_solver_resolution(self) -> float:
         """Return scalar resolution only for legacy uniform mode-solver setup.
 
-        ``compute_mode`` ignores this value when explicit transverse coordinates
+        ``compute_mode_multiple_frequencies`` ignores this value when explicit transverse coordinates
         are supplied.  For non-uniform grids we pass a harmless finite value so
         the compatibility argument does not force a uniform-grid check.
         """
@@ -189,8 +189,8 @@ class ModeOverlapDetector(PhasorDetector):
         inv_eps_stack = jnp.stack(inv_eps_per_freq, axis=0)
         frequencies = [wc.get_frequency() for wc in self.wave_characters]
 
-        mode_Es, mode_Hs, mode_neffs = compute_mode(
-            frequency=frequencies,
+        mode_Es, mode_Hs, mode_neffs = compute_mode_multiple_frequencies(
+            frequencies=frequencies,
             inv_permittivities=inv_eps_stack,
             inv_permeabilities=inv_permeability_slice,
             resolution=self._mode_solver_resolution(),

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -1,14 +1,14 @@
+import math
 from typing import Literal, Self, Sequence
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 
 from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.core.null import Null
 from fdtdx.core.physics.metrics import bidirectional_mode_overlap
-from fdtdx.core.physics.modes import compute_mode
+from fdtdx.core.physics.modes import compute_modes_tracked
 from fdtdx.dispersion import effective_inv_permittivity
 from fdtdx.objects.detectors.detector import DetectorState
 from fdtdx.objects.detectors.phasor import PhasorDetector
@@ -162,13 +162,11 @@ class ModeOverlapDetector(PhasorDetector):
         else:
             inv_permeability_slice = inv_permeabilities
 
-        # Solve one mode per frequency. Each compute_mode call is a jax.pure_callback
-        # and is fully jit-compatible.
-        mode_Es: list[jax.Array] = []
-        mode_Hs: list[jax.Array] = []
-        mode_neffs: list[jax.Array] = []
+        # Build per-frequency inverse permittivities (applies dispersive correction
+        # per frequency if needed). This is a Python loop over wave characters but
+        # the body is pure JAX ops — safe under jax.jit.
+        inv_eps_per_freq: list[jax.Array] = []
         for wc in self.wave_characters:
-            # Apply dispersive correction so the mode solver sees ε(ω) rather than ε∞.
             if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
                 c1_slice = dispersive_c1[:, :, *self.grid_slice]
                 c2_slice = dispersive_c2[:, :, *self.grid_slice]
@@ -178,34 +176,37 @@ class ModeOverlapDetector(PhasorDetector):
                     c1=c1_slice,
                     c2=c2_slice,
                     c3=c3_slice,
-                    omega=2.0 * np.pi * wc.get_frequency(),
+                    omega=2.0 * math.pi * wc.get_frequency(),
                     dt=self._config.time_step_duration,
                 )
             else:
                 inv_eps_i = inv_permittivity_slice
+            inv_eps_per_freq.append(inv_eps_i)
 
-            mode_E, mode_H, neff = compute_mode(
-                frequency=wc.get_frequency(),
-                inv_permittivities=inv_eps_i,
-                inv_permeabilities=inv_permeability_slice,
-                resolution=self._mode_solver_resolution(),
-                direction=self.direction,
-                mode_index=self.mode_index,
-                filter_pol=self.filter_pol,
-                dtype=self._config.dtype,
-                bend_radius=self.bend_radius,
-                bend_axis=self.bend_axis,
-                symmetry=self.symmetry,
-                transverse_coords=self._transverse_edge_coordinates(),
-            )
-            mode_Es.append(mode_E)
-            mode_Hs.append(mode_H)
-            mode_neffs.append(neff)
+        # All frequencies solved in a single jax.pure_callback with field-overlap
+        # tracking inside — safe under jax.jit because concrete numpy arrays are
+        # only accessed within the callback, never between traced operations.
+        inv_eps_stack = jnp.stack(inv_eps_per_freq, axis=0)
+        frequencies = [wc.get_frequency() for wc in self.wave_characters]
 
-        # Spatial dims are fixed at place_on_grid time, so all frequencies share the same shape.
-        self = self.aset("_mode_E", jnp.stack(mode_Es), create_new_ok=True)
-        self = self.aset("_mode_H", jnp.stack(mode_Hs), create_new_ok=True)
-        self = self.aset("_mode_neff", jnp.stack(mode_neffs), create_new_ok=True)
+        mode_Es, mode_Hs, mode_neffs = compute_modes_tracked(
+            frequencies=frequencies,
+            inv_permittivities_stack=inv_eps_stack,
+            inv_permeabilities=inv_permeability_slice,
+            resolution=self._mode_solver_resolution(),
+            direction=self.direction,
+            mode_index=self.mode_index,
+            filter_pol=self.filter_pol,
+            dtype=self._config.dtype,
+            bend_radius=self.bend_radius,
+            bend_axis=self.bend_axis,
+            symmetry=self.symmetry,
+            transverse_coords=self._transverse_edge_coordinates(),
+        )
+
+        self = self.aset("_mode_E", mode_Es, create_new_ok=True)
+        self = self.aset("_mode_H", mode_Hs, create_new_ok=True)
+        self = self.aset("_mode_neff", mode_neffs, create_new_ok=True)
         return self
 
     def compute_overlap_to_mode(

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -8,7 +8,7 @@ from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.core.null import Null
 from fdtdx.core.physics.metrics import bidirectional_mode_overlap
-from fdtdx.core.physics.modes import compute_modes_tracked
+from fdtdx.core.physics.modes import compute_mode
 from fdtdx.dispersion import effective_inv_permittivity
 from fdtdx.objects.detectors.detector import DetectorState
 from fdtdx.objects.detectors.phasor import PhasorDetector
@@ -189,9 +189,9 @@ class ModeOverlapDetector(PhasorDetector):
         inv_eps_stack = jnp.stack(inv_eps_per_freq, axis=0)
         frequencies = [wc.get_frequency() for wc in self.wave_characters]
 
-        mode_Es, mode_Hs, mode_neffs = compute_modes_tracked(
-            frequencies=frequencies,
-            inv_permittivities_stack=inv_eps_stack,
+        mode_Es, mode_Hs, mode_neffs = compute_mode(
+            frequency=frequencies,
+            inv_permittivities=inv_eps_stack,
             inv_permeabilities=inv_permeability_slice,
             resolution=self._mode_solver_resolution(),
             direction=self.direction,

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -29,7 +29,7 @@ class ModeOverlapDetector(PhasorDetector):
 
     ``compute_overlap()`` returns a complex array of shape ``(num_freqs,)``, where
     ``num_freqs = len(wave_characters)``.  Modes are solved once per frequency during
-    ``apply()``, with neff-proximity tracking to prevent mode hopping across frequencies.
+    ``apply()``, which is fully compatible with ``jax.jit``.
     """
 
     #: Direction of mode propagation, either "+" (forward) or "-" (backward).
@@ -162,11 +162,11 @@ class ModeOverlapDetector(PhasorDetector):
         else:
             inv_permeability_slice = inv_permeabilities
 
-        # Solve one mode per frequency with neff-proximity tracking.
+        # Solve one mode per frequency. Each compute_mode call is a jax.pure_callback
+        # and is fully jit-compatible.
         mode_Es: list[jax.Array] = []
         mode_Hs: list[jax.Array] = []
         mode_neffs: list[jax.Array] = []
-        prev_neff: float | None = None
         for wc in self.wave_characters:
             # Apply dispersive correction so the mode solver sees ε(ω) rather than ε∞.
             if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
@@ -197,9 +197,7 @@ class ModeOverlapDetector(PhasorDetector):
                 bend_axis=self.bend_axis,
                 symmetry=self.symmetry,
                 transverse_coords=self._transverse_edge_coordinates(),
-                target_neff=prev_neff,
             )
-            prev_neff = float(np.real(neff))  # requires eager execution — apply() must never be jit'd
             mode_Es.append(mode_E)
             mode_Hs.append(mode_H)
             mode_neffs.append(neff)

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -8,7 +8,7 @@ from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.core.null import Null
 from fdtdx.core.physics.metrics import bidirectional_mode_overlap
-from fdtdx.core.physics.modes import compute_mode_multiple_frequencies
+from fdtdx.core.physics.modes import compute_mode
 from fdtdx.dispersion import effective_inv_permittivity
 from fdtdx.objects.detectors.detector import DetectorState
 from fdtdx.objects.detectors.phasor import PhasorDetector
@@ -137,7 +137,7 @@ class ModeOverlapDetector(PhasorDetector):
     def _mode_solver_resolution(self) -> float:
         """Return scalar resolution only for legacy uniform mode-solver setup.
 
-        ``compute_mode_multiple_frequencies`` ignores this value when explicit transverse coordinates
+        ``compute_mode`` ignores this value when explicit transverse coordinates
         are supplied.  For non-uniform grids we pass a harmless finite value so
         the compatibility argument does not force a uniform-grid check.
         """
@@ -189,7 +189,7 @@ class ModeOverlapDetector(PhasorDetector):
         inv_eps_stack = jnp.stack(inv_eps_per_freq, axis=0)
         frequencies = [wc.get_frequency() for wc in self.wave_characters]
 
-        mode_Es, mode_Hs, mode_neffs = compute_mode_multiple_frequencies(
+        mode_Es, mode_Hs, mode_neffs = compute_mode(
             frequencies=frequencies,
             inv_permittivities=inv_eps_stack,
             inv_permeabilities=inv_permeability_slice,

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -2,13 +2,12 @@ from typing import Literal, Self, Sequence
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 
 from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.core.null import Null
-from fdtdx.core.physics.modes import compute_mode
-from fdtdx.dispersion import effective_inv_permittivity
+from fdtdx.core.physics.metrics import bidirectional_mode_overlap
+from fdtdx.core.physics.modes import compute_modes_multi_freq
 from fdtdx.objects.detectors.detector import DetectorState
 from fdtdx.objects.detectors.phasor import PhasorDetector
 from fdtdx.typing import SliceTuple3D
@@ -18,14 +17,18 @@ from fdtdx.typing import SliceTuple3D
 class ModeOverlapDetector(PhasorDetector):
     """
     Detector for measuring the overlap of a waveguide mode with the simulation fields.
-    This detector computes the overlap of a mode with the phasor fields at a specified
-    frequency, enabling frequency-domain analysis of the electromagnetic fields.
+    This detector computes the overlap integral at every frequency in ``wave_characters``,
+    enabling broadband frequency-domain analysis of the electromagnetic fields.
 
     The mode overlap is calculated by integrating the cross product of the mode fields
     with the simulation fields over a cross-sectional plane. This is useful for
     analyzing waveguide coupling efficiency, transmission coefficients, and modal
     decomposition of electromagnetic fields.
 
+    ``compute_overlap()`` returns a complex array of shape ``(num_freqs,)``, where
+    ``num_freqs = len(wave_characters)``.  All frequencies are solved in a single
+    ``jax.pure_callback`` call during ``apply()``, with neff-proximity tracking to
+    prevent mode hopping across frequencies.
     """
 
     #: Direction of mode propagation, either "+" (forward) or "-" (backward).
@@ -69,8 +72,9 @@ class ModeOverlapDetector(PhasorDetector):
 
     _mode_E: jax.Array = private_field()
     _mode_H: jax.Array = private_field()
-    _mode_neff: jax.Array = private_field()  # not required for detection, used for inspection
-    _cached_face_area_weights: jax.Array = private_field()
+    _mode_neff: jax.Array = private_field()  # shape (num_freqs,) after apply(); for inspection only
+    _cached_area_EuHv: jax.Array = private_field()  # EuxHv Yee face areas; set in place_on_grid
+    _cached_area_EvHu: jax.Array = private_field()  # EvxHu Yee face areas; set in place_on_grid
 
     @property
     def propagation_axis(self) -> int:
@@ -89,8 +93,6 @@ class ModeOverlapDetector(PhasorDetector):
             config=config,
             key=key,
         )
-        if len(self.wave_characters) > 1:
-            raise NotImplementedError()
         if (self.bend_radius is None) != (self.bend_axis is None):
             raise ValueError("bend_radius and bend_axis must both be set or both be None")
         if self.bend_axis is not None and self.bend_axis == self.propagation_axis:
@@ -99,16 +101,17 @@ class ModeOverlapDetector(PhasorDetector):
             )
         grid = self._config.resolved_grid
         if grid is not None:
-            weights = grid.face_area(axis=self.propagation_axis, slice_tuple=self.grid_slice_tuple)
+            area_EuHv, area_EvHu = grid.yee_face_areas(
+                propagation_axis=self.propagation_axis,
+                slice_tuple=self.grid_slice_tuple,
+            )
         else:
             spacing = self._config.uniform_spacing()
-            weights = jnp.ones(self.grid_shape, dtype=jnp.float32) * spacing * spacing
-        self = self.aset("_cached_face_area_weights", weights, create_new_ok=True)
+            area_EuHv = jnp.ones(self.grid_shape, dtype=jnp.float32) * spacing * spacing
+            area_EvHu = area_EuHv
+        self = self.aset("_cached_area_EuHv", area_EuHv, create_new_ok=True)
+        self = self.aset("_cached_area_EvHu", area_EvHu, create_new_ok=True)
         return self
-
-    def _face_area_weights(self) -> jax.Array:
-        """Return detector-plane face areas for mode-overlap integration."""
-        return self._cached_face_area_weights
 
     def _transverse_edge_coordinates(self) -> tuple[jax.Array, jax.Array] | None:
         """Return physical transverse edge coordinates for the mode solver.
@@ -158,26 +161,9 @@ class ModeOverlapDetector(PhasorDetector):
         else:
             inv_permeability_slice = inv_permeabilities
 
-        # Frequency-correct the permittivity seen by the mode solver so the
-        # reference mode profile reflects ε(ω_c) of any dispersive medium the
-        # detector sits in, not just ε∞. Matches the pattern in
-        # ModePlaneSource.apply. Cells with no pole have c1=c2=c3=0, in which
-        # case effective_inv_permittivity returns inv_eps unchanged.
-        if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
-            c1_slice = dispersive_c1[:, :, *self.grid_slice]
-            c2_slice = dispersive_c2[:, :, *self.grid_slice]
-            c3_slice = dispersive_c3[:, :, *self.grid_slice]
-            inv_permittivity_slice = effective_inv_permittivity(
-                inv_eps=inv_permittivity_slice,
-                c1=c1_slice,
-                c2=c2_slice,
-                c3=c3_slice,
-                omega=2.0 * np.pi * self.wave_characters[0].get_frequency(),
-                dt=self._config.time_step_duration,
-            )
-
-        mode_E, mode_H, mode_neff = compute_mode(
-            frequency=self.wave_characters[0].get_frequency(),
+        # All frequencies solved in one call with neff-proximity continuity tracking.
+        mode_Es, mode_Hs, mode_neffs = compute_modes_multi_freq(
+            frequencies=[wc.get_frequency() for wc in self.wave_characters],
             inv_permittivities=inv_permittivity_slice,
             inv_permeabilities=inv_permeability_slice,
             resolution=self._mode_solver_resolution(),
@@ -191,9 +177,9 @@ class ModeOverlapDetector(PhasorDetector):
             transverse_coords=self._transverse_edge_coordinates(),
         )
 
-        self = self.aset("_mode_E", mode_E, create_new_ok=True)
-        self = self.aset("_mode_H", mode_H, create_new_ok=True)
-        self = self.aset("_mode_neff", mode_neff, create_new_ok=True)
+        self = self.aset("_mode_E", mode_Es, create_new_ok=True)
+        self = self.aset("_mode_H", mode_Hs, create_new_ok=True)
+        self = self.aset("_mode_neff", mode_neffs, create_new_ok=True)
         return self
 
     def compute_overlap_to_mode(
@@ -201,27 +187,33 @@ class ModeOverlapDetector(PhasorDetector):
         state: DetectorState,
         mode_E: jax.Array,
         mode_H: jax.Array,
+        freq_idx: int = 0,
     ) -> jax.Array:
-        # shape (time step, num_freqs, num_components, *spatial)
-        # time steps is always 1 and num_components always 6
+        """Compute the mode overlap integral for a single mode and frequency slot.
+
+        Args:
+            state: Detector state containing accumulated phasors, shape
+                ``(1, num_freqs, 6, *spatial)``.
+            mode_E: Electric field of the target mode, shape ``(3, *spatial)``.
+            mode_H: Magnetic field of the target mode, shape ``(3, *spatial)``.
+            freq_idx: Index into the frequency axis of the phasor state.  Defaults
+                to 0 (first / only frequency).
+
+        Returns:
+            Complex scalar overlap coefficient.
+        """
         phasors = state["phasor"]
-        phasors_E, phasors_H = phasors[0, 0, :3], phasors[0, 0, 3:]
+        phasors_E, phasors_H = phasors[0, freq_idx, :3], phasors[0, freq_idx, 3:]
 
-        E_cross_H_star_sim = jnp.cross(
-            mode_E,
-            jnp.conj(phasors_H),
-            axis=0,
-        )[self.propagation_axis]
-
-        E_star_cross_H_sim = jnp.cross(
-            jnp.conj(phasors_E),
-            mode_H,
-            axis=0,
-        )[self.propagation_axis]
-
-        integrand = E_cross_H_star_sim + E_star_cross_H_sim
-        integrand = integrand * self._face_area_weights()
-        alpha_coeff = jnp.sum(integrand)
+        alpha_coeff = bidirectional_mode_overlap(
+            mode_E=mode_E,
+            mode_H=mode_H,
+            sim_E=phasors_E,
+            sim_H=phasors_H,
+            propagation_axis=self.propagation_axis,
+            area_EuHv=self._cached_area_EuHv,
+            area_EvHu=self._cached_area_EvHu,
+        )
 
         # in pulsed mode return unscaled coefficient
         if self.scaling_mode != "pulse":
@@ -233,10 +225,24 @@ class ModeOverlapDetector(PhasorDetector):
         self,
         state: DetectorState,
     ) -> jax.Array:
+        """Compute mode overlaps for all frequencies.
+
+        Returns:
+            Complex array of shape ``(num_freqs,)`` where ``num_freqs =
+            len(wave_characters)``.  Each element is the overlap coefficient
+            at the corresponding frequency.  Callers that previously consumed a
+            scalar result (single-frequency case) must index the returned array,
+            e.g. ``result[0]``.
+        """
         if isinstance(self._mode_E, Null) or isinstance(self._mode_H, Null):
             raise Exception("Need to call apply on ModeOverlapDetector before calling compute_mode_overlap!")
-        return self.compute_overlap_to_mode(
-            state=state,
-            mode_E=self._mode_E,
-            mode_H=self._mode_H,
-        )
+        results = [
+            self.compute_overlap_to_mode(
+                state=state,
+                mode_E=self._mode_E[i],
+                mode_H=self._mode_H[i],
+                freq_idx=i,
+            )
+            for i in range(self._mode_E.shape[0])
+        ]
+        return jnp.stack(results)

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -2,12 +2,14 @@ from typing import Literal, Self, Sequence
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.core.null import Null
 from fdtdx.core.physics.metrics import bidirectional_mode_overlap
 from fdtdx.core.physics.modes import compute_modes_multi_freq
+from fdtdx.dispersion import effective_inv_permittivity
 from fdtdx.objects.detectors.detector import DetectorState
 from fdtdx.objects.detectors.phasor import PhasorDetector
 from fdtdx.typing import SliceTuple3D
@@ -161,6 +163,27 @@ class ModeOverlapDetector(PhasorDetector):
         else:
             inv_permeability_slice = inv_permeabilities
 
+        # Apply frequency-dependent dispersive correction for each wave character so
+        # the mode solver sees ε(ω) rather than ε∞.  Cells with no pole have
+        # c1=c2=c3=0, in which case effective_inv_permittivity returns inv_eps unchanged.
+        if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
+            c1_slice = dispersive_c1[:, :, *self.grid_slice]
+            c2_slice = dispersive_c2[:, :, *self.grid_slice]
+            c3_slice = dispersive_c3[:, :, *self.grid_slice]
+            inv_permittivities_per_freq = [
+                effective_inv_permittivity(
+                    inv_eps=inv_permittivity_slice,
+                    c1=c1_slice,
+                    c2=c2_slice,
+                    c3=c3_slice,
+                    omega=2.0 * np.pi * wc.get_frequency(),
+                    dt=self._config.time_step_duration,
+                )
+                for wc in self.wave_characters
+            ]
+        else:
+            inv_permittivities_per_freq = None
+
         # All frequencies solved in one call with neff-proximity continuity tracking.
         mode_Es, mode_Hs, mode_neffs = compute_modes_multi_freq(
             frequencies=[wc.get_frequency() for wc in self.wave_characters],
@@ -175,6 +198,7 @@ class ModeOverlapDetector(PhasorDetector):
             bend_axis=self.bend_axis,
             symmetry=self.symmetry,
             transverse_coords=self._transverse_edge_coordinates(),
+            inv_permittivities_per_freq=inv_permittivities_per_freq,
         )
 
         self = self.aset("_mode_E", mode_Es, create_new_ok=True)

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -8,7 +8,7 @@ from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.core.null import Null
 from fdtdx.core.physics.metrics import bidirectional_mode_overlap
-from fdtdx.core.physics.modes import compute_modes_multi_freq
+from fdtdx.core.physics.modes import compute_mode
 from fdtdx.dispersion import effective_inv_permittivity
 from fdtdx.objects.detectors.detector import DetectorState
 from fdtdx.objects.detectors.phasor import PhasorDetector
@@ -28,9 +28,8 @@ class ModeOverlapDetector(PhasorDetector):
     decomposition of electromagnetic fields.
 
     ``compute_overlap()`` returns a complex array of shape ``(num_freqs,)``, where
-    ``num_freqs = len(wave_characters)``.  All frequencies are solved in a single
-    ``jax.pure_callback`` call during ``apply()``, with neff-proximity tracking to
-    prevent mode hopping across frequencies.
+    ``num_freqs = len(wave_characters)``.  Modes are solved once per frequency during
+    ``apply()``, with neff-proximity tracking to prevent mode hopping across frequencies.
     """
 
     #: Direction of mode propagation, either "+" (forward) or "-" (backward).
@@ -163,15 +162,19 @@ class ModeOverlapDetector(PhasorDetector):
         else:
             inv_permeability_slice = inv_permeabilities
 
-        # Apply frequency-dependent dispersive correction for each wave character so
-        # the mode solver sees ε(ω) rather than ε∞.  Cells with no pole have
-        # c1=c2=c3=0, in which case effective_inv_permittivity returns inv_eps unchanged.
-        if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
-            c1_slice = dispersive_c1[:, :, *self.grid_slice]
-            c2_slice = dispersive_c2[:, :, *self.grid_slice]
-            c3_slice = dispersive_c3[:, :, *self.grid_slice]
-            inv_permittivities_per_freq = [
-                effective_inv_permittivity(
+        # Solve one mode per frequency.  apply() is always called eagerly (never under jax.jit),
+        # so a Python loop with concrete prev_neff values between iterations is safe.
+        mode_Es: list[jax.Array] = []
+        mode_Hs: list[jax.Array] = []
+        mode_neffs: list[jax.Array] = []
+        prev_neff: float | None = None
+        for wc in self.wave_characters:
+            # Apply dispersive correction so the mode solver sees ε(ω) rather than ε∞.
+            if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
+                c1_slice = dispersive_c1[:, :, *self.grid_slice]
+                c2_slice = dispersive_c2[:, :, *self.grid_slice]
+                c3_slice = dispersive_c3[:, :, *self.grid_slice]
+                inv_eps_i = effective_inv_permittivity(
                     inv_eps=inv_permittivity_slice,
                     c1=c1_slice,
                     c2=c2_slice,
@@ -179,31 +182,32 @@ class ModeOverlapDetector(PhasorDetector):
                     omega=2.0 * np.pi * wc.get_frequency(),
                     dt=self._config.time_step_duration,
                 )
-                for wc in self.wave_characters
-            ]
-        else:
-            inv_permittivities_per_freq = None
+            else:
+                inv_eps_i = inv_permittivity_slice
 
-        # All frequencies solved in one call with neff-proximity continuity tracking.
-        mode_Es, mode_Hs, mode_neffs = compute_modes_multi_freq(
-            frequencies=[wc.get_frequency() for wc in self.wave_characters],
-            inv_permittivities=inv_permittivity_slice,
-            inv_permeabilities=inv_permeability_slice,
-            resolution=self._mode_solver_resolution(),
-            direction=self.direction,
-            mode_index=self.mode_index,
-            filter_pol=self.filter_pol,
-            dtype=self._config.dtype,
-            bend_radius=self.bend_radius,
-            bend_axis=self.bend_axis,
-            symmetry=self.symmetry,
-            transverse_coords=self._transverse_edge_coordinates(),
-            inv_permittivities_per_freq=inv_permittivities_per_freq,
-        )
+            mode_E, mode_H, neff = compute_mode(
+                frequency=wc.get_frequency(),
+                inv_permittivities=inv_eps_i,
+                inv_permeabilities=inv_permeability_slice,
+                resolution=self._mode_solver_resolution(),
+                direction=self.direction,
+                mode_index=self.mode_index,
+                filter_pol=self.filter_pol,
+                dtype=self._config.dtype,
+                bend_radius=self.bend_radius,
+                bend_axis=self.bend_axis,
+                symmetry=self.symmetry,
+                transverse_coords=self._transverse_edge_coordinates(),
+                target_neff=prev_neff,
+            )
+            prev_neff = float(np.real(neff))  # requires eager execution — apply() must never be jit'd
+            mode_Es.append(mode_E)
+            mode_Hs.append(mode_H)
+            mode_neffs.append(neff)
 
-        self = self.aset("_mode_E", mode_Es, create_new_ok=True)
-        self = self.aset("_mode_H", mode_Hs, create_new_ok=True)
-        self = self.aset("_mode_neff", mode_neffs, create_new_ok=True)
+        self = self.aset("_mode_E", jnp.stack(mode_Es), create_new_ok=True)
+        self = self.aset("_mode_H", jnp.stack(mode_Hs), create_new_ok=True)
+        self = self.aset("_mode_neff", jnp.stack(mode_neffs), create_new_ok=True)
         return self
 
     def compute_overlap_to_mode(
@@ -260,13 +264,22 @@ class ModeOverlapDetector(PhasorDetector):
         """
         if isinstance(self._mode_E, Null) or isinstance(self._mode_H, Null):
             raise Exception("Need to call apply on ModeOverlapDetector before calling compute_mode_overlap!")
-        results = [
-            self.compute_overlap_to_mode(
-                state=state,
-                mode_E=self._mode_E[i],
-                mode_H=self._mode_H[i],
-                freq_idx=i,
+        phasors = state["phasor"]  # (1, num_freqs, 6, *spatial)
+        phasors_E = phasors[0, :, :3]  # (num_freqs, 3, *spatial)
+        phasors_H = phasors[0, :, 3:]
+
+        def overlap_one(mode_E, mode_H, sim_E, sim_H):
+            return bidirectional_mode_overlap(
+                mode_E=mode_E,
+                mode_H=mode_H,
+                sim_E=sim_E,
+                sim_H=sim_H,
+                propagation_axis=self.propagation_axis,
+                area_EuHv=self._cached_area_EuHv,
+                area_EvHu=self._cached_area_EvHu,
             )
-            for i in range(self._mode_E.shape[0])
-        ]
-        return jnp.stack(results)
+
+        results = jax.vmap(overlap_one)(self._mode_E, self._mode_H, phasors_E, phasors_H)
+        if self.scaling_mode != "pulse":
+            results = results / 4.0
+        return results

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -162,8 +162,7 @@ class ModeOverlapDetector(PhasorDetector):
         else:
             inv_permeability_slice = inv_permeabilities
 
-        # Solve one mode per frequency.  apply() is always called eagerly (never under jax.jit),
-        # so a Python loop with concrete prev_neff values between iterations is safe.
+        # Solve one mode per frequency with neff-proximity tracking.
         mode_Es: list[jax.Array] = []
         mode_Hs: list[jax.Array] = []
         mode_neffs: list[jax.Array] = []
@@ -205,6 +204,7 @@ class ModeOverlapDetector(PhasorDetector):
             mode_Hs.append(mode_H)
             mode_neffs.append(neff)
 
+        # Spatial dims are fixed at place_on_grid time, so all frequencies share the same shape.
         self = self.aset("_mode_E", jnp.stack(mode_Es), create_new_ok=True)
         self = self.aset("_mode_H", jnp.stack(mode_Hs), create_new_ok=True)
         self = self.aset("_mode_neff", jnp.stack(mode_neffs), create_new_ok=True)
@@ -243,10 +243,6 @@ class ModeOverlapDetector(PhasorDetector):
             area_EvHu=self._cached_area_EvHu,
         )
 
-        # in pulsed mode return unscaled coefficient
-        if self.scaling_mode != "pulse":
-            alpha_coeff = alpha_coeff / 4.0
-
         return alpha_coeff
 
     def compute_overlap(
@@ -258,9 +254,8 @@ class ModeOverlapDetector(PhasorDetector):
         Returns:
             Complex array of shape ``(num_freqs,)`` where ``num_freqs =
             len(wave_characters)``.  Each element is the overlap coefficient
-            at the corresponding frequency.  Callers that previously consumed a
-            scalar result (single-frequency case) must index the returned array,
-            e.g. ``result[0]``.
+            at the corresponding frequency.  For a single wave character, index
+            the result as ``result[0]``.
         """
         if isinstance(self._mode_E, Null) or isinstance(self._mode_H, Null):
             raise Exception("Need to call apply on ModeOverlapDetector before calling compute_mode_overlap!")
@@ -279,7 +274,4 @@ class ModeOverlapDetector(PhasorDetector):
                 area_EvHu=self._cached_area_EvHu,
             )
 
-        results = jax.vmap(overlap_one)(self._mode_E, self._mode_H, phasors_E, phasors_H)
-        if self.scaling_mode != "pulse":
-            results = results / 4.0
-        return results
+        return jax.vmap(overlap_one)(self._mode_E, self._mode_H, phasors_E, phasors_H)

--- a/src/fdtdx/objects/sources/mode.py
+++ b/src/fdtdx/objects/sources/mode.py
@@ -11,7 +11,7 @@ from fdtdx.core.grid import calculate_time_offset_yee
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.core.linalg import get_wave_vector_raw
 from fdtdx.core.physics.metrics import compute_energy
-from fdtdx.core.physics.modes import compute_mode_one_frequency
+from fdtdx.core.physics.modes import compute_mode
 from fdtdx.dispersion import effective_inv_permittivity
 from fdtdx.objects.sources.tfsf import TFSFPlaneSource, _build_dispersive_H_filter
 
@@ -68,7 +68,7 @@ class ModePlaneSource(TFSFPlaneSource):
     def _mode_solver_resolution(self) -> float:
         """Return scalar resolution only for legacy uniform mode-solver setup.
 
-        ``compute_mode_one_frequency`` ignores this value when explicit transverse coordinates
+        ``compute_mode`` ignores this value when explicit transverse coordinates
         are provided, but the argument remains part of the compatibility API.
         """
         if self._config.has_nonuniform_grid:
@@ -141,9 +141,10 @@ class ModePlaneSource(TFSFPlaneSource):
         self = self.aset("_inv_permeability", inv_permeability_slice, create_new_ok=True)
 
         # compute mode
-        mode_E, mode_H, eff_index = compute_mode_one_frequency(
-            frequency=self.wave_character.get_frequency(),
-            inv_permittivities=inv_permittivity_slice,
+        freq = self.wave_character.get_frequency()
+        mode_Es, mode_Hs, neffs = compute_mode(
+            frequencies=[freq],
+            inv_permittivities=jnp.expand_dims(inv_permittivity_slice, 0),
             inv_permeabilities=inv_permeability_slice,
             resolution=self._mode_solver_resolution(),
             direction=self.direction,
@@ -153,6 +154,7 @@ class ModePlaneSource(TFSFPlaneSource):
             symmetry=self.symmetry,
             transverse_coords=self._transverse_edge_coordinates(),
         )
+        mode_E, mode_H, eff_index = mode_Es[0], mode_Hs[0], neffs[0]
         mode_E, mode_H = jnp.real(mode_E), jnp.real(mode_H)
 
         self = self.aset("_E", mode_E, create_new_ok=True)

--- a/src/fdtdx/objects/sources/mode.py
+++ b/src/fdtdx/objects/sources/mode.py
@@ -11,7 +11,7 @@ from fdtdx.core.grid import calculate_time_offset_yee
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.core.linalg import get_wave_vector_raw
 from fdtdx.core.physics.metrics import compute_energy
-from fdtdx.core.physics.modes import compute_mode
+from fdtdx.core.physics.modes import compute_mode_one_frequency
 from fdtdx.dispersion import effective_inv_permittivity
 from fdtdx.objects.sources.tfsf import TFSFPlaneSource, _build_dispersive_H_filter
 
@@ -68,7 +68,7 @@ class ModePlaneSource(TFSFPlaneSource):
     def _mode_solver_resolution(self) -> float:
         """Return scalar resolution only for legacy uniform mode-solver setup.
 
-        ``compute_mode`` ignores this value when explicit transverse coordinates
+        ``compute_mode_one_frequency`` ignores this value when explicit transverse coordinates
         are provided, but the argument remains part of the compatibility API.
         """
         if self._config.has_nonuniform_grid:
@@ -141,7 +141,7 @@ class ModePlaneSource(TFSFPlaneSource):
         self = self.aset("_inv_permeability", inv_permeability_slice, create_new_ok=True)
 
         # compute mode
-        mode_E, mode_H, eff_index = compute_mode(
+        mode_E, mode_H, eff_index = compute_mode_one_frequency(
             frequency=self.wave_character.get_frequency(),
             inv_permittivities=inv_permittivity_slice,
             inv_permeabilities=inv_permeability_slice,

--- a/src/fdtdx/utils/sparams.py
+++ b/src/fdtdx/utils/sparams.py
@@ -263,8 +263,10 @@ def calculate_sparam(
 
     Returns:
         A 2-tuple ``(sparams, detector_states)`` where *sparams* maps
-        ``(detector_name, input_port_name)`` to a complex scattering amplitude
-        and *detector_states* is the final :class:`~fdtdx.DetectorState` dict
+        ``(detector_name, input_port_name)`` to a complex array of shape
+        ``(num_freqs,)`` containing the scattering amplitude at each frequency
+        in ``wave_characters`` (``num_freqs = len(wave_characters)``), and
+        *detector_states* is the final :class:`~fdtdx.DetectorState` dict
         for every detector in the simulation.
     """
     if key is None:

--- a/tests/integration/core/physics/test_mode_tracking.py
+++ b/tests/integration/core/physics/test_mode_tracking.py
@@ -1,20 +1,19 @@
-"""Integration tests for field-overlap mode tracking in compute_mode and compute_modes_tracked.
+"""Integration tests for field-overlap mode tracking in compute_mode.
 
-Geometry: three-layer waveguide (eps=4 core, eps=8 top/bottom slabs) in a 6 µm × 6 µm
+Geometry: three-layer waveguide (eps=4 core, eps=8 top/bottom slabs) in a 6 um x 6 um
 cross-section, propagation along z.  At mode_index=9 and frequencies spanning
-lambda ≈ 1.5–2.5 µm, neff branches cross: independent per-frequency neff-rank sorting
-returns a different physical mode at the crossing step (field overlap ≈ 0.63).
+lambda ~1.5-2.5 um, neff branches cross: independent per-frequency neff-rank sorting
+returns a different physical mode at the crossing step (field overlap ~0.63).
 
-``reference_E`` field-overlap selection in ``compute_mode`` and the internal tracking
-in ``compute_modes_tracked`` both maintain physical continuity across the crossing
-(consecutive overlap > 0.70).
+``reference_E`` (scalar frequency) and automatic tracking (list frequency) both
+maintain physical continuity across the crossing (consecutive overlap > 0.70).
 """
 
+import jax.numpy as jnp
 import numpy as np
 import pytest
-import jax.numpy as jnp
 
-from fdtdx.core.physics.modes import compute_mode, compute_modes_tracked
+from fdtdx.core.physics.modes import compute_mode
 
 _C0 = 299_792_458.0
 
@@ -75,8 +74,11 @@ def inv_eps():
 @pytest.fixture(scope="module")
 def mode_before_crossing(inv_eps):
     E, H, neff = compute_mode(
-        _FREQ_BEFORE_CROSSING, inv_eps, 1.0,
-        resolution=_RES, mode_index=_CROSSING_MODE,
+        _FREQ_BEFORE_CROSSING,
+        inv_eps,
+        1.0,
+        resolution=_RES,
+        mode_index=_CROSSING_MODE,
     )
     return np.array(E), np.array(H), neff
 
@@ -93,8 +95,11 @@ class TestFieldOverlapModeTracking:
         """neff-rank selection alone gives field overlap < 0.70 at the crossing step."""
         E_before, _, _ = mode_before_crossing
         E_after, _, _ = compute_mode(
-            _FREQ_AT_CROSSING, inv_eps, 1.0,
-            resolution=_RES, mode_index=_CROSSING_MODE,
+            _FREQ_AT_CROSSING,
+            inv_eps,
+            1.0,
+            resolution=_RES,
+            mode_index=_CROSSING_MODE,
         )
         overlap = _field_overlap(E_before, np.array(E_after))
         assert overlap < 0.70, (
@@ -106,18 +111,19 @@ class TestFieldOverlapModeTracking:
         """``reference_E`` raises field overlap above 0.70 at the crossing step."""
         E_before, _, _ = mode_before_crossing
         E_tracked, _, _ = compute_mode(
-            _FREQ_AT_CROSSING, inv_eps, 1.0,
-            resolution=_RES, mode_index=_CROSSING_MODE,
+            _FREQ_AT_CROSSING,
+            inv_eps,
+            1.0,
+            resolution=_RES,
+            mode_index=_CROSSING_MODE,
             reference_E=E_before,
         )
         overlap = _field_overlap(E_before, np.array(E_tracked))
-        assert overlap > 0.70, (
-            f"Expected reference_E tracking to raise overlap above 0.70, got {overlap:.3f}"
-        )
+        assert overlap > 0.70, f"Expected reference_E tracking to raise overlap above 0.70, got {overlap:.3f}"
 
 
-class TestComputeModesTrackedFullSweep:
-    """``compute_modes_tracked`` maintains field continuity across all 11 frequencies.
+class TestComputeModeMultiFreqFullSweep:
+    """``compute_mode`` with list frequency maintains field continuity across all 11 frequencies.
 
     Each consecutive pair of mode fields must have overlap > 0.70, including
     the crossing at steps 8→9 where neff-rank sorting alone drops to ~0.63.
@@ -125,9 +131,9 @@ class TestComputeModesTrackedFullSweep:
 
     def test_all_consecutive_overlaps_above_threshold(self, inv_eps):
         inv_eps_stack = jnp.stack([inv_eps] * len(_FREQS), axis=0)
-        mode_Es, _, _ = compute_modes_tracked(
-            frequencies=list(_FREQS),
-            inv_permittivities_stack=inv_eps_stack,
+        mode_Es, _, _ = compute_mode(
+            frequency=list(_FREQS),
+            inv_permittivities=inv_eps_stack,
             inv_permeabilities=1.0,
             resolution=_RES,
             mode_index=_CROSSING_MODE,
@@ -135,6 +141,4 @@ class TestComputeModesTrackedFullSweep:
         mode_Es_np = np.array(mode_Es)
         for i in range(len(_FREQS) - 1):
             overlap = _field_overlap(mode_Es_np[i], mode_Es_np[i + 1])
-            assert overlap > 0.70, (
-                f"Steps {i}→{i + 1}: overlap {overlap:.3f} < 0.70"
-            )
+            assert overlap > 0.70, f"Steps {i}→{i + 1}: overlap {overlap:.3f} < 0.70"

--- a/tests/integration/core/physics/test_mode_tracking.py
+++ b/tests/integration/core/physics/test_mode_tracking.py
@@ -1,19 +1,19 @@
-"""Integration tests for field-overlap mode tracking in compute_mode_one_frequency and compute_mode_multiple_frequencies.
+"""Integration tests for field-overlap mode tracking in compute_mode.
 
 Geometry: three-layer waveguide (eps=4 core, eps=8 top/bottom slabs) in a 6 um x 6 um
 cross-section, propagation along z.  At mode_index=9 and frequencies spanning
 lambda ~1.5-2.5 um, neff branches cross: independent per-frequency neff-rank sorting
 returns a different physical mode at the crossing step (field overlap ~0.63).
 
-``reference_E`` (scalar frequency) and automatic tracking (list frequency) both
-maintain physical continuity across the crossing (consecutive overlap > 0.70).
+Automatic field-overlap tracking in compute_mode maintains physical continuity across
+the crossing (consecutive overlap > 0.70).
 """
 
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from fdtdx.core.physics.modes import compute_mode_multiple_frequencies, compute_mode_one_frequency
+from fdtdx.core.physics.modes import compute_mode
 
 _C0 = 299_792_458.0
 
@@ -71,59 +71,8 @@ def inv_eps():
     return _make_inv_eps()
 
 
-@pytest.fixture(scope="module")
-def mode_before_crossing(inv_eps):
-    E, H, neff = compute_mode_one_frequency(
-        _FREQ_BEFORE_CROSSING,
-        inv_eps,
-        1.0,
-        resolution=_RES,
-        mode_index=_CROSSING_MODE,
-    )
-    return np.array(E), np.array(H), neff
-
-
-class TestFieldOverlapModeTracking:
-    """``reference_E`` in ``compute_mode_one_frequency`` prevents mode hopping at a branch crossing.
-
-    At the crossing step, neff-rank sorting alone returns a different physical mode
-    (field overlap ≈ 0.63).  Passing the previous step's mode_E as ``reference_E``
-    selects the candidate with the highest field overlap, maintaining continuity.
-    """
-
-    def test_without_reference_E_overlap_is_low_at_crossing(self, inv_eps, mode_before_crossing):
-        """neff-rank selection alone gives field overlap < 0.70 at the crossing step."""
-        E_before, _, _ = mode_before_crossing
-        E_after, _, _ = compute_mode_one_frequency(
-            _FREQ_AT_CROSSING,
-            inv_eps,
-            1.0,
-            resolution=_RES,
-            mode_index=_CROSSING_MODE,
-        )
-        overlap = _field_overlap(E_before, np.array(E_after))
-        assert overlap < 0.70, (
-            f"Expected overlap < 0.70 at crossing without tracking, "
-            f"got {overlap:.3f} — geometry may not produce a crossing at these frequencies"
-        )
-
-    def test_with_reference_E_overlap_is_higher_at_crossing(self, inv_eps, mode_before_crossing):
-        """``reference_E`` raises field overlap above 0.70 at the crossing step."""
-        E_before, _, _ = mode_before_crossing
-        E_tracked, _, _ = compute_mode_one_frequency(
-            _FREQ_AT_CROSSING,
-            inv_eps,
-            1.0,
-            resolution=_RES,
-            mode_index=_CROSSING_MODE,
-            reference_E=E_before,
-        )
-        overlap = _field_overlap(E_before, np.array(E_tracked))
-        assert overlap > 0.70, f"Expected reference_E tracking to raise overlap above 0.70, got {overlap:.3f}"
-
-
 class TestComputeModeMultiFreqFullSweep:
-    """``compute_mode_multiple_frequencies`` maintains field continuity across all 11 frequencies.
+    """``compute_mode`` maintains field continuity across all 11 frequencies.
 
     Each consecutive pair of mode fields must have overlap > 0.70, including
     the crossing at steps 8→9 where neff-rank sorting alone drops to ~0.63.
@@ -131,7 +80,7 @@ class TestComputeModeMultiFreqFullSweep:
 
     def test_all_consecutive_overlaps_above_threshold(self, inv_eps):
         inv_eps_stack = jnp.stack([inv_eps] * len(_FREQS), axis=0)
-        mode_Es, _, _ = compute_mode_multiple_frequencies(
+        mode_Es, _, _ = compute_mode(
             frequencies=list(_FREQS),
             inv_permittivities=inv_eps_stack,
             inv_permeabilities=1.0,
@@ -141,4 +90,4 @@ class TestComputeModeMultiFreqFullSweep:
         mode_Es_np = np.array(mode_Es)
         for i in range(len(_FREQS) - 1):
             overlap = _field_overlap(mode_Es_np[i], mode_Es_np[i + 1])
-            assert overlap > 0.70, f"Steps {i}→{i + 1}: overlap {overlap:.3f} < 0.70"
+            assert overlap > 0.70, f"Steps {i}->{i + 1}: overlap {overlap:.3f} < 0.70"

--- a/tests/integration/core/physics/test_mode_tracking.py
+++ b/tests/integration/core/physics/test_mode_tracking.py
@@ -1,4 +1,4 @@
-"""Integration tests for field-overlap mode tracking in compute_mode.
+"""Integration tests for field-overlap mode tracking in compute_mode_one_frequency and compute_mode_multiple_frequencies.
 
 Geometry: three-layer waveguide (eps=4 core, eps=8 top/bottom slabs) in a 6 um x 6 um
 cross-section, propagation along z.  At mode_index=9 and frequencies spanning
@@ -13,7 +13,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from fdtdx.core.physics.modes import compute_mode
+from fdtdx.core.physics.modes import compute_mode_multiple_frequencies, compute_mode_one_frequency
 
 _C0 = 299_792_458.0
 
@@ -73,7 +73,7 @@ def inv_eps():
 
 @pytest.fixture(scope="module")
 def mode_before_crossing(inv_eps):
-    E, H, neff = compute_mode(
+    E, H, neff = compute_mode_one_frequency(
         _FREQ_BEFORE_CROSSING,
         inv_eps,
         1.0,
@@ -84,7 +84,7 @@ def mode_before_crossing(inv_eps):
 
 
 class TestFieldOverlapModeTracking:
-    """``reference_E`` in ``compute_mode`` prevents mode hopping at a branch crossing.
+    """``reference_E`` in ``compute_mode_one_frequency`` prevents mode hopping at a branch crossing.
 
     At the crossing step, neff-rank sorting alone returns a different physical mode
     (field overlap ≈ 0.63).  Passing the previous step's mode_E as ``reference_E``
@@ -94,7 +94,7 @@ class TestFieldOverlapModeTracking:
     def test_without_reference_E_overlap_is_low_at_crossing(self, inv_eps, mode_before_crossing):
         """neff-rank selection alone gives field overlap < 0.70 at the crossing step."""
         E_before, _, _ = mode_before_crossing
-        E_after, _, _ = compute_mode(
+        E_after, _, _ = compute_mode_one_frequency(
             _FREQ_AT_CROSSING,
             inv_eps,
             1.0,
@@ -110,7 +110,7 @@ class TestFieldOverlapModeTracking:
     def test_with_reference_E_overlap_is_higher_at_crossing(self, inv_eps, mode_before_crossing):
         """``reference_E`` raises field overlap above 0.70 at the crossing step."""
         E_before, _, _ = mode_before_crossing
-        E_tracked, _, _ = compute_mode(
+        E_tracked, _, _ = compute_mode_one_frequency(
             _FREQ_AT_CROSSING,
             inv_eps,
             1.0,
@@ -123,7 +123,7 @@ class TestFieldOverlapModeTracking:
 
 
 class TestComputeModeMultiFreqFullSweep:
-    """``compute_mode`` with list frequency maintains field continuity across all 11 frequencies.
+    """``compute_mode_multiple_frequencies`` maintains field continuity across all 11 frequencies.
 
     Each consecutive pair of mode fields must have overlap > 0.70, including
     the crossing at steps 8→9 where neff-rank sorting alone drops to ~0.63.
@@ -131,8 +131,8 @@ class TestComputeModeMultiFreqFullSweep:
 
     def test_all_consecutive_overlaps_above_threshold(self, inv_eps):
         inv_eps_stack = jnp.stack([inv_eps] * len(_FREQS), axis=0)
-        mode_Es, _, _ = compute_mode(
-            frequency=list(_FREQS),
+        mode_Es, _, _ = compute_mode_multiple_frequencies(
+            frequencies=list(_FREQS),
             inv_permittivities=inv_eps_stack,
             inv_permeabilities=1.0,
             resolution=_RES,

--- a/tests/integration/core/physics/test_mode_tracking.py
+++ b/tests/integration/core/physics/test_mode_tracking.py
@@ -1,0 +1,140 @@
+"""Integration tests for field-overlap mode tracking in compute_mode and compute_modes_tracked.
+
+Geometry: three-layer waveguide (eps=4 core, eps=8 top/bottom slabs) in a 6 µm × 6 µm
+cross-section, propagation along z.  At mode_index=9 and frequencies spanning
+lambda ≈ 1.5–2.5 µm, neff branches cross: independent per-frequency neff-rank sorting
+returns a different physical mode at the crossing step (field overlap ≈ 0.63).
+
+``reference_E`` field-overlap selection in ``compute_mode`` and the internal tracking
+in ``compute_modes_tracked`` both maintain physical continuity across the crossing
+(consecutive overlap > 0.70).
+"""
+
+import numpy as np
+import pytest
+import jax.numpy as jnp
+
+from fdtdx.core.physics.modes import compute_mode, compute_modes_tracked
+
+_C0 = 299_792_458.0
+
+_LAMBDA0_UM = 2.0
+_FREQ0 = _C0 / (_LAMBDA0_UM * 1e-6)
+_FWIDTH = _FREQ0 / 3.0
+_FREQS = np.linspace(_FREQ0 - _FWIDTH, _FREQ0 + _FWIDTH, 11)
+
+# Steps 8→9 straddle a mode crossing for mode_index=9 (lambda ≈ 1.667 → 1.579 µm).
+_FREQ_BEFORE_CROSSING = _FREQS[8]
+_FREQ_AT_CROSSING = _FREQS[9]
+_CROSSING_MODE = 9
+
+_RES = 0.15e-6
+_NCELLS = 40
+
+
+def _make_inv_eps() -> jnp.ndarray:
+    """Inverse-permittivity for a three-layer waveguide, shape (3, 40, 40, 1).
+
+    Propagation along z; cross-section in x-y.
+
+        Main core:    eps=4, 1.5 µm wide (10 cells), 1.0 µm tall (7 cells)
+        Bottom layer: eps=8, same width,  1.0 µm tall, centre at y = -0.8 µm
+        Top layer:    eps=8, same width,  0.8 µm tall, centre at y = +0.7 µm
+    """
+    mid = _NCELLS // 2
+    eps = np.ones((_NCELLS, _NCELLS), dtype=np.float32)
+
+    wx = round(1.5e-6 / _RES)
+    wy = round(1.0e-6 / _RES)
+    eps[mid - wx // 2 : mid + wx // 2, mid - wy // 2 : mid + wy // 2] = 4.0
+
+    by_c = mid - round(0.8e-6 / _RES)
+    by_h = round(1.0e-6 / _RES)
+    eps[mid - wx // 2 : mid + wx // 2, by_c - by_h // 2 : by_c + by_h // 2] = 8.0
+
+    ty_c = mid + round(0.7e-6 / _RES)
+    ty_h = round(0.8e-6 / _RES)
+    eps[mid - wx // 2 : mid + wx // 2, ty_c - ty_h // 2 : ty_c + ty_h // 2] = 8.0
+
+    inv_eps_2d = 1.0 / eps
+    inv_eps = np.broadcast_to(inv_eps_2d[np.newaxis, :, :, np.newaxis], (3, _NCELLS, _NCELLS, 1)).copy()
+    return jnp.array(inv_eps)
+
+
+def _field_overlap(E1: np.ndarray, E2: np.ndarray) -> float:
+    """Normalised |<E1|E2>| overlap in [0, 1]."""
+    denom = np.sqrt(np.sum(np.abs(E1) ** 2) * np.sum(np.abs(E2) ** 2)) + 1e-30
+    return float(np.abs(np.sum(np.conj(E1) * E2)) / denom)
+
+
+@pytest.fixture(scope="module")
+def inv_eps():
+    return _make_inv_eps()
+
+
+@pytest.fixture(scope="module")
+def mode_before_crossing(inv_eps):
+    E, H, neff = compute_mode(
+        _FREQ_BEFORE_CROSSING, inv_eps, 1.0,
+        resolution=_RES, mode_index=_CROSSING_MODE,
+    )
+    return np.array(E), np.array(H), neff
+
+
+class TestFieldOverlapModeTracking:
+    """``reference_E`` in ``compute_mode`` prevents mode hopping at a branch crossing.
+
+    At the crossing step, neff-rank sorting alone returns a different physical mode
+    (field overlap ≈ 0.63).  Passing the previous step's mode_E as ``reference_E``
+    selects the candidate with the highest field overlap, maintaining continuity.
+    """
+
+    def test_without_reference_E_overlap_is_low_at_crossing(self, inv_eps, mode_before_crossing):
+        """neff-rank selection alone gives field overlap < 0.70 at the crossing step."""
+        E_before, _, _ = mode_before_crossing
+        E_after, _, _ = compute_mode(
+            _FREQ_AT_CROSSING, inv_eps, 1.0,
+            resolution=_RES, mode_index=_CROSSING_MODE,
+        )
+        overlap = _field_overlap(E_before, np.array(E_after))
+        assert overlap < 0.70, (
+            f"Expected overlap < 0.70 at crossing without tracking, "
+            f"got {overlap:.3f} — geometry may not produce a crossing at these frequencies"
+        )
+
+    def test_with_reference_E_overlap_is_higher_at_crossing(self, inv_eps, mode_before_crossing):
+        """``reference_E`` raises field overlap above 0.70 at the crossing step."""
+        E_before, _, _ = mode_before_crossing
+        E_tracked, _, _ = compute_mode(
+            _FREQ_AT_CROSSING, inv_eps, 1.0,
+            resolution=_RES, mode_index=_CROSSING_MODE,
+            reference_E=E_before,
+        )
+        overlap = _field_overlap(E_before, np.array(E_tracked))
+        assert overlap > 0.70, (
+            f"Expected reference_E tracking to raise overlap above 0.70, got {overlap:.3f}"
+        )
+
+
+class TestComputeModesTrackedFullSweep:
+    """``compute_modes_tracked`` maintains field continuity across all 11 frequencies.
+
+    Each consecutive pair of mode fields must have overlap > 0.70, including
+    the crossing at steps 8→9 where neff-rank sorting alone drops to ~0.63.
+    """
+
+    def test_all_consecutive_overlaps_above_threshold(self, inv_eps):
+        inv_eps_stack = jnp.stack([inv_eps] * len(_FREQS), axis=0)
+        mode_Es, _, _ = compute_modes_tracked(
+            frequencies=list(_FREQS),
+            inv_permittivities_stack=inv_eps_stack,
+            inv_permeabilities=1.0,
+            resolution=_RES,
+            mode_index=_CROSSING_MODE,
+        )
+        mode_Es_np = np.array(mode_Es)
+        for i in range(len(_FREQS) - 1):
+            overlap = _field_overlap(mode_Es_np[i], mode_Es_np[i + 1])
+            assert overlap > 0.70, (
+                f"Steps {i}→{i + 1}: overlap {overlap:.3f} < 0.70"
+            )

--- a/tests/integration/objects/test_mode_detector.py
+++ b/tests/integration/objects/test_mode_detector.py
@@ -1,0 +1,133 @@
+"""Integration tests for ModeOverlapDetector with multiple wave characters.
+
+Exercises compute_modes_multi_freq through the real tidy3d mode solver with a
+uniform air permittivity slice.  Verifies output shapes, finiteness, and neff
+plausibility without mocking any external dependencies.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import fdtdx
+from fdtdx.core.wavelength import WaveCharacter
+from fdtdx.fdtd.initialization import apply_params
+from fdtdx.materials import Material
+from fdtdx.objects.detectors.mode import ModeOverlapDetector
+
+# Minimum cross-section for tidy3d's ARPACK solver is 8x8 cells.
+_RESOLUTION = 200e-9
+_NCELLS_T = 8
+_PML = 3
+_TOTAL_T = _NCELLS_T + 2 * _PML  # 14 cells per transverse axis
+
+_WC_1550 = WaveCharacter(wavelength=1.55e-6)
+_WC_1300 = WaveCharacter(wavelength=1.30e-6)
+
+
+@pytest.fixture(scope="module")
+def two_freq_det():
+    """Uniform-air domain with a 2-wave-character ModeOverlapDetector (z-plane).
+
+    Calls apply_params so compute_modes_multi_freq runs through the real tidy3d
+    ARPACK solver.  Fixture is module-scoped so the expensive solve runs once.
+    """
+    total_t = _TOTAL_T * _RESOLUTION
+    total_z = (1 + 2 * _PML) * _RESOLUTION
+
+    volume = fdtdx.SimulationVolume(
+        partial_real_shape=(total_t, total_t, total_z),
+        material=Material(),
+    )
+    bound_cfg = fdtdx.BoundaryConfig(
+        thickness_grid_minx=_PML,
+        thickness_grid_maxx=_PML,
+        thickness_grid_miny=_PML,
+        thickness_grid_maxy=_PML,
+        thickness_grid_minz=_PML,
+        thickness_grid_maxz=_PML,
+    )
+    bound_dict, bound_constraints = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+
+    det = ModeOverlapDetector(
+        name="det",
+        wave_characters=(_WC_1550, _WC_1300),
+        direction="+",
+        filter_pol=None,
+        partial_grid_shape=(None, None, 1),  # z-plane → propagation_axis=2
+    )
+
+    config = fdtdx.SimulationConfig(
+        time=1e-14,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
+    )
+    objects = [volume, det, *list(bound_dict.values())]
+    constraints = [
+        *bound_constraints,
+        det.same_size(volume, axes=(0, 1)),
+        det.place_at_center(volume, axes=(0, 1, 2)),
+    ]
+
+    key = jax.random.PRNGKey(0)
+    obj_container, arrays, _, config, _ = fdtdx.place_objects(
+        object_list=objects,
+        config=config,
+        constraints=constraints,
+        key=key,
+    )
+    arrays = fdtdx.extend_material_to_pml(objects=obj_container, arrays=arrays)
+    _, obj_container, _ = apply_params(arrays, obj_container, {}, key)
+
+    return obj_container["det"]
+
+
+class TestMultiFreqDetectorApply:
+    """End-to-end tests for ModeOverlapDetector.apply() with two wave characters."""
+
+    def test_mode_E_shape(self, two_freq_det):
+        """_mode_E has shape (num_freqs, 3, transverse_x, transverse_y, 1)."""
+        assert two_freq_det._mode_E.shape == (2, 3, _TOTAL_T, _TOTAL_T, 1)
+
+    def test_mode_H_shape(self, two_freq_det):
+        """_mode_H has shape (num_freqs, 3, transverse_x, transverse_y, 1)."""
+        assert two_freq_det._mode_H.shape == (2, 3, _TOTAL_T, _TOTAL_T, 1)
+
+    def test_neff_shape(self, two_freq_det):
+        """_mode_neff has shape (num_freqs,)."""
+        assert two_freq_det._mode_neff.shape == (2,)
+
+    def test_mode_fields_finite(self, two_freq_det):
+        """All mode field components are finite (no NaN/Inf)."""
+        assert jnp.all(jnp.isfinite(two_freq_det._mode_E))
+        assert jnp.all(jnp.isfinite(two_freq_det._mode_H))
+
+    def test_neff_finite(self, two_freq_det):
+        """All effective indices are finite."""
+        assert jnp.all(jnp.isfinite(two_freq_det._mode_neff))
+
+    def test_neff_positive_real_part(self, two_freq_det):
+        """real(neff) > 0 for both frequencies (physical mode)."""
+        neffs = np.real(np.array(two_freq_det._mode_neff))
+        assert np.all(neffs > 0), f"Non-positive neff: {neffs}"
+
+    def test_neff_continuity(self, two_freq_det):
+        """Neff values at 1550 nm and 1300 nm stay close — no mode hopping."""
+        neffs = np.real(np.array(two_freq_det._mode_neff))
+        diff = abs(neffs[0] - neffs[1])
+        assert diff < 0.2, (
+            f"neff jumped between 1550 nm and 1300 nm: {neffs[0]:.4f} vs {neffs[1]:.4f} (diff={diff:.4f})"
+        )
+
+    def test_freq_count_matches_wave_characters(self, two_freq_det):
+        """One mode (E, H, neff) returned per wave character."""
+        assert two_freq_det._mode_E.shape[0] == 2
+        assert two_freq_det._mode_H.shape[0] == 2
+        assert two_freq_det._mode_neff.shape[0] == 2
+
+    def test_compute_overlap_returns_correct_shape(self, two_freq_det):
+        """compute_overlap() on a zero-phasor state returns shape (2,)."""
+        state = two_freq_det.init_state()
+        result = two_freq_det.compute_overlap(state=state)
+        assert result.shape == (2,)
+        assert jnp.iscomplexobj(result)

--- a/tests/integration/objects/test_mode_detector.py
+++ b/tests/integration/objects/test_mode_detector.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 import fdtdx
-from fdtdx.core.physics.modes import compute_modes_tracked
+from fdtdx.core.physics.modes import compute_mode
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.fdtd.initialization import apply_params
 from fdtdx.materials import Material
@@ -170,11 +170,11 @@ class TestModeOverlapDetectorApply:
             assert mag == pytest.approx(1.0, abs=0.05), f"Self-overlap at freq {i} = {mag:.4f}, expected ~= 1.0"
 
 
-class TestComputeModesTrackedJitCompatibility:
-    """``compute_modes_tracked`` is callable from inside ``jax.jit``."""
+class TestComputeModeJitCompatibility:
+    """``compute_mode`` with list frequency is callable from inside ``jax.jit``."""
 
-    def test_compute_modes_tracked_callable_under_jit(self):
-        """``jax.jit`` traces through ``compute_modes_tracked`` without raising."""
+    def test_compute_mode_list_freq_callable_under_jit(self):
+        """``jax.jit`` traces through multi-frequency ``compute_mode`` without raising."""
         frequencies = [
             _WC_1550.get_frequency(),
             _WC_1300.get_frequency(),
@@ -184,9 +184,9 @@ class TestComputeModesTrackedJitCompatibility:
 
         @jax.jit
         def fn(stack: jax.Array) -> jax.Array:
-            mode_Es, _mode_Hs, _neffs = compute_modes_tracked(
-                frequencies=frequencies,
-                inv_permittivities_stack=stack,
+            mode_Es, _mode_Hs, _neffs = compute_mode(
+                frequency=frequencies,
+                inv_permittivities=stack,
                 inv_permeabilities=1.0,
                 resolution=_RESOLUTION,
             )

--- a/tests/integration/objects/test_mode_detector.py
+++ b/tests/integration/objects/test_mode_detector.py
@@ -26,12 +26,10 @@ _WC_1550 = WaveCharacter(wavelength=1.55e-6)
 _WC_1300 = WaveCharacter(wavelength=1.30e-6)
 
 
-@pytest.fixture(scope="module")
-def two_freq_det():
-    """Uniform-air domain with a 2-wave-character ModeOverlapDetector (z-plane).
+def _make_det_fixture(wave_characters):
+    """Build and apply a ModeOverlapDetector with the given wave characters.
 
-    Calls apply_params so compute_mode runs twice (once per frequency) through the
-    real tidy3d ARPACK solver.  Fixture is module-scoped so the expensive solve runs once.
+    Shared helper for the two_freq_det and single_freq_det fixtures.
     """
     total_t = _TOTAL_T * _RESOLUTION
     total_z = (1 + 2 * _PML) * _RESOLUTION
@@ -52,12 +50,11 @@ def two_freq_det():
 
     det = ModeOverlapDetector(
         name="det",
-        wave_characters=(_WC_1550, _WC_1300),
+        wave_characters=wave_characters,
         direction="+",
         filter_pol=None,
-        partial_grid_shape=(None, None, 1),  # z-plane → propagation_axis=2
+        partial_grid_shape=(None, None, 1),
     )
-
     config = fdtdx.SimulationConfig(
         time=1e-14,
         grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
@@ -68,18 +65,28 @@ def two_freq_det():
         det.same_size(volume, axes=(0, 1)),
         det.place_at_center(volume, axes=(0, 1, 2)),
     ]
-
     key = jax.random.PRNGKey(0)
     obj_container, arrays, _, config, _ = fdtdx.place_objects(
-        object_list=objects,
-        config=config,
-        constraints=constraints,
-        key=key,
+        object_list=objects, config=config, constraints=constraints, key=key,
     )
     arrays = fdtdx.extend_material_to_pml(objects=obj_container, arrays=arrays)
     _, obj_container, _ = apply_params(arrays, obj_container, {}, key)
-
     return obj_container["det"]
+
+
+@pytest.fixture(scope="module")
+def two_freq_det():
+    """Uniform-air domain: 2-wave-character detector (1550 nm + 1300 nm, z-plane)."""
+    return _make_det_fixture((_WC_1550, _WC_1300))
+
+
+@pytest.fixture(scope="module")
+def single_freq_det():
+    """Uniform-air domain: single-wave-character detector (1550 nm only, z-plane).
+
+    Same geometry as two_freq_det so their modes can be compared directly.
+    """
+    return _make_det_fixture((_WC_1550,))
 
 
 class TestMultiFreqDetectorApply:
@@ -161,3 +168,55 @@ class TestMultiFreqDetectorApply:
         # In air: neff ≈ 1 at all wavelengths
         assert np.all(neffs > 0.9), f"neffs below 0.9 in air: {neffs}"
         assert np.all(neffs < 1.1), f"neffs above 1.1 in air: {neffs}"
+
+
+class TestSingleVsMultiFreqAgreement:
+    """A single-frequency detector and the 1550 nm slot of a two-frequency detector
+    must return the same mode fields and the same overlap on identical phasors.
+
+    This validates that neff-proximity tracking at the first frequency (target_neff=None)
+    is equivalent to the standalone single-frequency path.
+    """
+
+    def test_mode_E_at_1550_matches(self, two_freq_det, single_freq_det):
+        """Mode E-field at 1550 nm is the same whether solved alone or as part of a sweep."""
+        mode_E_multi = np.array(two_freq_det._mode_E[0])   # (3, *spatial)
+        mode_E_single = np.array(single_freq_det._mode_E[0])
+
+        # Fields may differ by a global phase; compare normalised magnitudes
+        mag_multi = np.abs(mode_E_multi)
+        mag_single = np.abs(mode_E_single)
+        assert np.allclose(mag_multi, mag_single, atol=1e-4), (
+            f"Mode-E magnitude mismatch at 1550 nm: max diff = {np.max(np.abs(mag_multi - mag_single)):.2e}"
+        )
+
+    def test_overlap_at_1550_matches(self, two_freq_det, single_freq_det):
+        """compute_overlap()[0] on an identical synthetic phasor agrees between detectors.
+
+        We build a phasor whose slot 0 is the single-freq detector's own mode fields
+        (self-overlap = 1).  The two-freq detector with the same phasor slot 0 should
+        also return overlap ≈ 1.
+        """
+        # Build phasor from the single-freq mode fields
+        state_single = single_freq_det.init_state()
+        phasor_s = state_single["phasor"]
+        phasor_s = phasor_s.at[0, 0, :3].set(single_freq_det._mode_E[0])
+        phasor_s = phasor_s.at[0, 0, 3:].set(single_freq_det._mode_H[0])
+        state_single = {"phasor": phasor_s}
+
+        # Same phasor slot 0 in a two-freq phasor array
+        state_multi = two_freq_det.init_state()
+        phasor_m = state_multi["phasor"]
+        phasor_m = phasor_m.at[0, 0, :3].set(single_freq_det._mode_E[0])
+        phasor_m = phasor_m.at[0, 0, 3:].set(single_freq_det._mode_H[0])
+        state_multi = {"phasor": phasor_m}
+
+        overlap_single = float(jnp.abs(single_freq_det.compute_overlap(state_single)[0]))
+        overlap_multi = float(jnp.abs(two_freq_det.compute_overlap(state_multi)[0]))
+
+        assert overlap_single == pytest.approx(1.0, abs=0.05), (
+            f"Single-freq self-overlap = {overlap_single:.4f}"
+        )
+        assert overlap_multi == pytest.approx(overlap_single, abs=0.05), (
+            f"Multi-freq overlap[0]={overlap_multi:.4f} vs single={overlap_single:.4f}"
+        )

--- a/tests/integration/objects/test_mode_detector.py
+++ b/tests/integration/objects/test_mode_detector.py
@@ -1,9 +1,8 @@
 """Integration tests for ModeOverlapDetector with multiple wave characters.
 
-Exercises multi-frequency mode solving through the real tidy3d mode solver with a
-Si/SiO2 waveguide cross-section (800 nm Si core, SiO2 cladding, z-propagation).
-Verifies output shapes, finiteness, guided-mode neff bounds, and self-overlap
-normalization without mocking any external dependencies.
+Geometry: Si/SiO2 waveguide (800 nm Si core, SiO2 cladding, z-propagation).
+Covers output shapes, field finiteness, guided-mode neff bounds, self-overlap
+normalization, and JIT compatibility of the multi-frequency mode solver.
 """
 
 import jax
@@ -12,12 +11,13 @@ import numpy as np
 import pytest
 
 import fdtdx
+from fdtdx.core.physics.modes import compute_modes_tracked
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.fdtd.initialization import apply_params
 from fdtdx.materials import Material
 from fdtdx.objects.detectors.mode import ModeOverlapDetector
 
-# Minimum cross-section for tidy3d's ARPACK solver is 8x8 cells.
+# Minimum transverse cross-section for the ARPACK mode solver is 8x8 cells.
 _RESOLUTION = 200e-9
 _NCELLS_T = 8
 _PML = 3
@@ -34,12 +34,9 @@ _WC_1550 = WaveCharacter(wavelength=1.55e-6)
 
 
 def _make_det_fixture(wave_characters):
-    """Build a ModeOverlapDetector over a Si/SiO2 waveguide cross-section.
-
-    The domain is SiO2 cladding with an 800x800 nm Si core centred in the
-    transverse (x-y) plane.  Propagation axis is z.  Using a real guided
-    structure makes test_self_overlap_equals_one a genuine physics test:
-    normalization errors that cancel in air will produce |overlap| != 1 here.
+    """ModeOverlapDetector over a Si/SiO2 waveguide: SiO2 cladding, 800x800 nm Si core,
+    propagation along z.  The guided structure produces non-uniform field profiles
+    that expose normalization errors invisible in uniform-medium geometries.
     """
     total_t = _TOTAL_T * _RESOLUTION
     total_z = (1 + 2 * _PML) * _RESOLUTION
@@ -154,12 +151,11 @@ class TestModeOverlapDetectorApply:
         assert jnp.iscomplexobj(result)
 
     def test_self_overlap_equals_one(self, det_fixture, n_freqs, request):
-        """Feeding each mode back as its own phasor gives |overlap| ~= 1 at every frequency.
+        """Self-overlap of each mode field is ~1.0 at every frequency.
 
-        Validates Poynting-flux normalization end-to-end through the real tidy3d solver
-        on a genuine guided mode: a unit-power mode must have self-overlap = 1 by the
-        bidirectional formula.  This test would fail with a wrong 1/4 factor, wrong
-        conjugation, or wrong area weights.
+        A unit-power mode fed back as its own phasor must satisfy |overlap| = 1
+        by the bidirectional formula.  Catches incorrect normalization factors,
+        conjugation errors, or wrong area weights.
         """
         det = request.getfixturevalue(det_fixture)
         state = det.init_state()
@@ -172,3 +168,29 @@ class TestModeOverlapDetectorApply:
         for i in range(n_freqs):
             mag = float(jnp.abs(result[i]))
             assert mag == pytest.approx(1.0, abs=0.05), f"Self-overlap at freq {i} = {mag:.4f}, expected ~= 1.0"
+
+
+class TestComputeModesTrackedJitCompatibility:
+    """``compute_modes_tracked`` is callable from inside ``jax.jit``."""
+
+    def test_compute_modes_tracked_callable_under_jit(self):
+        """``jax.jit`` traces through ``compute_modes_tracked`` without raising."""
+        frequencies = [
+            _WC_1550.get_frequency(),
+            _WC_1300.get_frequency(),
+        ]
+        # Minimal 8x8 SiO2 cross-section, z-propagation (last dim == 1).
+        inv_eps_stack = jnp.ones((2, 1, 8, 8, 1), dtype=jnp.float32) / _EPS_SIO2
+
+        @jax.jit
+        def fn(stack: jax.Array) -> jax.Array:
+            mode_Es, _mode_Hs, _neffs = compute_modes_tracked(
+                frequencies=frequencies,
+                inv_permittivities_stack=stack,
+                inv_permeabilities=1.0,
+                resolution=_RESOLUTION,
+            )
+            return mode_Es
+
+        result = fn(inv_eps_stack)
+        assert result.shape == (2, 3, 8, 8, 1)

--- a/tests/integration/objects/test_mode_detector.py
+++ b/tests/integration/objects/test_mode_detector.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 import fdtdx
-from fdtdx.core.physics.modes import compute_mode
+from fdtdx.core.physics.modes import compute_mode_multiple_frequencies
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.fdtd.initialization import apply_params
 from fdtdx.materials import Material
@@ -170,11 +170,11 @@ class TestModeOverlapDetectorApply:
             assert mag == pytest.approx(1.0, abs=0.05), f"Self-overlap at freq {i} = {mag:.4f}, expected ~= 1.0"
 
 
-class TestComputeModeJitCompatibility:
-    """``compute_mode`` with list frequency is callable from inside ``jax.jit``."""
+class TestComputeModeMultipleFrequenciesJitCompatibility:
+    """``compute_mode_multiple_frequencies`` is callable from inside ``jax.jit``."""
 
-    def test_compute_mode_list_freq_callable_under_jit(self):
-        """``jax.jit`` traces through multi-frequency ``compute_mode`` without raising."""
+    def test_callable_under_jit(self):
+        """``jax.jit`` traces through ``compute_mode_multiple_frequencies`` without raising."""
         frequencies = [
             _WC_1550.get_frequency(),
             _WC_1300.get_frequency(),
@@ -184,8 +184,8 @@ class TestComputeModeJitCompatibility:
 
         @jax.jit
         def fn(stack: jax.Array) -> jax.Array:
-            mode_Es, _mode_Hs, _neffs = compute_mode(
-                frequency=frequencies,
+            mode_Es, _mode_Hs, _neffs = compute_mode_multiple_frequencies(
+                frequencies=frequencies,
                 inv_permittivities=stack,
                 inv_permeabilities=1.0,
                 resolution=_RESOLUTION,

--- a/tests/integration/objects/test_mode_detector.py
+++ b/tests/integration/objects/test_mode_detector.py
@@ -1,9 +1,8 @@
 """Integration tests for ModeOverlapDetector with multiple wave characters.
 
 Exercises multi-frequency mode solving through the real tidy3d mode solver with a
-uniform air permittivity slice.  Verifies output shapes, finiteness, self-overlap
-normalization, and single-vs-multi-frequency consistency without mocking any external
-dependencies.
+uniform air permittivity slice.  Verifies output shapes, finiteness, positive neff,
+and self-overlap normalization without mocking any external dependencies.
 """
 
 import jax
@@ -30,10 +29,7 @@ _WC_1550 = WaveCharacter(wavelength=1.55e-6)
 
 
 def _make_det_fixture(wave_characters):
-    """Build and apply a ModeOverlapDetector with the given wave characters.
-
-    Shared helper for the two_freq_det and single_freq_det fixtures.
-    """
+    """Build and apply a ModeOverlapDetector with the given wave characters."""
     total_t = _TOTAL_T * _RESOLUTION
     total_z = (1 + 2 * _PML) * _RESOLUTION
 
@@ -87,179 +83,54 @@ def two_freq_det():
 
 
 @pytest.fixture(scope="module")
-def single_freq_det():
-    """Uniform-air domain: single-wave-character detector (1550 nm only, z-plane).
-
-    Same geometry as two_freq_det so their modes can be compared directly.
-    """
-    return _make_det_fixture((_WC_1550,))
-
-
-@pytest.fixture(scope="module")
 def four_freq_det():
-    """Uniform-air domain: 4-wave-character detector (1200/1300/1450/1550 nm, z-plane).
-
-    Spans a wide wavelength range (350 nm) to stress-test the neff-proximity
-    loop and verify shapes, finiteness, and self-overlap normalization across
-    all four frequencies in a single apply() call.
-    """
+    """Uniform-air domain: 4-wave-character detector (1200/1300/1450/1550 nm, z-plane)."""
     return _make_det_fixture((_WC_1200, _WC_1300, _WC_1450, _WC_1550))
 
 
-class TestMultiFreqDetectorApply:
-    """End-to-end tests for ModeOverlapDetector.apply() with two wave characters."""
+@pytest.mark.parametrize("det_fixture,n_freqs", [("two_freq_det", 2), ("four_freq_det", 4)])
+class TestModeOverlapDetectorApply:
+    """End-to-end tests for ModeOverlapDetector.apply() across 2 and 4 wave characters."""
 
-    def test_mode_E_shape(self, two_freq_det):
-        """_mode_E has shape (num_freqs, 3, transverse_x, transverse_y, 1)."""
-        assert two_freq_det._mode_E.shape == (2, 3, _TOTAL_T, _TOTAL_T, 1)
+    def test_output_shapes(self, det_fixture, n_freqs, request):
+        """mode_E, mode_H have shape (n_freqs, 3, *spatial); mode_neff has shape (n_freqs,)."""
+        det = request.getfixturevalue(det_fixture)
+        assert det._mode_E.ndim == 5
+        assert det._mode_E.shape[0] == n_freqs
+        assert det._mode_E.shape[1] == 3
+        assert det._mode_E.shape == det._mode_H.shape
+        assert det._mode_neff.shape == (n_freqs,)
 
-    def test_mode_H_shape(self, two_freq_det):
-        """_mode_H has shape (num_freqs, 3, transverse_x, transverse_y, 1)."""
-        assert two_freq_det._mode_H.shape == (2, 3, _TOTAL_T, _TOTAL_T, 1)
-
-    def test_neff_shape(self, two_freq_det):
-        """_mode_neff has shape (num_freqs,)."""
-        assert two_freq_det._mode_neff.shape == (2,)
-
-    def test_mode_fields_finite(self, two_freq_det):
-        """All mode field components are finite (no NaN/Inf)."""
-        assert jnp.all(jnp.isfinite(two_freq_det._mode_E))
-        assert jnp.all(jnp.isfinite(two_freq_det._mode_H))
-
-    def test_neff_finite(self, two_freq_det):
-        """All effective indices are finite."""
-        assert jnp.all(jnp.isfinite(two_freq_det._mode_neff))
-
-    def test_neff_positive_real_part(self, two_freq_det):
-        """real(neff) > 0 for both frequencies (physical mode)."""
-        neffs = np.real(np.array(two_freq_det._mode_neff))
+    def test_fields_finite_and_neff_positive(self, det_fixture, n_freqs, request):
+        """All mode field components are finite and real(neff) > 0 at every frequency."""
+        det = request.getfixturevalue(det_fixture)
+        assert jnp.all(jnp.isfinite(det._mode_E))
+        assert jnp.all(jnp.isfinite(det._mode_H))
+        neffs = np.real(np.array(det._mode_neff))
         assert np.all(neffs > 0), f"Non-positive neff: {neffs}"
 
-    def test_freq_count_matches_wave_characters(self, two_freq_det):
-        """One mode (E, H, neff) returned per wave character."""
-        assert two_freq_det._mode_E.shape[0] == 2
-        assert two_freq_det._mode_H.shape[0] == 2
-        assert two_freq_det._mode_neff.shape[0] == 2
-
-    def test_compute_overlap_returns_correct_shape(self, two_freq_det):
-        """compute_overlap() on a zero-phasor state returns shape (2,)."""
-        state = two_freq_det.init_state()
-        result = two_freq_det.compute_overlap(state=state)
-        assert result.shape == (2,)
+    def test_compute_overlap_shape_and_dtype(self, det_fixture, n_freqs, request):
+        """compute_overlap() on a zero phasor returns complex array of shape (n_freqs,)."""
+        det = request.getfixturevalue(det_fixture)
+        state = det.init_state()
+        result = det.compute_overlap(state=state)
+        assert result.shape == (n_freqs,)
         assert jnp.iscomplexobj(result)
 
-    def test_self_overlap_equals_one(self, two_freq_det):
-        """Feeding the mode fields back as the phasor gives |overlap|≈1 at freq-0.
+    def test_self_overlap_equals_one(self, det_fixture, n_freqs, request):
+        """Feeding each mode back as its own phasor gives |overlap| ≈ 1 at every frequency.
 
-        Validates Poynting-flux normalization: a unit-power mode has self-overlap = 1.
+        Validates Poynting-flux normalization end-to-end through the real tidy3d solver:
+        a unit-power mode must have self-overlap = 1 by the bidirectional formula.
         """
-        state = two_freq_det.init_state()
+        det = request.getfixturevalue(det_fixture)
+        state = det.init_state()
         phasor = state["phasor"]
-        phasor = phasor.at[0, 0, :3].set(two_freq_det._mode_E[0])
-        phasor = phasor.at[0, 0, 3:].set(two_freq_det._mode_H[0])
+        for i in range(n_freqs):
+            phasor = phasor.at[0, i, :3].set(det._mode_E[i])
+            phasor = phasor.at[0, i, 3:].set(det._mode_H[i])
         state = {"phasor": phasor}
-        result = two_freq_det.compute_overlap(state=state)
-        assert jnp.abs(result[0]) == pytest.approx(1.0, abs=0.05), (
-            f"Self-overlap at freq-0 is {float(jnp.abs(result[0])):.4f}, expected ≈1.0"
-        )
-
-
-class TestSingleVsMultiFreqAgreement:
-    """A single-frequency detector and the 1550 nm slot of a two-frequency detector
-    must return the same mode fields and the same overlap on identical phasors.
-
-    Validates that the first frequency in a multi-frequency sweep produces the same
-    mode as a standalone single-frequency detector at the same wavelength.
-    """
-
-    def test_mode_E_at_1550_matches(self, two_freq_det, single_freq_det):
-        """Mode E-field at 1550 nm is the same whether solved alone or as part of a sweep."""
-        mode_E_multi = np.array(two_freq_det._mode_E[0])  # (3, *spatial)
-        mode_E_single = np.array(single_freq_det._mode_E[0])
-
-        # Fields may differ by a global phase; compare normalised magnitudes
-        mag_multi = np.abs(mode_E_multi)
-        mag_single = np.abs(mode_E_single)
-        assert np.allclose(mag_multi, mag_single, atol=1e-4), (
-            f"Mode-E magnitude mismatch at 1550 nm: max diff = {np.max(np.abs(mag_multi - mag_single)):.2e}"
-        )
-
-    def test_overlap_at_1550_matches(self, two_freq_det, single_freq_det):
-        """compute_overlap()[0] on an identical synthetic phasor agrees between detectors.
-
-        We build a phasor whose slot 0 is the single-freq detector's own mode fields
-        (self-overlap = 1).  The two-freq detector with the same phasor slot 0 should
-        also return overlap ≈ 1.
-        """
-        # Build phasor from the single-freq mode fields
-        state_single = single_freq_det.init_state()
-        phasor_s = state_single["phasor"]
-        phasor_s = phasor_s.at[0, 0, :3].set(single_freq_det._mode_E[0])
-        phasor_s = phasor_s.at[0, 0, 3:].set(single_freq_det._mode_H[0])
-        state_single = {"phasor": phasor_s}
-
-        # Same phasor slot 0 in a two-freq phasor array
-        state_multi = two_freq_det.init_state()
-        phasor_m = state_multi["phasor"]
-        phasor_m = phasor_m.at[0, 0, :3].set(single_freq_det._mode_E[0])
-        phasor_m = phasor_m.at[0, 0, 3:].set(single_freq_det._mode_H[0])
-        state_multi = {"phasor": phasor_m}
-
-        overlap_single = float(jnp.abs(single_freq_det.compute_overlap(state_single)[0]))
-        overlap_multi = float(jnp.abs(two_freq_det.compute_overlap(state_multi)[0]))
-
-        assert overlap_single == pytest.approx(1.0, abs=0.05), f"Single-freq self-overlap = {overlap_single:.4f}"
-        assert overlap_multi == pytest.approx(overlap_single, abs=0.05), (
-            f"Multi-freq overlap[0]={overlap_multi:.4f} vs single={overlap_single:.4f}"
-        )
-
-
-class TestFourFreqDetectorApply:
-    """End-to-end tests for ModeOverlapDetector.apply() with four wave characters.
-
-    Spans 1200-1550 nm (350 nm range) with neff-proximity tracking across four frequencies.
-    """
-
-    def test_mode_E_shape(self, four_freq_det):
-        """_mode_E has shape (4, 3, *spatial)."""
-        assert four_freq_det._mode_E.shape == (4, 3, _TOTAL_T, _TOTAL_T, 1)
-
-    def test_mode_H_shape(self, four_freq_det):
-        """_mode_H has shape (4, 3, *spatial)."""
-        assert four_freq_det._mode_H.shape == (4, 3, _TOTAL_T, _TOTAL_T, 1)
-
-    def test_neff_shape(self, four_freq_det):
-        """_mode_neff has shape (4,)."""
-        assert four_freq_det._mode_neff.shape == (4,)
-
-    def test_mode_fields_finite(self, four_freq_det):
-        """All mode field components are finite across all four frequencies."""
-        assert jnp.all(jnp.isfinite(four_freq_det._mode_E))
-        assert jnp.all(jnp.isfinite(four_freq_det._mode_H))
-
-    def test_neff_all_positive(self, four_freq_det):
-        """real(neff) > 0 at every frequency."""
-        neffs = np.real(np.array(four_freq_det._mode_neff))
-        assert np.all(neffs > 0), f"Non-positive neff: {neffs}"
-
-    def test_self_overlap_equals_one_at_each_frequency(self, four_freq_det):
-        """Feeding mode fields back as phasor gives |overlap| ≈ 1 at every frequency slot."""
-        state = four_freq_det.init_state()
-        phasor = state["phasor"]
-        for i in range(4):
-            phasor = phasor.at[0, i, :3].set(four_freq_det._mode_E[i])
-            phasor = phasor.at[0, i, 3:].set(four_freq_det._mode_H[i])
-        state = {"phasor": phasor}
-        result = four_freq_det.compute_overlap(state=state)
-        for i, wc in enumerate([_WC_1200, _WC_1300, _WC_1450, _WC_1550]):
+        result = det.compute_overlap(state=state)
+        for i in range(n_freqs):
             mag = float(jnp.abs(result[i]))
-            assert mag == pytest.approx(1.0, abs=0.05), (
-                f"Self-overlap at {int(wc.wavelength * 1e9)} nm = {mag:.4f}, expected ≈ 1.0"
-            )
-
-    def test_compute_overlap_shape(self, four_freq_det):
-        """compute_overlap() on a zero phasor returns shape (4,), complex."""
-        state = four_freq_det.init_state()
-        result = four_freq_det.compute_overlap(state=state)
-        assert result.shape == (4,)
-        assert jnp.iscomplexobj(result)
+            assert mag == pytest.approx(1.0, abs=0.05), f"Self-overlap at freq {i} = {mag:.4f}, expected ≈ 1.0"

--- a/tests/integration/objects/test_mode_detector.py
+++ b/tests/integration/objects/test_mode_detector.py
@@ -187,8 +187,8 @@ class TestSingleVsMultiFreqAgreement:
     """A single-frequency detector and the 1550 nm slot of a two-frequency detector
     must return the same mode fields and the same overlap on identical phasors.
 
-    This validates that neff-proximity tracking at the first frequency (target_neff=None)
-    is equivalent to the standalone single-frequency path.
+    Validates that the first frequency in a multi-frequency sweep produces the same
+    mode as a standalone single-frequency detector at the same wavelength.
     """
 
     def test_mode_E_at_1550_matches(self, two_freq_det, single_freq_det):
@@ -238,8 +238,7 @@ class TestSingleVsMultiFreqAgreement:
 class TestFourFreqDetectorApply:
     """End-to-end tests for ModeOverlapDetector.apply() with four wave characters.
 
-    Spans 1200–1550 nm (350 nm range) in a single apply() call with neff-proximity
-    tracking across all four solver calls.
+    Spans 1200–1550 nm (350 nm range) with neff-proximity tracking across four frequencies.
     """
 
     def test_mode_E_shape(self, four_freq_det):

--- a/tests/integration/objects/test_mode_detector.py
+++ b/tests/integration/objects/test_mode_detector.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 import fdtdx
-from fdtdx.core.physics.modes import compute_mode_multiple_frequencies
+from fdtdx.core.physics.modes import compute_mode
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.fdtd.initialization import apply_params
 from fdtdx.materials import Material
@@ -170,7 +170,7 @@ class TestModeOverlapDetectorApply:
             assert mag == pytest.approx(1.0, abs=0.05), f"Self-overlap at freq {i} = {mag:.4f}, expected ~= 1.0"
 
 
-class TestComputeModeMultipleFrequenciesJitCompatibility:
+class TestComputeModeJitCompatibility:
     """``compute_mode_multiple_frequencies`` is callable from inside ``jax.jit``."""
 
     def test_callable_under_jit(self):
@@ -184,7 +184,7 @@ class TestComputeModeMultipleFrequenciesJitCompatibility:
 
         @jax.jit
         def fn(stack: jax.Array) -> jax.Array:
-            mode_Es, _mode_Hs, _neffs = compute_mode_multiple_frequencies(
+            mode_Es, _mode_Hs, _neffs = compute_mode(
                 frequencies=frequencies,
                 inv_permittivities=stack,
                 inv_permeabilities=1.0,

--- a/tests/integration/objects/test_mode_detector.py
+++ b/tests/integration/objects/test_mode_detector.py
@@ -1,8 +1,9 @@
 """Integration tests for ModeOverlapDetector with multiple wave characters.
 
 Exercises multi-frequency mode solving through the real tidy3d mode solver with a
-uniform air permittivity slice.  Verifies output shapes, finiteness, positive neff,
-and self-overlap normalization without mocking any external dependencies.
+Si/SiO2 waveguide cross-section (800 nm Si core, SiO2 cladding, z-propagation).
+Verifies output shapes, finiteness, guided-mode neff bounds, and self-overlap
+normalization without mocking any external dependencies.
 """
 
 import jax
@@ -22,6 +23,10 @@ _NCELLS_T = 8
 _PML = 3
 _TOTAL_T = _NCELLS_T + 2 * _PML  # 14 cells per transverse axis
 
+_EPS_SI = fdtdx.constants.relative_permittivity_silicon  # 12.25, n≈3.5
+_EPS_SIO2 = fdtdx.constants.relative_permittivity_silica  # 2.25,  n≈1.5
+_CORE_SIZE = 4 * _RESOLUTION  # 800 nm — 4 cells, well-guided at 1550 nm
+
 _WC_1200 = WaveCharacter(wavelength=1.20e-6)
 _WC_1300 = WaveCharacter(wavelength=1.30e-6)
 _WC_1450 = WaveCharacter(wavelength=1.45e-6)
@@ -29,7 +34,13 @@ _WC_1550 = WaveCharacter(wavelength=1.55e-6)
 
 
 def _make_det_fixture(wave_characters):
-    """Build and apply a ModeOverlapDetector with the given wave characters."""
+    """Build a ModeOverlapDetector over a Si/SiO2 waveguide cross-section.
+
+    The domain is SiO2 cladding with an 800x800 nm Si core centred in the
+    transverse (x-y) plane.  Propagation axis is z.  Using a real guided
+    structure makes test_self_overlap_equals_one a genuine physics test:
+    normalization errors that cancel in air will produce |overlap| != 1 here.
+    """
     total_t = _TOTAL_T * _RESOLUTION
     total_z = (1 + 2 * _PML) * _RESOLUTION
 
@@ -47,6 +58,20 @@ def _make_det_fixture(wave_characters):
     )
     bound_dict, bound_constraints = fdtdx.boundary_objects_from_config(bound_cfg, volume)
 
+    # SiO2 cladding fills the entire volume
+    cladding = fdtdx.UniformMaterialObject(
+        name="cladding",
+        partial_real_shape=(None, None, None),
+        material=fdtdx.Material(permittivity=_EPS_SIO2),
+    )
+
+    # Si core centred in the transverse plane, spanning full z extent
+    core = fdtdx.UniformMaterialObject(
+        name="core",
+        partial_real_shape=(_CORE_SIZE, _CORE_SIZE, None),
+        material=fdtdx.Material(permittivity=_EPS_SI),
+    )
+
     det = ModeOverlapDetector(
         name="det",
         wave_characters=wave_characters,
@@ -58,9 +83,12 @@ def _make_det_fixture(wave_characters):
         time=1e-14,
         grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
     )
-    objects = [volume, det, *list(bound_dict.values())]
+    objects = [volume, cladding, core, det, *list(bound_dict.values())]
     constraints = [
         *bound_constraints,
+        *cladding.same_position_and_size(volume),
+        core.same_size(volume, axes=(2,)),
+        core.place_at_center(volume, axes=(0, 1, 2)),
         det.same_size(volume, axes=(0, 1)),
         det.place_at_center(volume, axes=(0, 1, 2)),
     ]
@@ -78,13 +106,13 @@ def _make_det_fixture(wave_characters):
 
 @pytest.fixture(scope="module")
 def two_freq_det():
-    """Uniform-air domain: 2-wave-character detector (1550 nm + 1300 nm, z-plane)."""
+    """Si/SiO2 waveguide: 2-wave-character detector (1550 nm + 1300 nm, z-plane)."""
     return _make_det_fixture((_WC_1550, _WC_1300))
 
 
 @pytest.fixture(scope="module")
 def four_freq_det():
-    """Uniform-air domain: 4-wave-character detector (1200/1300/1450/1550 nm, z-plane)."""
+    """Si/SiO2 waveguide: 4-wave-character detector (1200/1300/1450/1550 nm, z-plane)."""
     return _make_det_fixture((_WC_1200, _WC_1300, _WC_1450, _WC_1550))
 
 
@@ -101,13 +129,21 @@ class TestModeOverlapDetectorApply:
         assert det._mode_E.shape == det._mode_H.shape
         assert det._mode_neff.shape == (n_freqs,)
 
-    def test_fields_finite_and_neff_positive(self, det_fixture, n_freqs, request):
-        """All mode field components are finite and real(neff) > 0 at every frequency."""
+    def test_fields_finite_and_neff_in_guided_range(self, det_fixture, n_freqs, request):
+        """All mode field components are finite and neff is in (n_clad, n_core) at every frequency.
+
+        For a guided mode in Si/SiO2, real(neff) must lie strictly between the cladding
+        index (sqrt(2.25)~1.5) and the core index (sqrt(12.25)~3.5).  Failure here
+        indicates wrong permittivity assignment or a solver returning a radiation mode.
+        """
         det = request.getfixturevalue(det_fixture)
         assert jnp.all(jnp.isfinite(det._mode_E))
         assert jnp.all(jnp.isfinite(det._mode_H))
         neffs = np.real(np.array(det._mode_neff))
-        assert np.all(neffs > 0), f"Non-positive neff: {neffs}"
+        n_clad = np.sqrt(_EPS_SIO2)  # ~1.5
+        n_core = np.sqrt(_EPS_SI)  # ~3.5
+        assert np.all(neffs > n_clad), f"neff below cladding index {n_clad:.3f}: {neffs}"
+        assert np.all(neffs < n_core), f"neff above core index {n_core:.3f}: {neffs}"
 
     def test_compute_overlap_shape_and_dtype(self, det_fixture, n_freqs, request):
         """compute_overlap() on a zero phasor returns complex array of shape (n_freqs,)."""
@@ -118,10 +154,12 @@ class TestModeOverlapDetectorApply:
         assert jnp.iscomplexobj(result)
 
     def test_self_overlap_equals_one(self, det_fixture, n_freqs, request):
-        """Feeding each mode back as its own phasor gives |overlap| ≈ 1 at every frequency.
+        """Feeding each mode back as its own phasor gives |overlap| ~= 1 at every frequency.
 
-        Validates Poynting-flux normalization end-to-end through the real tidy3d solver:
-        a unit-power mode must have self-overlap = 1 by the bidirectional formula.
+        Validates Poynting-flux normalization end-to-end through the real tidy3d solver
+        on a genuine guided mode: a unit-power mode must have self-overlap = 1 by the
+        bidirectional formula.  This test would fail with a wrong 1/4 factor, wrong
+        conjugation, or wrong area weights.
         """
         det = request.getfixturevalue(det_fixture)
         state = det.init_state()
@@ -133,4 +171,4 @@ class TestModeOverlapDetectorApply:
         result = det.compute_overlap(state=state)
         for i in range(n_freqs):
             mag = float(jnp.abs(result[i]))
-            assert mag == pytest.approx(1.0, abs=0.05), f"Self-overlap at freq {i} = {mag:.4f}, expected ≈ 1.0"
+            assert mag == pytest.approx(1.0, abs=0.05), f"Self-overlap at freq {i} = {mag:.4f}, expected ~= 1.0"

--- a/tests/integration/objects/test_mode_detector.py
+++ b/tests/integration/objects/test_mode_detector.py
@@ -1,8 +1,9 @@
 """Integration tests for ModeOverlapDetector with multiple wave characters.
 
 Exercises multi-frequency mode solving through the real tidy3d mode solver with a
-uniform air permittivity slice.  Verifies output shapes, finiteness, neff
-plausibility, and self-overlap normalization without mocking any external dependencies.
+uniform air permittivity slice.  Verifies output shapes, finiteness, self-overlap
+normalization, and single-vs-multi-frequency consistency without mocking any external
+dependencies.
 """
 
 import jax
@@ -134,14 +135,6 @@ class TestMultiFreqDetectorApply:
         neffs = np.real(np.array(two_freq_det._mode_neff))
         assert np.all(neffs > 0), f"Non-positive neff: {neffs}"
 
-    def test_neff_continuity(self, two_freq_det):
-        """Neff values at 1550 nm and 1300 nm stay close — no mode hopping."""
-        neffs = np.real(np.array(two_freq_det._mode_neff))
-        diff = abs(neffs[0] - neffs[1])
-        assert diff < 0.2, (
-            f"neff jumped between 1550 nm and 1300 nm: {neffs[0]:.4f} vs {neffs[1]:.4f} (diff={diff:.4f})"
-        )
-
     def test_freq_count_matches_wave_characters(self, two_freq_det):
         """One mode (E, H, neff) returned per wave character."""
         assert two_freq_det._mode_E.shape[0] == 2
@@ -158,32 +151,17 @@ class TestMultiFreqDetectorApply:
     def test_self_overlap_equals_one(self, two_freq_det):
         """Feeding the mode fields back as the phasor gives |overlap|≈1 at freq-0.
 
-        This validates Poynting-flux normalization: a normalised mode has unit
-        self-overlap when bidirectional_mode_overlap is divided by 4.
+        Validates Poynting-flux normalization: a unit-power mode has self-overlap = 1.
         """
         state = two_freq_det.init_state()
-        # Fill phasor[0, 0, :3] with mode_E[0] and phasor[0, 0, 3:] with mode_H[0]
         phasor = state["phasor"]
         phasor = phasor.at[0, 0, :3].set(two_freq_det._mode_E[0])
         phasor = phasor.at[0, 0, 3:].set(two_freq_det._mode_H[0])
         state = {"phasor": phasor}
         result = two_freq_det.compute_overlap(state=state)
-        # air domain: neff≈1, self-overlap should be real and ≈1
         assert jnp.abs(result[0]) == pytest.approx(1.0, abs=0.05), (
             f"Self-overlap at freq-0 is {float(jnp.abs(result[0])):.4f}, expected ≈1.0"
         )
-
-    def test_neff_monotone_normal_dispersion(self, two_freq_det):
-        """In air (non-dispersive), neff is the same at both frequencies.
-
-        For a dispersive Si/SiO2 waveguide neff would increase at shorter wavelength
-        (normal dispersion), but here we just verify the values are physically plausible
-        and self-consistent (both equal ≈1.0 for air).
-        """
-        neffs = np.real(np.array(two_freq_det._mode_neff))
-        # In air: neff ≈ 1 at all wavelengths
-        assert np.all(neffs > 0.9), f"neffs below 0.9 in air: {neffs}"
-        assert np.all(neffs < 1.1), f"neffs above 1.1 in air: {neffs}"
 
 
 class TestSingleVsMultiFreqAgreement:
@@ -263,12 +241,6 @@ class TestFourFreqDetectorApply:
         """real(neff) > 0 at every frequency."""
         neffs = np.real(np.array(four_freq_det._mode_neff))
         assert np.all(neffs > 0), f"Non-positive neff: {neffs}"
-
-    def test_neff_continuity_no_large_jump(self, four_freq_det):
-        """No consecutive neff pair differs by more than 0.2 (no mode hopping)."""
-        neffs = np.real(np.array(four_freq_det._mode_neff))
-        diffs = np.abs(np.diff(neffs))
-        assert np.all(diffs < 0.2), f"Large neff jump across frequencies: {neffs}, diffs={diffs}"
 
     def test_self_overlap_equals_one_at_each_frequency(self, four_freq_det):
         """Feeding mode fields back as phasor gives |overlap| ≈ 1 at every frequency slot."""

--- a/tests/integration/objects/test_mode_detector.py
+++ b/tests/integration/objects/test_mode_detector.py
@@ -69,7 +69,10 @@ def _make_det_fixture(wave_characters):
     ]
     key = jax.random.PRNGKey(0)
     obj_container, arrays, _, config, _ = fdtdx.place_objects(
-        object_list=objects, config=config, constraints=constraints, key=key,
+        object_list=objects,
+        config=config,
+        constraints=constraints,
+        key=key,
     )
     arrays = fdtdx.extend_material_to_pml(objects=obj_container, arrays=arrays)
     _, obj_container, _ = apply_params(arrays, obj_container, {}, key)
@@ -193,7 +196,7 @@ class TestSingleVsMultiFreqAgreement:
 
     def test_mode_E_at_1550_matches(self, two_freq_det, single_freq_det):
         """Mode E-field at 1550 nm is the same whether solved alone or as part of a sweep."""
-        mode_E_multi = np.array(two_freq_det._mode_E[0])   # (3, *spatial)
+        mode_E_multi = np.array(two_freq_det._mode_E[0])  # (3, *spatial)
         mode_E_single = np.array(single_freq_det._mode_E[0])
 
         # Fields may differ by a global phase; compare normalised magnitudes
@@ -227,9 +230,7 @@ class TestSingleVsMultiFreqAgreement:
         overlap_single = float(jnp.abs(single_freq_det.compute_overlap(state_single)[0]))
         overlap_multi = float(jnp.abs(two_freq_det.compute_overlap(state_multi)[0]))
 
-        assert overlap_single == pytest.approx(1.0, abs=0.05), (
-            f"Single-freq self-overlap = {overlap_single:.4f}"
-        )
+        assert overlap_single == pytest.approx(1.0, abs=0.05), f"Single-freq self-overlap = {overlap_single:.4f}"
         assert overlap_multi == pytest.approx(overlap_single, abs=0.05), (
             f"Multi-freq overlap[0]={overlap_multi:.4f} vs single={overlap_single:.4f}"
         )
@@ -238,7 +239,7 @@ class TestSingleVsMultiFreqAgreement:
 class TestFourFreqDetectorApply:
     """End-to-end tests for ModeOverlapDetector.apply() with four wave characters.
 
-    Spans 1200–1550 nm (350 nm range) with neff-proximity tracking across four frequencies.
+    Spans 1200-1550 nm (350 nm range) with neff-proximity tracking across four frequencies.
     """
 
     def test_mode_E_shape(self, four_freq_det):
@@ -267,9 +268,7 @@ class TestFourFreqDetectorApply:
         """No consecutive neff pair differs by more than 0.2 (no mode hopping)."""
         neffs = np.real(np.array(four_freq_det._mode_neff))
         diffs = np.abs(np.diff(neffs))
-        assert np.all(diffs < 0.2), (
-            f"Large neff jump across frequencies: {neffs}, diffs={diffs}"
-        )
+        assert np.all(diffs < 0.2), f"Large neff jump across frequencies: {neffs}, diffs={diffs}"
 
     def test_self_overlap_equals_one_at_each_frequency(self, four_freq_det):
         """Feeding mode fields back as phasor gives |overlap| ≈ 1 at every frequency slot."""

--- a/tests/integration/objects/test_mode_detector.py
+++ b/tests/integration/objects/test_mode_detector.py
@@ -1,8 +1,8 @@
 """Integration tests for ModeOverlapDetector with multiple wave characters.
 
-Exercises compute_modes_multi_freq through the real tidy3d mode solver with a
-uniform air permittivity slice.  Verifies output shapes, finiteness, and neff
-plausibility without mocking any external dependencies.
+Exercises multi-frequency mode solving through the real tidy3d mode solver with a
+uniform air permittivity slice.  Verifies output shapes, finiteness, neff
+plausibility, and self-overlap normalization without mocking any external dependencies.
 """
 
 import jax
@@ -30,8 +30,8 @@ _WC_1300 = WaveCharacter(wavelength=1.30e-6)
 def two_freq_det():
     """Uniform-air domain with a 2-wave-character ModeOverlapDetector (z-plane).
 
-    Calls apply_params so compute_modes_multi_freq runs through the real tidy3d
-    ARPACK solver.  Fixture is module-scoped so the expensive solve runs once.
+    Calls apply_params so compute_mode runs twice (once per frequency) through the
+    real tidy3d ARPACK solver.  Fixture is module-scoped so the expensive solve runs once.
     """
     total_t = _TOTAL_T * _RESOLUTION
     total_z = (1 + 2 * _PML) * _RESOLUTION
@@ -131,3 +131,33 @@ class TestMultiFreqDetectorApply:
         result = two_freq_det.compute_overlap(state=state)
         assert result.shape == (2,)
         assert jnp.iscomplexobj(result)
+
+    def test_self_overlap_equals_one(self, two_freq_det):
+        """Feeding the mode fields back as the phasor gives |overlap|≈1 at freq-0.
+
+        This validates Poynting-flux normalization: a normalised mode has unit
+        self-overlap when bidirectional_mode_overlap is divided by 4.
+        """
+        state = two_freq_det.init_state()
+        # Fill phasor[0, 0, :3] with mode_E[0] and phasor[0, 0, 3:] with mode_H[0]
+        phasor = state["phasor"]
+        phasor = phasor.at[0, 0, :3].set(two_freq_det._mode_E[0])
+        phasor = phasor.at[0, 0, 3:].set(two_freq_det._mode_H[0])
+        state = {"phasor": phasor}
+        result = two_freq_det.compute_overlap(state=state)
+        # air domain: neff≈1, self-overlap should be real and ≈1
+        assert jnp.abs(result[0]) == pytest.approx(1.0, abs=0.05), (
+            f"Self-overlap at freq-0 is {float(jnp.abs(result[0])):.4f}, expected ≈1.0"
+        )
+
+    def test_neff_monotone_normal_dispersion(self, two_freq_det):
+        """In air (non-dispersive), neff is the same at both frequencies.
+
+        For a dispersive Si/SiO2 waveguide neff would increase at shorter wavelength
+        (normal dispersion), but here we just verify the values are physically plausible
+        and self-consistent (both equal ≈1.0 for air).
+        """
+        neffs = np.real(np.array(two_freq_det._mode_neff))
+        # In air: neff ≈ 1 at all wavelengths
+        assert np.all(neffs > 0.9), f"neffs below 0.9 in air: {neffs}"
+        assert np.all(neffs < 1.1), f"neffs above 1.1 in air: {neffs}"

--- a/tests/integration/objects/test_mode_detector.py
+++ b/tests/integration/objects/test_mode_detector.py
@@ -22,8 +22,10 @@ _NCELLS_T = 8
 _PML = 3
 _TOTAL_T = _NCELLS_T + 2 * _PML  # 14 cells per transverse axis
 
-_WC_1550 = WaveCharacter(wavelength=1.55e-6)
+_WC_1200 = WaveCharacter(wavelength=1.20e-6)
 _WC_1300 = WaveCharacter(wavelength=1.30e-6)
+_WC_1450 = WaveCharacter(wavelength=1.45e-6)
+_WC_1550 = WaveCharacter(wavelength=1.55e-6)
 
 
 def _make_det_fixture(wave_characters):
@@ -87,6 +89,17 @@ def single_freq_det():
     Same geometry as two_freq_det so their modes can be compared directly.
     """
     return _make_det_fixture((_WC_1550,))
+
+
+@pytest.fixture(scope="module")
+def four_freq_det():
+    """Uniform-air domain: 4-wave-character detector (1200/1300/1450/1550 nm, z-plane).
+
+    Spans a wide wavelength range (350 nm) to stress-test the neff-proximity
+    loop and verify shapes, finiteness, and self-overlap normalization across
+    all four frequencies in a single apply() call.
+    """
+    return _make_det_fixture((_WC_1200, _WC_1300, _WC_1450, _WC_1550))
 
 
 class TestMultiFreqDetectorApply:
@@ -220,3 +233,63 @@ class TestSingleVsMultiFreqAgreement:
         assert overlap_multi == pytest.approx(overlap_single, abs=0.05), (
             f"Multi-freq overlap[0]={overlap_multi:.4f} vs single={overlap_single:.4f}"
         )
+
+
+class TestFourFreqDetectorApply:
+    """End-to-end tests for ModeOverlapDetector.apply() with four wave characters.
+
+    Spans 1200–1550 nm (350 nm range) in a single apply() call with neff-proximity
+    tracking across all four solver calls.
+    """
+
+    def test_mode_E_shape(self, four_freq_det):
+        """_mode_E has shape (4, 3, *spatial)."""
+        assert four_freq_det._mode_E.shape == (4, 3, _TOTAL_T, _TOTAL_T, 1)
+
+    def test_mode_H_shape(self, four_freq_det):
+        """_mode_H has shape (4, 3, *spatial)."""
+        assert four_freq_det._mode_H.shape == (4, 3, _TOTAL_T, _TOTAL_T, 1)
+
+    def test_neff_shape(self, four_freq_det):
+        """_mode_neff has shape (4,)."""
+        assert four_freq_det._mode_neff.shape == (4,)
+
+    def test_mode_fields_finite(self, four_freq_det):
+        """All mode field components are finite across all four frequencies."""
+        assert jnp.all(jnp.isfinite(four_freq_det._mode_E))
+        assert jnp.all(jnp.isfinite(four_freq_det._mode_H))
+
+    def test_neff_all_positive(self, four_freq_det):
+        """real(neff) > 0 at every frequency."""
+        neffs = np.real(np.array(four_freq_det._mode_neff))
+        assert np.all(neffs > 0), f"Non-positive neff: {neffs}"
+
+    def test_neff_continuity_no_large_jump(self, four_freq_det):
+        """No consecutive neff pair differs by more than 0.2 (no mode hopping)."""
+        neffs = np.real(np.array(four_freq_det._mode_neff))
+        diffs = np.abs(np.diff(neffs))
+        assert np.all(diffs < 0.2), (
+            f"Large neff jump across frequencies: {neffs}, diffs={diffs}"
+        )
+
+    def test_self_overlap_equals_one_at_each_frequency(self, four_freq_det):
+        """Feeding mode fields back as phasor gives |overlap| ≈ 1 at every frequency slot."""
+        state = four_freq_det.init_state()
+        phasor = state["phasor"]
+        for i in range(4):
+            phasor = phasor.at[0, i, :3].set(four_freq_det._mode_E[i])
+            phasor = phasor.at[0, i, 3:].set(four_freq_det._mode_H[i])
+        state = {"phasor": phasor}
+        result = four_freq_det.compute_overlap(state=state)
+        for i, wc in enumerate([_WC_1200, _WC_1300, _WC_1450, _WC_1550]):
+            mag = float(jnp.abs(result[i]))
+            assert mag == pytest.approx(1.0, abs=0.05), (
+                f"Self-overlap at {int(wc.wavelength * 1e9)} nm = {mag:.4f}, expected ≈ 1.0"
+            )
+
+    def test_compute_overlap_shape(self, four_freq_det):
+        """compute_overlap() on a zero phasor returns shape (4,), complex."""
+        state = four_freq_det.init_state()
+        result = four_freq_det.compute_overlap(state=state)
+        assert result.shape == (4,)
+        assert jnp.iscomplexobj(result)

--- a/tests/simulation/fdtd/test_pulsed_vs_cw.py
+++ b/tests/simulation/fdtd/test_pulsed_vs_cw.py
@@ -247,3 +247,182 @@ def test_pulsed_vs_cw_transmission():
             f"wl={wl * 1e6:.2f} µm: T_pulsed={T_pulsed[i]:.4f}, T_CW={T_cw[i]:.4f}, "
             f"relative error={rel_err:.3f} > {_TOLERANCE}"
         )
+
+
+# ── Mode overlap pulsed vs CW ─────────────────────────────────────────────────
+#
+# Si/SiO2 slab waveguide (propagation along x, periodic in y).
+# One broadband pulsed run with ModeOverlapDetector carrying all 3 wave_characters
+# is compared against 3 independent CW runs each with a single wave_character.
+# Agreement validates that multi-frequency phasor accumulation produces the same
+# S-parameter at each frequency as running the frequencies independently.
+#
+# Domain (50 nm resolution, x is propagation axis):
+#   x: 3 µm total (60 cells); PML 10 cells each side; active 40 cells
+#   y: 150 nm (3 cells), periodic — slab approximation
+#   z: 2 µm total (40 cells); PML 10 cells each side
+#   Si core: 250 nm (5 cells) centred in z
+#   Source: x-index 12; output detector: x-index 25
+
+_WG_RESOLUTION = 50e-9
+_WG_PML = 10
+_WG_DOMAIN_X = 3e-6
+_WG_DOMAIN_Y = 3 * _WG_RESOLUTION
+_WG_DOMAIN_Z = 2e-6
+_WG_CORE_HEIGHT = 250e-9
+_WG_SOURCE_X = _WG_PML + 2  # = 12
+_WG_DET_X = 25
+_WG_SIM_TIME = 300e-15  # 300 fs: ~69 periods at 1300 nm, enough for CW startup ramp to be negligible
+_WG_CENTER_WL = 1.45e-6
+
+_WG_EPS_SI = fdtdx.constants.relative_permittivity_silicon
+_WG_EPS_SIO2 = fdtdx.constants.relative_permittivity_silica
+
+_WG_TEST_WCS = [
+    fdtdx.WaveCharacter(wavelength=1.30e-6),
+    fdtdx.WaveCharacter(wavelength=1.45e-6),
+    fdtdx.WaveCharacter(wavelength=1.55e-6),
+]
+_WG_TOLERANCE = 0.05
+
+
+def _build_waveguide_scene(temporal_profile, source_wc, det_wave_characters):
+    """Return (objects, constraints, config) for the Si/SiO2 slab waveguide."""
+    config = fdtdx.SimulationConfig(
+        grid=fdtdx.UniformGrid(spacing=_WG_RESOLUTION),
+        time=_WG_SIM_TIME,
+        dtype=jnp.float32,
+    )
+    objects, constraints = [], []
+
+    volume = fdtdx.SimulationVolume(
+        partial_real_shape=(_WG_DOMAIN_X, _WG_DOMAIN_Y, _WG_DOMAIN_Z),
+    )
+    objects.append(volume)
+
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+        thickness=_WG_PML,
+        override_types={"min_y": "periodic", "max_y": "periodic"},
+    )
+    bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    constraints.extend(c_list)
+    objects.extend(bound_dict.values())
+
+    cladding = fdtdx.UniformMaterialObject(
+        name="cladding",
+        partial_real_shape=(None, None, None),
+        material=fdtdx.Material(permittivity=_WG_EPS_SIO2),
+    )
+    constraints.extend(cladding.same_position_and_size(volume))
+    objects.append(cladding)
+
+    core = fdtdx.UniformMaterialObject(
+        name="core",
+        partial_real_shape=(None, None, _WG_CORE_HEIGHT),
+        material=fdtdx.Material(permittivity=_WG_EPS_SI),
+    )
+    constraints.extend([core.same_size(volume, axes=(0, 1)), core.place_at_center(volume, axes=(0, 1, 2))])
+    objects.append(core)
+
+    source = fdtdx.ModePlaneSource(
+        name="source",
+        partial_grid_shape=(1, None, None),
+        wave_character=source_wc,
+        temporal_profile=temporal_profile,
+        direction="+",
+        mode_index=0,
+        filter_pol="te",
+    )
+    constraints.extend(
+        [
+            source.same_size(volume, axes=(1, 2)),
+            source.place_at_center(volume, axes=(1, 2)),
+            source.set_grid_coordinates(axes=(0,), sides=("-",), coordinates=(_WG_SOURCE_X,)),
+        ]
+    )
+    objects.append(source)
+
+    input_det = fdtdx.ModeOverlapDetector(
+        name="det_source",
+        wave_characters=tuple(det_wave_characters),
+        direction="+",
+        mode_index=0,
+        filter_pol="te",
+        scaling_mode="pulse",
+    )
+    constraints.extend([input_det.same_size(source), input_det.same_position(source, grid_margins=(1, 0, 0))])
+    objects.append(input_det)
+
+    det_out = fdtdx.ModeOverlapDetector(
+        name="det_out",
+        partial_grid_shape=(1, None, None),
+        wave_characters=tuple(det_wave_characters),
+        direction="+",
+        mode_index=0,
+        filter_pol="te",
+        scaling_mode="pulse",
+    )
+    constraints.extend(
+        [
+            det_out.same_size(volume, axes=(1, 2)),
+            det_out.place_at_center(volume, axes=(1, 2)),
+            det_out.set_grid_coordinates(axes=(0,), sides=("-",), coordinates=(_WG_DET_X,)),
+        ]
+    )
+    objects.append(det_out)
+
+    return objects, constraints, config
+
+
+def test_pulsed_vs_cw_mode_overlap():
+    """Multi-freq pulsed ModeOverlapDetector agrees with single-freq CW runs within 5 %.
+
+    One broadband pulsed run carries all 3 wave_characters on a single
+    ModeOverlapDetector.  Three independent CW runs each carry one wave_character.
+    |S_pulsed(wl)| must agree with |S_CW(wl)| at every wavelength, proving that
+    multi-frequency phasor accumulation does not cross-contaminate frequency channels
+    and that per-frequency normalization is correct.
+    """
+    center_wc = fdtdx.WaveCharacter(wavelength=_WG_CENTER_WL)
+    pulsed_profile = fdtdx.GaussianPulseProfile(
+        center_wave=center_wc,
+        spectral_width=fdtdx.WaveCharacter(wavelength=_WG_CENTER_WL * 10),
+    )
+    key = jax.random.PRNGKey(0)
+
+    # ── Pulsed run (all 3 frequencies at once) ────────────────────────────────
+    objs, cons, cfg = _build_waveguide_scene(pulsed_profile, center_wc, _WG_TEST_WCS)
+    obj_container, arrays, _, cfg, _ = fdtdx.place_objects(object_list=objs, config=cfg, constraints=cons, key=key)
+    arrays = fdtdx.extend_material_to_pml(objects=obj_container, arrays=arrays)
+    result_pulsed, _ = fdtdx.calculate_sparam(
+        objects=obj_container,
+        arrays=arrays,
+        config=cfg,
+        input_port_name="source",
+        show_progress=False,
+    )
+    s_pulsed = np.array(result_pulsed[("det_out", "source")])  # shape (3,)
+
+    # ── CW runs (one per frequency) ───────────────────────────────────────────
+    s_cw = []
+    for wc in _WG_TEST_WCS:
+        objs, cons, cfg = _build_waveguide_scene(fdtdx.SingleFrequencyProfile(), wc, [wc])
+        obj_container, arrays, _, cfg, _ = fdtdx.place_objects(object_list=objs, config=cfg, constraints=cons, key=key)
+        arrays = fdtdx.extend_material_to_pml(objects=obj_container, arrays=arrays)
+        result, _ = fdtdx.calculate_sparam(
+            objects=obj_container,
+            arrays=arrays,
+            config=cfg,
+            input_port_name="source",
+            show_progress=False,
+        )
+        s_cw.append(complex(np.array(result[("det_out", "source")])[0]))
+
+    # ── Comparison ────────────────────────────────────────────────────────────
+    for i, wc in enumerate(_WG_TEST_WCS):
+        wl_nm = int(wc.wavelength * 1e9)
+        rel_err = abs(abs(s_pulsed[i]) - abs(s_cw[i])) / abs(s_cw[i])
+        assert rel_err < _WG_TOLERANCE, (
+            f"wl={wl_nm} nm: |S_pulsed|={abs(s_pulsed[i]):.4f}, "
+            f"|S_CW|={abs(s_cw[i]):.4f}, rel_err={rel_err:.3f} > {_WG_TOLERANCE}"
+        )

--- a/tests/simulation/physics/test_sparams.py
+++ b/tests/simulation/physics/test_sparams.py
@@ -208,8 +208,12 @@ def test_waveguide_sparam_transmission():
 
 # ── Multi-frequency sparam test ───────────────────────────────────────────────
 
+_WC_1300 = fdtdx.WaveCharacter(wavelength=1.30e-6)
+_WC_1400 = fdtdx.WaveCharacter(wavelength=1.40e-6)
+_WC_1500 = fdtdx.WaveCharacter(wavelength=1.50e-6)
 _WC_1550 = fdtdx.WaveCharacter(wavelength=1.55e-6)
-_WC_1450 = fdtdx.WaveCharacter(wavelength=1.45e-6)
+
+_MULTIFREQ_WCS = (_WC_1300, _WC_1400, _WC_1500, _WC_1550)
 
 
 def _build_waveguide_sparams_multifreq():
@@ -275,10 +279,10 @@ def _build_waveguide_sparams_multifreq():
     ])
     objects.append(source)
 
-    # Input normalization detector — two frequencies
+    # Input normalization detector — four frequencies
     input_det = fdtdx.ModeOverlapDetector(
         name="det_source",
-        wave_characters=(_WC_1550, _WC_1450),
+        wave_characters=_MULTIFREQ_WCS,
         direction="+",
         mode_index=0,
         filter_pol="te",
@@ -287,11 +291,11 @@ def _build_waveguide_sparams_multifreq():
     constraints.extend([input_det.same_size(source), input_det.same_position(source, grid_margins=(1, 0, 0))])
     objects.append(input_det)
 
-    # One output detector — two frequencies
+    # One output detector — four frequencies
     det = fdtdx.ModeOverlapDetector(
         name="det_near",
         partial_grid_shape=(1, None, None),
-        wave_characters=(_WC_1550, _WC_1450),
+        wave_characters=_MULTIFREQ_WCS,
         direction="+",
         mode_index=0,
         filter_pol="te",
@@ -308,12 +312,13 @@ def _build_waveguide_sparams_multifreq():
 
 
 def test_waveguide_multifreq_sparam():
-    """S-parameters at both 1550 nm and 1450 nm exceed 0.90.
+    """S-parameters at all four wavelengths (1300/1400/1500/1550 nm) exceed 0.90.
 
     Uses the same lossless Si/SiO2 slab waveguide as test_waveguide_sparam_transmission
-    but with ModeOverlapDetectors that carry two wave characters.  Validates that
-    broadband multi-frequency mode overlap works end-to-end: the mode solver is called
-    once per frequency with neff-proximity tracking, and the DFT phasors at both
+    but with ModeOverlapDetectors carrying four wave characters.  Validates end-to-end
+    broadband overlap: the mode solver runs once per frequency with neff-proximity
+    tracking (critical at 1300/1400 nm where a second TE mode exists and the wrong
+    mode could be selected without tracking), and the DFT phasors at all four
     frequencies produce physically correct S-parameter magnitudes.
     """
     objects, constraints, config = _build_waveguide_sparams_multifreq()
@@ -334,7 +339,7 @@ def test_waveguide_multifreq_sparam():
 
     for (det_name, src_name), s_params in result.items():
         s_arr = np.array(s_params)  # shape (2,) — one entry per frequency
-        for freq_idx, (wc, s) in enumerate(zip([_WC_1550, _WC_1450], s_arr)):
+        for freq_idx, (wc, s) in enumerate(zip(_MULTIFREQ_WCS, s_arr)):
             power = float(abs(s) ** 2)
             wavelength_nm = int(wc.wavelength * 1e9)
             print(f"|S({det_name!r}, {wavelength_nm}nm)|² = {power:.4f}")

--- a/tests/simulation/physics/test_sparams.py
+++ b/tests/simulation/physics/test_sparams.py
@@ -319,8 +319,8 @@ def test_waveguide_multifreq_sparam():
     """S-parameters at all four wavelengths (1300/1400/1500/1550 nm) exceed 0.90.
 
     Lossless Si/SiO2 slab waveguide with ModeOverlapDetectors carrying four wave
-    characters.  At 1300/1400 nm a second TE mode exists; neff-proximity tracking
-    ensures the fundamental is selected consistently across the frequency sweep.
+    characters.  Validates that the multi-frequency phasor accumulation and overlap
+    computation produce physically correct broadband transmission in a single run.
     """
     objects, constraints, config = _build_waveguide_sparams_multifreq()
 
@@ -342,7 +342,7 @@ def test_waveguide_multifreq_sparam():
     )
 
     for (det_name, src_name), s_params in result.items():
-        s_arr = np.array(s_params)  # shape (2,) — one entry per frequency
+        s_arr = np.array(s_params)  # shape (num_freqs,)
         for freq_idx, (wc, s) in enumerate(zip(_MULTIFREQ_WCS, s_arr)):
             power = float(abs(s) ** 2)
             wavelength_nm = int(wc.wavelength * 1e9)

--- a/tests/simulation/physics/test_sparams.py
+++ b/tests/simulation/physics/test_sparams.py
@@ -272,11 +272,13 @@ def _build_waveguide_sparams_multifreq():
         mode_index=0,
         filter_pol="te",
     )
-    constraints.extend([
-        source.same_size(volume, axes=(1, 2)),
-        source.place_at_center(volume, axes=(1, 2)),
-        source.set_grid_coordinates(axes=(0,), sides=("-",), coordinates=(_SOURCE_X,)),
-    ])
+    constraints.extend(
+        [
+            source.same_size(volume, axes=(1, 2)),
+            source.place_at_center(volume, axes=(1, 2)),
+            source.set_grid_coordinates(axes=(0,), sides=("-",), coordinates=(_SOURCE_X,)),
+        ]
+    )
     objects.append(source)
 
     # Input normalization detector — four frequencies
@@ -301,11 +303,13 @@ def _build_waveguide_sparams_multifreq():
         filter_pol="te",
         scaling_mode="pulse",
     )
-    constraints.extend([
-        det.same_size(volume, axes=(1, 2)),
-        det.place_at_center(volume, axes=(1, 2)),
-        det.set_grid_coordinates(axes=(0,), sides=("-",), coordinates=(_DET1_X,)),
-    ])
+    constraints.extend(
+        [
+            det.same_size(volume, axes=(1, 2)),
+            det.place_at_center(volume, axes=(1, 2)),
+            det.set_grid_coordinates(axes=(0,), sides=("-",), coordinates=(_DET1_X,)),
+        ]
+    )
     objects.append(det)
 
     return objects, constraints, config
@@ -322,7 +326,10 @@ def test_waveguide_multifreq_sparam():
 
     key = jax.random.PRNGKey(0)
     obj_container, arrays, _params, config, _ = fdtdx.place_objects(
-        object_list=objects, config=config, constraints=constraints, key=key,
+        object_list=objects,
+        config=config,
+        constraints=constraints,
+        key=key,
     )
     arrays = fdtdx.extend_material_to_pml(objects=obj_container, arrays=arrays)
 

--- a/tests/simulation/physics/test_sparams.py
+++ b/tests/simulation/physics/test_sparams.py
@@ -196,10 +196,149 @@ def test_waveguide_sparam_transmission():
 
     for (det_name, src_name), s_param in result.items():
         assert src_name == "source", f"Unexpected source name in key: {src_name!r}"
-        power = float(abs(np.array(s_param)) ** 2)
+        # compute_overlap always returns (num_freqs,); index [0] for single-frequency detectors
+        power = float(abs(np.array(s_param)[0]) ** 2)
         print(f"{power=}")
         assert power > (1.0 - _TOLERANCE) and power <= 1.0001, (
             f"|S({det_name!r}, 'source')|² = {power}, "
             f"expected > {1.0 - _TOLERANCE:.2f} "
             f"(lossless Si/SiO2 slab waveguide should transmit large % of TE mode power)"
         )
+
+
+# ── Multi-frequency sparam test ───────────────────────────────────────────────
+
+_WC_1550 = fdtdx.WaveCharacter(wavelength=1.55e-6)
+_WC_1450 = fdtdx.WaveCharacter(wavelength=1.45e-6)
+
+
+def _build_waveguide_sparams_multifreq():
+    """Same Si/SiO2 slab geometry as _build_waveguide_sparams but detectors carry
+    two wave characters (1550 nm and 1450 nm) to validate broadband overlap.
+
+    The GaussianPulseProfile spectral width is unchanged (10x centre wavelength)
+    so both frequencies are well within the pulse bandwidth.
+    """
+    config = fdtdx.SimulationConfig(
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
+        time=_SIM_TIME,
+        dtype=jnp.float32,
+    )
+    objects, constraints = [], []
+
+    volume = fdtdx.SimulationVolume(
+        partial_real_shape=(_DOMAIN_X, _DOMAIN_Y, _DOMAIN_Z),
+    )
+    objects.append(volume)
+
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+        thickness=_PML_CELLS,
+        override_types={"min_y": "periodic", "max_y": "periodic"},
+    )
+    bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    constraints.extend(c_list)
+    objects.extend(bound_dict.values())
+
+    cladding = fdtdx.UniformMaterialObject(
+        name="cladding",
+        partial_real_shape=(None, None, None),
+        material=fdtdx.Material(permittivity=_EPS_SIO2),
+    )
+    constraints.extend(cladding.same_position_and_size(volume))
+    objects.append(cladding)
+
+    core = fdtdx.UniformMaterialObject(
+        name="core",
+        partial_real_shape=(None, None, _WG_HEIGHT),
+        material=fdtdx.Material(permittivity=_EPS_SI),
+    )
+    constraints.extend([core.same_size(volume, axes=(0, 1)), core.place_at_center(volume, axes=(0, 1, 2))])
+    objects.append(core)
+
+    center_wave = fdtdx.WaveCharacter(wavelength=_CENTER_WAVELENGTH)
+    wave_range = fdtdx.WaveCharacter(wavelength=_CENTER_WAVELENGTH * 10)
+    profile = fdtdx.GaussianPulseProfile(center_wave=center_wave, spectral_width=wave_range)
+
+    source = fdtdx.ModePlaneSource(
+        name="source",
+        partial_grid_shape=(1, None, None),
+        wave_character=center_wave,
+        temporal_profile=profile,
+        direction="+",
+        mode_index=0,
+        filter_pol="te",
+    )
+    constraints.extend([
+        source.same_size(volume, axes=(1, 2)),
+        source.place_at_center(volume, axes=(1, 2)),
+        source.set_grid_coordinates(axes=(0,), sides=("-",), coordinates=(_SOURCE_X,)),
+    ])
+    objects.append(source)
+
+    # Input normalization detector — two frequencies
+    input_det = fdtdx.ModeOverlapDetector(
+        name="det_source",
+        wave_characters=(_WC_1550, _WC_1450),
+        direction="+",
+        mode_index=0,
+        filter_pol="te",
+        scaling_mode="pulse",
+    )
+    constraints.extend([input_det.same_size(source), input_det.same_position(source, grid_margins=(1, 0, 0))])
+    objects.append(input_det)
+
+    # One output detector — two frequencies
+    det = fdtdx.ModeOverlapDetector(
+        name="det_near",
+        partial_grid_shape=(1, None, None),
+        wave_characters=(_WC_1550, _WC_1450),
+        direction="+",
+        mode_index=0,
+        filter_pol="te",
+        scaling_mode="pulse",
+    )
+    constraints.extend([
+        det.same_size(volume, axes=(1, 2)),
+        det.place_at_center(volume, axes=(1, 2)),
+        det.set_grid_coordinates(axes=(0,), sides=("-",), coordinates=(_DET1_X,)),
+    ])
+    objects.append(det)
+
+    return objects, constraints, config
+
+
+def test_waveguide_multifreq_sparam():
+    """S-parameters at both 1550 nm and 1450 nm exceed 0.90.
+
+    Uses the same lossless Si/SiO2 slab waveguide as test_waveguide_sparam_transmission
+    but with ModeOverlapDetectors that carry two wave characters.  Validates that
+    broadband multi-frequency mode overlap works end-to-end: the mode solver is called
+    once per frequency with neff-proximity tracking, and the DFT phasors at both
+    frequencies produce physically correct S-parameter magnitudes.
+    """
+    objects, constraints, config = _build_waveguide_sparams_multifreq()
+
+    key = jax.random.PRNGKey(0)
+    obj_container, arrays, _params, config, _ = fdtdx.place_objects(
+        object_list=objects, config=config, constraints=constraints, key=key,
+    )
+    arrays = fdtdx.extend_material_to_pml(objects=obj_container, arrays=arrays)
+
+    result, _ = fdtdx.calculate_sparam(
+        objects=obj_container,
+        arrays=arrays,
+        config=config,
+        input_port_name="source",
+        show_progress=False,
+    )
+
+    for (det_name, src_name), s_params in result.items():
+        s_arr = np.array(s_params)  # shape (2,) — one entry per frequency
+        for freq_idx, (wc, s) in enumerate(zip([_WC_1550, _WC_1450], s_arr)):
+            power = float(abs(s) ** 2)
+            wavelength_nm = int(wc.wavelength * 1e9)
+            print(f"|S({det_name!r}, {wavelength_nm}nm)|² = {power:.4f}")
+            assert power > (1.0 - _TOLERANCE), (
+                f"|S({det_name!r}, {wavelength_nm}nm)|² = {power:.4f}, "
+                f"expected > {1.0 - _TOLERANCE:.2f} (lossless waveguide)"
+            )

--- a/tests/simulation/physics/test_sparams.py
+++ b/tests/simulation/physics/test_sparams.py
@@ -314,12 +314,9 @@ def _build_waveguide_sparams_multifreq():
 def test_waveguide_multifreq_sparam():
     """S-parameters at all four wavelengths (1300/1400/1500/1550 nm) exceed 0.90.
 
-    Uses the same lossless Si/SiO2 slab waveguide as test_waveguide_sparam_transmission
-    but with ModeOverlapDetectors carrying four wave characters.  Validates end-to-end
-    broadband overlap: the mode solver runs once per frequency with neff-proximity
-    tracking (critical at 1300/1400 nm where a second TE mode exists and the wrong
-    mode could be selected without tracking), and the DFT phasors at all four
-    frequencies produce physically correct S-parameter magnitudes.
+    Lossless Si/SiO2 slab waveguide with ModeOverlapDetectors carrying four wave
+    characters.  At 1300/1400 nm a second TE mode exists; neff-proximity tracking
+    ensures the fundamental is selected consistently across the frequency sweep.
     """
     objects, constraints, config = _build_waveguide_sparams_multifreq()
 

--- a/tests/unit/core/physics/test_metrics.py
+++ b/tests/unit/core/physics/test_metrics.py
@@ -1,9 +1,11 @@
 """Test cases for electromagnetic field metrics and normalization utilities."""
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from fdtdx.core.physics.metrics import (
+    bidirectional_mode_overlap,
     compute_energy,
     compute_poynting_flux,
     normalize_by_energy,
@@ -329,3 +331,95 @@ def test_normalize_by_poynting_flux_preservation():
 
     assert jnp.allclose(E_norm[1] / E_norm[0], E[1] / E[0])
     assert jnp.allclose(H_norm[1] / H_norm[0], H[1] / H[0])
+
+
+class TestBidirectionalModeOverlapVsTidy3d:
+    """Cross-validate bidirectional_mode_overlap against tidy3d's _dot_numpy.
+
+    Convention (propagation_axis=2, transverse u=0, v=1):
+
+        our_result = conj(4 * _dot_numpy(
+            E1=mode, H1=mode, E2=sim, H2=sim, dS=areas, conjugate=True
+        ))
+
+    Derivation: tidy3d conjugates E1/H1 while we conjugate the simulation fields.
+    Swapping which side is conjugated turns the result into its complex conjugate.
+    The factor of 4 accounts for tidy3d's built-in 1/4 prefactor.
+
+    For real-valued self-overlap the conjugate is a no-op, so |our| == 4 * |tidy3d|.
+    """
+
+    def test_random_complex_fields(self):
+        """Agrees with tidy3d _dot_numpy on random complex fields."""
+        from tidy3d.components.mode.solver import _dot_numpy
+
+        rng = np.random.default_rng(42)
+        nx, ny = 5, 6
+
+        def rand_field():
+            return jnp.asarray(
+                (rng.standard_normal((3, nx, ny, 1)) + 1j * rng.standard_normal((3, nx, ny, 1))).astype(np.complex64)
+            )
+
+        mode_E, mode_H = rand_field(), rand_field()
+        sim_E, sim_H = rand_field(), rand_field()
+        area_EuHv = jnp.asarray(rng.uniform(0.5, 2.0, (nx, ny, 1)).astype(np.float32))
+        area_EvHu = jnp.asarray(rng.uniform(0.5, 2.0, (nx, ny, 1)).astype(np.float32))
+
+        our = bidirectional_mode_overlap(
+            mode_E=mode_E,
+            mode_H=mode_H,
+            sim_E=sim_E,
+            sim_H=sim_H,
+            propagation_axis=2,
+            area_EuHv=area_EuHv,
+            area_EvHu=area_EvHu,
+        )
+
+        # tidy3d takes (Eu, Ev) tuples; fields squeezed to 2D (remove propagation dim)
+        tidy3d_result = _dot_numpy(
+            E1=(np.array(mode_E[0, :, :, 0]), np.array(mode_E[1, :, :, 0])),
+            H1=(np.array(mode_H[0, :, :, 0]), np.array(mode_H[1, :, :, 0])),
+            E2=(np.array(sim_E[0, :, :, 0]), np.array(sim_E[1, :, :, 0])),
+            H2=(np.array(sim_H[0, :, :, 0]), np.array(sim_H[1, :, :, 0])),
+            dS=(np.array(area_EuHv[:, :, 0]), np.array(area_EvHu[:, :, 0])),
+            conjugate=True,
+        )
+
+        expected = np.conj(4.0 * complex(tidy3d_result))
+        assert np.isclose(complex(our), expected, rtol=1e-4), (
+            f"our={complex(our):.6g}, expected conj(4*tidy3d)={expected:.6g}"
+        )
+
+    def test_self_overlap_magnitude_equals_four_times_tidy3d(self):
+        """Self-overlap: |our| == 4 * |tidy3d| (conjugate is no-op for real results)."""
+        from tidy3d.components.mode.solver import _dot_numpy
+
+        rng = np.random.default_rng(7)
+        nx, ny = 4, 4
+        mode_E = jnp.asarray(rng.standard_normal((3, nx, ny, 1)).astype(np.float32))
+        mode_H = jnp.asarray(rng.standard_normal((3, nx, ny, 1)).astype(np.float32))
+        area = jnp.ones((nx, ny, 1), dtype=jnp.float32)
+
+        our = bidirectional_mode_overlap(
+            mode_E=mode_E,
+            mode_H=mode_H,
+            sim_E=mode_E,
+            sim_H=mode_H,
+            propagation_axis=2,
+            area_EuHv=area,
+            area_EvHu=area,
+        )
+
+        tidy3d_result = _dot_numpy(
+            E1=(np.array(mode_E[0, :, :, 0]), np.array(mode_E[1, :, :, 0])),
+            H1=(np.array(mode_H[0, :, :, 0]), np.array(mode_H[1, :, :, 0])),
+            E2=(np.array(mode_E[0, :, :, 0]), np.array(mode_E[1, :, :, 0])),
+            H2=(np.array(mode_H[0, :, :, 0]), np.array(mode_H[1, :, :, 0])),
+            dS=(np.array(area[:, :, 0]), np.array(area[:, :, 0])),
+            conjugate=True,
+        )
+
+        assert np.isclose(abs(float(np.real(our))), 4.0 * abs(float(np.real(tidy3d_result))), rtol=1e-5), (
+            f"|our|={abs(float(np.real(our))):.6g}, 4*|tidy3d|={4.0*abs(float(np.real(tidy3d_result))):.6g}"
+        )

--- a/tests/unit/core/physics/test_metrics.py
+++ b/tests/unit/core/physics/test_metrics.py
@@ -338,15 +338,13 @@ class TestBidirectionalModeOverlapVsTidy3d:
 
     Convention (propagation_axis=2, transverse u=0, v=1):
 
-        our_result = conj(4 * _dot_numpy(
+        our_result = _dot_numpy(
             E1=mode, H1=mode, E2=sim, H2=sim, dS=areas, conjugate=True
-        ))
+        )
 
-    Derivation: tidy3d conjugates E1/H1 while we conjugate the simulation fields.
-    Swapping which side is conjugated turns the result into its complex conjugate.
-    The factor of 4 accounts for tidy3d's built-in 1/4 prefactor.
-
-    For real-valued self-overlap the conjugate is a no-op, so |our| == 4 * |tidy3d|.
+    Both formulas conjugate the mode fields and include the 1/4 prefactor,
+    so self-overlap = 1 for unit-power modes and results are identical for
+    both real and complex fields.
     """
 
     def test_random_complex_fields(self):
@@ -386,13 +384,13 @@ class TestBidirectionalModeOverlapVsTidy3d:
             conjugate=True,
         )
 
-        expected = np.conj(4.0 * complex(tidy3d_result))
+        expected = complex(tidy3d_result)
         assert np.isclose(complex(our), expected, rtol=1e-4), (
-            f"our={complex(our):.6g}, expected conj(4*tidy3d)={expected:.6g}"
+            f"our={complex(our):.6g}, expected tidy3d={expected:.6g}"
         )
 
-    def test_self_overlap_magnitude_equals_four_times_tidy3d(self):
-        """Self-overlap: |our| == 4 * |tidy3d| (conjugate is no-op for real results)."""
+    def test_self_overlap_magnitude_equals_tidy3d(self):
+        """Self-overlap: |our| == |tidy3d| (both include 1/4; conjugate is no-op for real results)."""
         from tidy3d.components.mode.solver import _dot_numpy
 
         rng = np.random.default_rng(7)
@@ -420,6 +418,6 @@ class TestBidirectionalModeOverlapVsTidy3d:
             conjugate=True,
         )
 
-        assert np.isclose(abs(float(np.real(our))), 4.0 * abs(float(np.real(tidy3d_result))), rtol=1e-5), (
-            f"|our|={abs(float(np.real(our))):.6g}, 4*|tidy3d|={4.0*abs(float(np.real(tidy3d_result))):.6g}"
+        assert np.isclose(abs(float(np.real(our))), abs(float(np.real(tidy3d_result))), rtol=1e-5), (
+            f"|our|={abs(float(np.real(our))):.6g}, |tidy3d|={abs(float(np.real(tidy3d_result))):.6g}"
         )

--- a/tests/unit/core/physics/test_metrics.py
+++ b/tests/unit/core/physics/test_metrics.py
@@ -385,9 +385,7 @@ class TestBidirectionalModeOverlapVsTidy3d:
         )
 
         expected = complex(tidy3d_result)
-        assert np.isclose(complex(our), expected, rtol=1e-4), (
-            f"our={complex(our):.6g}, expected tidy3d={expected:.6g}"
-        )
+        assert np.isclose(complex(our), expected, rtol=1e-4), f"our={complex(our):.6g}, expected tidy3d={expected:.6g}"
 
     def test_self_overlap_magnitude_equals_tidy3d(self):
         """Self-overlap: |our| == |tidy3d| (both include 1/4; conjugate is no-op for real results)."""

--- a/tests/unit/core/physics/test_modes.py
+++ b/tests/unit/core/physics/test_modes.py
@@ -913,12 +913,8 @@ class TestComputeModeTargetNeff:
         mock_wrapper.side_effect = [modes_freq0, modes_freq1, modes_freq1]
 
         _, _, neff0 = compute_mode(frequency=2e14, target_neff=None, mode_index=0, **base_args)
-        _, _, neff1_tracked = compute_mode(
-            frequency=3e14, target_neff=float(np.real(neff0)), **base_args
-        )
-        _, _, neff1_untracked = compute_mode(
-            frequency=3e14, target_neff=None, mode_index=0, **base_args
-        )
+        _, _, neff1_tracked = compute_mode(frequency=3e14, target_neff=float(np.real(neff0)), **base_args)
+        _, _, neff1_untracked = compute_mode(frequency=3e14, target_neff=None, mode_index=0, **base_args)
 
         assert float(np.real(neff0)) == pytest.approx(2.5, abs=0.01)
         assert float(np.real(neff1_tracked)) == pytest.approx(2.4, abs=0.01), (
@@ -970,17 +966,13 @@ class TestComputeModeTargetNeff:
             _, _, neff = compute_mode(frequency=freq, target_neff=None, mode_index=0, **base_args)
             untracked_neffs.append(float(np.real(neff)))
 
-        expected_tracked   = [3.0, 2.9, 2.8, 2.7]
+        expected_tracked = [3.0, 2.9, 2.8, 2.7]
         expected_untracked = [3.0, 3.5, 3.6, 3.7]
 
         for i, (got, exp) in enumerate(zip(tracked_neffs, expected_tracked)):
-            assert got == pytest.approx(exp, abs=0.01), (
-                f"Tracked freq {i}: expected neff≈{exp}, got {got:.3f}"
-            )
+            assert got == pytest.approx(exp, abs=0.01), f"Tracked freq {i}: expected neff≈{exp}, got {got:.3f}"
         for i, (got, exp) in enumerate(zip(untracked_neffs, expected_untracked)):
-            assert got == pytest.approx(exp, abs=0.01), (
-                f"Untracked freq {i}: expected neff≈{exp}, got {got:.3f}"
-            )
+            assert got == pytest.approx(exp, abs=0.01), f"Untracked freq {i}: expected neff≈{exp}, got {got:.3f}"
 
     @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
     @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
@@ -1030,14 +1022,10 @@ class TestComputeModeTargetNeff:
             _, _, neff = compute_mode(frequency=freq, target_neff=None, mode_index=0, **base_args)
             untracked_neffs.append(float(np.real(neff)))
 
-        expected_tracked   = [3.00, 2.85, 2.70, 2.55, 2.40, 2.25]
+        expected_tracked = [3.00, 2.85, 2.70, 2.55, 2.40, 2.25]
         expected_untracked = [3.00, 3.20, 3.50, 3.00, 2.40, 3.50]
 
         for i, (got, exp) in enumerate(zip(tracked_neffs, expected_tracked)):
-            assert got == pytest.approx(exp, abs=0.01), (
-                f"Tracked freq {i}: expected neff≈{exp}, got {got:.3f}"
-            )
+            assert got == pytest.approx(exp, abs=0.01), f"Tracked freq {i}: expected neff≈{exp}, got {got:.3f}"
         for i, (got, exp) in enumerate(zip(untracked_neffs, expected_untracked)):
-            assert got == pytest.approx(exp, abs=0.01), (
-                f"Untracked freq {i}: expected neff≈{exp}, got {got:.3f}"
-            )
+            assert got == pytest.approx(exp, abs=0.01), f"Untracked freq {i}: expected neff≈{exp}, got {got:.3f}"

--- a/tests/unit/core/physics/test_modes.py
+++ b/tests/unit/core/physics/test_modes.py
@@ -8,7 +8,6 @@ from fdtdx.core.physics.modes import (
     ModeTupleType,
     compute_mode,
     compute_mode_polarization_fraction,
-    compute_modes_multi_freq,
     sort_modes,
     tidy3d_mode_computation_wrapper,
 )
@@ -782,260 +781,101 @@ class TestComputeModeBendPassthrough:
         assert kwargs["plane_center"] == pytest.approx(expected)
 
 
-class TestComputeModesMultiFreq:
-    """Tests for compute_modes_multi_freq — multi-frequency mode solving with continuity tracking."""
+class TestComputeModeTargetNeff:
+    """Tests for the target_neff parameter in compute_mode."""
 
-    def _make_mock_mode(self, neff=1.5, shape=(5, 6)):
+    def _make_mock_mode(self, neff, shape=(5, 6)):
         return ModeTupleType(
-            neff=neff + 0.01j,
-            Ex=np.ones(shape, dtype=np.complex64),
-            Ey=np.ones(shape, dtype=np.complex64),
-            Ez=np.ones(shape, dtype=np.complex64),
-            Hx=np.ones(shape, dtype=np.complex64),
-            Hy=np.ones(shape, dtype=np.complex64),
-            Hz=np.ones(shape, dtype=np.complex64),
+            neff=float(neff),
+            Ex=np.ones(shape, dtype=np.complex64) * float(neff),
+            Ey=np.zeros(shape, dtype=np.complex64),
+            Ez=np.zeros(shape, dtype=np.complex64),
+            Hx=np.zeros(shape, dtype=np.complex64),
+            Hy=np.ones(shape, dtype=np.complex64) * float(neff),
+            Hz=np.zeros(shape, dtype=np.complex64),
         )
-
-    def test_empty_frequencies_raises(self):
-        """An empty frequencies list raises ValueError before any computation."""
-        inv_permittivities = jnp.ones((1, 5, 6, 1))
-        with pytest.raises(ValueError, match="non-empty"):
-            compute_modes_multi_freq([], inv_permittivities, 1.0, resolution=1e-8)
-
-    def test_invalid_permittivities_shape_raises(self):
-        """Invalid inv_permittivities shape raises the same exception as compute_mode."""
-        inv_permittivities = jnp.ones((3, 2, 2, 2))
-        with pytest.raises(Exception, match="Invalid shape of inv_permittivities"):
-            compute_modes_multi_freq([2e14], inv_permittivities, 1.0, resolution=1e-8)
-
-    def test_invalid_permeabilities_shape_raises(self):
-        """Invalid inv_permeabilities shape raises the same exception as compute_mode."""
-        inv_permittivities = jnp.ones((3, 1, 5, 5))
-        inv_permeabilities = jnp.ones((3, 2, 2, 2))
-        with pytest.raises(Exception, match="Invalid shape of inv_permeabilities"):
-            compute_modes_multi_freq([2e14], inv_permittivities, inv_permeabilities, resolution=1e-8)
-
-    def test_only_bend_radius_raises(self):
-        """Setting bend_radius without bend_axis raises ValueError."""
-        inv_permittivities = jnp.ones((1, 5, 6, 1))
-        with pytest.raises(ValueError, match="both be set or both be None"):
-            compute_modes_multi_freq([2e14], inv_permittivities, 1.0, resolution=1e-8, bend_radius=5e-6)
 
     @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
     @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_single_frequency_returns_correct_shapes(self, mock_normalize, mock_wrapper):
-        """A single-element frequencies list returns shapes (1, 3, *spatial)."""
-        mock_wrapper.return_value = [self._make_mock_mode()]
-        mock_normalize.return_value = (
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-        )
+    def test_target_neff_selects_closest_mode(self, mock_normalize, mock_wrapper):
+        """target_neff picks mode closest in real(neff), overriding mode_index ordering.
 
-        mode_Es, mode_Hs, mode_neffs = compute_modes_multi_freq(
-            frequencies=[2e14],
-            inv_permittivities=jnp.ones((1, 5, 6, 1)),
-            inv_permeabilities=1.0,
-            resolution=1e-8,
-        )
-
-        assert mode_Es.shape == (1, 3, 5, 6, 1)
-        assert mode_Hs.shape == (1, 3, 5, 6, 1)
-        assert mode_neffs.shape == (1,)
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_two_frequencies_wrapper_called_twice(self, mock_normalize, mock_wrapper):
-        """With two frequencies, tidy3d_mode_computation_wrapper is called once per frequency."""
-        mock_wrapper.side_effect = [
-            [self._make_mock_mode(neff=1.5)],
-            [self._make_mock_mode(neff=1.48)],
-        ]
-        mock_normalize.return_value = (
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-        )
-
-        compute_modes_multi_freq(
-            frequencies=[2e14, 1.9e14],
-            inv_permittivities=jnp.ones((1, 5, 6, 1)),
-            inv_permeabilities=1.0,
-            resolution=1e-8,
-        )
-
-        assert mock_wrapper.call_count == 2
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_tracking_follows_neff_proximity(self, mock_normalize, mock_wrapper):
-        """At freq-1 the mode closest in neff to the freq-0 anchor is selected.
-
-        Setup: anchor at freq-0 has neff=3.0 (highest, mode_index=0).
-        At freq-1 two candidates: neff=2.8 and neff=2.0.
-        Proximity to 3.0: |3.0-2.8|=0.2 < |3.0-2.0|=1.0, so 2.8 should be tracked.
+        Three modes sorted highest-to-lowest: [3.0, 2.0, 1.0].
+        target_neff=1.9 is closest to 2.0 (|1.9-2.0|=0.1 vs |1.9-3.0|=1.1).
+        mode_index=0 would have returned the 3.0 mode; target_neff overrides this.
         """
-
-        def _make_mode_neff(neff, shape=(5, 6)):
-            return ModeTupleType(
-                neff=float(neff),
-                Ex=np.ones(shape, dtype=np.complex64) * float(neff),
-                Ey=np.zeros(shape, dtype=np.complex64),
-                Ez=np.zeros(shape, dtype=np.complex64),
-                Hx=np.zeros(shape, dtype=np.complex64),
-                Hy=np.ones(shape, dtype=np.complex64) * float(neff),
-                Hz=np.zeros(shape, dtype=np.complex64),
-            )
-
-        # freq-0: three candidates sorted by neff; mode_index=0 picks neff=3.0
-        # freq-1: two candidates; proximity to 3.0 picks 2.8 over 2.0
-        mock_wrapper.side_effect = [
-            [_make_mode_neff(3.0), _make_mode_neff(2.0), _make_mode_neff(1.0)],
-            [_make_mode_neff(2.0), _make_mode_neff(2.8)],
+        mock_wrapper.return_value = [
+            self._make_mock_mode(3.0),
+            self._make_mock_mode(2.0),
+            self._make_mock_mode(1.0),
         ]
         mock_normalize.return_value = (
             jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
             jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
         )
 
-        _, _, mode_neffs = compute_modes_multi_freq(
-            frequencies=[2e14, 1.9e14],
+        _, _, neff = compute_mode(
+            frequency=2e14,
+            inv_permittivities=jnp.ones((1, 5, 6, 1)),
+            inv_permeabilities=1.0,
+            resolution=1e-8,
+            target_neff=1.9,
+        )
+
+        assert abs(float(np.real(neff)) - 2.0) < 0.01, (
+            f"Expected neff≈2.0 with target_neff=1.9, got {float(np.real(neff)):.3f}"
+        )
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_target_neff_none_uses_mode_index(self, mock_normalize, mock_wrapper):
+        """When target_neff is None, mode_index selects from the sorted list (default behaviour).
+
+        Three modes sorted highest-to-lowest: [3.0, 2.0, 1.0].
+        mode_index=0 picks the highest-neff mode (3.0).
+        """
+        mock_wrapper.return_value = [
+            self._make_mock_mode(3.0),
+            self._make_mock_mode(2.0),
+            self._make_mock_mode(1.0),
+        ]
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+
+        _, _, neff = compute_mode(
+            frequency=2e14,
             inv_permittivities=jnp.ones((1, 5, 6, 1)),
             inv_permeabilities=1.0,
             resolution=1e-8,
             mode_index=0,
-            filter_pol=None,
+            target_neff=None,
         )
 
-        # neff at freq-1 should be 2.8, not 2.0
-        assert abs(float(np.real(mode_neffs[1])) - 2.8) < 0.01, (
-            f"Expected tracked neff≈2.8 at freq-1, got {float(np.real(mode_neffs[1])):.3f}"
+        assert abs(float(np.real(neff)) - 3.0) < 0.01, (
+            f"Expected neff≈3.0 with mode_index=0 (no target_neff), got {float(np.real(neff)):.3f}"
         )
-
-    def test_resolution_required_without_transverse_coords(self):
-        """ValueError when neither resolution nor transverse_coords is provided."""
-        inv_permittivities = jnp.ones((1, 5, 6, 1))
-        with pytest.raises(ValueError, match="resolution is required"):
-            compute_modes_multi_freq([2e14], inv_permittivities, 1.0)
-
-    def test_transverse_coords_wrong_length_raises(self):
-        """ValueError when transverse_coords has != 2 arrays."""
-        inv_permittivities = jnp.ones((1, 5, 6, 1))
-        bad_coords = [np.linspace(0, 5e-6, 6), np.linspace(0, 6e-6, 7), np.linspace(0, 1e-6, 2)]
-        with pytest.raises(ValueError, match="exactly two coordinate arrays"):
-            compute_modes_multi_freq([2e14], inv_permittivities, 1.0, transverse_coords=bad_coords)
-
-    def test_transverse_coords_wrong_shape_raises(self):
-        """ValueError when a transverse_coords array has the wrong length."""
-        inv_permittivities = jnp.ones((1, 5, 6, 1))
-        bad_coords = [np.linspace(0, 5e-6, 4), np.linspace(0, 6e-6, 7)]  # x should have 6 edges
-        with pytest.raises(ValueError, match="must be 1D with length"):
-            compute_modes_multi_freq([2e14], inv_permittivities, 1.0, transverse_coords=bad_coords)
-
-    def test_transverse_coords_non_increasing_raises(self):
-        """ValueError when a transverse_coords array is not strictly increasing."""
-        inv_permittivities = jnp.ones((1, 5, 6, 1))
-        bad_coords = [np.array([0.0, 2e-6, 1e-6, 3e-6, 4e-6, 5e-6]), np.linspace(0, 6e-6, 7)]
-        with pytest.raises(ValueError, match="strictly increasing"):
-            compute_modes_multi_freq([2e14], inv_permittivities, 1.0, transverse_coords=bad_coords)
 
     @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
     @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_transverse_coords_path(self, mock_normalize, mock_wrapper):
-        """Non-uniform transverse_coords are accepted and passed to the tidy3d wrapper."""
-        mock_wrapper.return_value = [self._make_mock_mode()]
-        mock_normalize.return_value = (
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-        )
-        x_edges = np.array([0.0, 1e-6, 3e-6, 6e-6, 10e-6, 15e-6])  # non-uniform, 6 edges for 5 cells
-        y_edges = np.linspace(0, 6e-6, 7)  # 7 edges for 6 cells
-        inv_permittivities = jnp.ones((1, 5, 6, 1))
-
-        mode_Es, _, _ = compute_modes_multi_freq([2e14], inv_permittivities, 1.0, transverse_coords=[x_edges, y_edges])
-
-        assert mode_Es.shape == (1, 3, 5, 6, 1)
-        assert mock_wrapper.called
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_propagation_axis_0(self, mock_normalize, mock_wrapper):
-        """Propagation along x (axis 0) — singleton on dim 1."""
-        mock_wrapper.return_value = [self._make_mock_mode(shape=(6, 7))]
-        mock_normalize.return_value = (
-            jnp.ones((3, 1, 6, 7), dtype=jnp.complex64),
-            jnp.ones((3, 1, 6, 7), dtype=jnp.complex64),
-        )
-        inv_permittivities = jnp.ones((1, 1, 6, 7))  # propagation_axis = 0
-
-        mode_Es, _, _ = compute_modes_multi_freq([2e14], inv_permittivities, 1.0, resolution=1e-8)
-
-        assert mode_Es.shape == (1, 3, 1, 6, 7)
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_propagation_axis_1(self, mock_normalize, mock_wrapper):
-        """Propagation along y (axis 1) — singleton on dim 2."""
-        mock_wrapper.return_value = [self._make_mock_mode(shape=(5, 7))]
-        mock_normalize.return_value = (
-            jnp.ones((3, 5, 1, 7), dtype=jnp.complex64),
-            jnp.ones((3, 5, 1, 7), dtype=jnp.complex64),
-        )
-        inv_permittivities = jnp.ones((1, 5, 1, 7))  # propagation_axis = 1
-
-        mode_Es, _, _ = compute_modes_multi_freq([2e14], inv_permittivities, 1.0, resolution=1e-8)
-
-        assert mode_Es.shape == (1, 3, 5, 1, 7)
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_3component_permittivity(self, mock_normalize, mock_wrapper):
-        """3-component (diagonal anisotropic) permittivity is permuted by propagation axis."""
-        mock_wrapper.return_value = [self._make_mock_mode()]
-        mock_normalize.return_value = (
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-        )
-        inv_permittivities = jnp.ones((3, 5, 6, 1))  # 3-component, propagation_axis = 2
-
-        mode_Es, _, _ = compute_modes_multi_freq([2e14], inv_permittivities, 1.0, resolution=1e-8)
-
-        assert mode_Es.shape == (1, 3, 5, 6, 1)
-        assert mock_wrapper.called
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_array_permeability(self, mock_normalize, mock_wrapper):
-        """Array (non-scalar) inv_permeabilities are accepted and sliced correctly."""
-        mock_wrapper.return_value = [self._make_mock_mode()]
-        mock_normalize.return_value = (
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-        )
-        inv_permittivities = jnp.ones((1, 5, 6, 1))
-        inv_permeabilities = jnp.ones((1, 5, 6, 1))  # array permeability
-
-        mode_Es, _, _ = compute_modes_multi_freq([2e14], inv_permittivities, inv_permeabilities, resolution=1e-8)
-
-        assert mode_Es.shape == (1, 3, 5, 6, 1)
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_bend_radius_passed_to_wrapper(self, mock_normalize, mock_wrapper):
-        """bend_radius and bend_axis are converted and forwarded to tidy3d wrapper."""
-        mock_wrapper.return_value = [self._make_mock_mode()]
+    def test_target_neff_passed_to_wrapper(self, mock_normalize, mock_wrapper):
+        """target_neff kwarg is forwarded to tidy3d_mode_computation_wrapper."""
+        mock_wrapper.return_value = [self._make_mock_mode(2.0)]
         mock_normalize.return_value = (
             jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
             jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
         )
 
-        compute_modes_multi_freq(
-            [2e14],
-            jnp.ones((1, 5, 6, 1)),
-            1.0,
+        compute_mode(
+            frequency=2e14,
+            inv_permittivities=jnp.ones((1, 5, 6, 1)),
+            inv_permeabilities=1.0,
             resolution=1e-8,
-            bend_radius=5e-6,
-            bend_axis=0,
+            target_neff=2.5,
         )
 
         kwargs = mock_wrapper.call_args.kwargs
-        assert kwargs["bend_radius"] == pytest.approx(5.0)  # metres → µm
-        assert kwargs["bend_axis"] == 0  # propagation_axis=2 → transverse [0,1] → bend_axis=0
+        assert "target_neff" in kwargs or any("target_neff" in str(a) for a in mock_wrapper.call_args.args), (
+            "target_neff should be forwarded to tidy3d_mode_computation_wrapper"
+        )

--- a/tests/unit/core/physics/test_modes.py
+++ b/tests/unit/core/physics/test_modes.py
@@ -879,3 +879,165 @@ class TestComputeModeTargetNeff:
         assert "target_neff" in kwargs or any("target_neff" in str(a) for a in mock_wrapper.call_args.args), (
             "target_neff should be forwarded to tidy3d_mode_computation_wrapper"
         )
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_tracking_prevents_mode_hop_when_ordering_reverses(self, mock_normalize, mock_wrapper):
+        """Mode ordering reversal: tracking follows the same physical mode; untracked switches.
+
+        freq 0: [Mode_A(2.5), Mode_B(2.3)]  → mode_index=0 returns Mode_A (neff≈2.5)
+        freq 1: [Mode_B(2.7), Mode_A(2.4)]  → mode_index=0 would return Mode_B (WRONG)
+                                               target_neff=2.5 → returns Mode_A (CORRECT)
+
+        This is the load-bearing test for neff-proximity tracking: it fails if the
+        selection logic is removed or if target_neff is not forwarded correctly.
+        """
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+        modes_freq0 = [self._make_mock_mode(2.5), self._make_mock_mode(2.3)]
+        # At freq 1 the ordering reverses: Mode_B overtakes Mode_A in neff
+        modes_freq1 = [self._make_mock_mode(2.7), self._make_mock_mode(2.4)]
+
+        base_args = dict(
+            inv_permittivities=jnp.ones((1, 5, 6, 1)),
+            inv_permeabilities=1.0,
+            resolution=1e-8,
+        )
+
+        # Three calls consume from side_effect in order:
+        #   call 1 (no tracking)  → modes_freq0 → neff0 = 2.5
+        #   call 2 (tracking)     → modes_freq1 → picks 2.4 (|2.4-2.5| < |2.7-2.5|)
+        #   call 3 (no tracking)  → modes_freq1 → mode_index=0 picks 2.7 (wrong mode)
+        mock_wrapper.side_effect = [modes_freq0, modes_freq1, modes_freq1]
+
+        _, _, neff0 = compute_mode(frequency=2e14, target_neff=None, mode_index=0, **base_args)
+        _, _, neff1_tracked = compute_mode(
+            frequency=3e14, target_neff=float(np.real(neff0)), **base_args
+        )
+        _, _, neff1_untracked = compute_mode(
+            frequency=3e14, target_neff=None, mode_index=0, **base_args
+        )
+
+        assert float(np.real(neff0)) == pytest.approx(2.5, abs=0.01)
+        assert float(np.real(neff1_tracked)) == pytest.approx(2.4, abs=0.01), (
+            f"Tracking should follow Mode_A (neff≈2.4), got {float(np.real(neff1_tracked)):.3f}"
+        )
+        assert float(np.real(neff1_untracked)) == pytest.approx(2.7, abs=0.01), (
+            f"Without tracking, mode_index=0 picks Mode_B (neff≈2.7), got {float(np.real(neff1_untracked)):.3f}"
+        )
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_tracking_follows_mode_across_four_frequencies(self, mock_normalize, mock_wrapper):
+        """Tracking correctly follows Mode_A across 4 frequencies while mode_index=0 hops to Mode_B.
+
+        Mode_A decreases smoothly (normal dispersion).
+        Mode_B crosses above Mode_A at freq 1 and stays there — without tracking,
+        mode_index=0 switches to Mode_B at every subsequent frequency.
+
+        freq 0: [Mode_A(3.0), Mode_B(2.2)]  → seed: mode_index=0 → 3.0
+        freq 1: [Mode_B(3.5), Mode_A(2.9)]  → tracked: 2.9  untracked: 3.5
+        freq 2: [Mode_B(3.6), Mode_A(2.8)]  → tracked: 2.8  untracked: 3.6
+        freq 3: [Mode_B(3.7), Mode_A(2.7)]  → tracked: 2.7  untracked: 3.7
+        """
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+        modes_per_freq = [
+            [self._make_mock_mode(3.0), self._make_mock_mode(2.2)],
+            [self._make_mock_mode(3.5), self._make_mock_mode(2.9)],
+            [self._make_mock_mode(3.6), self._make_mock_mode(2.8)],
+            [self._make_mock_mode(3.7), self._make_mock_mode(2.7)],
+        ]
+        # tracked sweep (4 calls) then untracked sweep (4 calls)
+        mock_wrapper.side_effect = modes_per_freq + modes_per_freq
+
+        base_args = dict(inv_permittivities=jnp.ones((1, 5, 6, 1)), inv_permeabilities=1.0, resolution=1e-8)
+        frequencies = [1e14, 2e14, 3e14, 4e14]
+
+        tracked_neffs = []
+        prev_neff = None
+        for freq in frequencies:
+            _, _, neff = compute_mode(frequency=freq, target_neff=prev_neff, mode_index=0, **base_args)
+            prev_neff = float(np.real(neff))
+            tracked_neffs.append(prev_neff)
+
+        untracked_neffs = []
+        for freq in frequencies:
+            _, _, neff = compute_mode(frequency=freq, target_neff=None, mode_index=0, **base_args)
+            untracked_neffs.append(float(np.real(neff)))
+
+        expected_tracked   = [3.0, 2.9, 2.8, 2.7]
+        expected_untracked = [3.0, 3.5, 3.6, 3.7]
+
+        for i, (got, exp) in enumerate(zip(tracked_neffs, expected_tracked)):
+            assert got == pytest.approx(exp, abs=0.01), (
+                f"Tracked freq {i}: expected neff≈{exp}, got {got:.3f}"
+            )
+        for i, (got, exp) in enumerate(zip(untracked_neffs, expected_untracked)):
+            assert got == pytest.approx(exp, abs=0.01), (
+                f"Untracked freq {i}: expected neff≈{exp}, got {got:.3f}"
+            )
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_tracking_three_modes_multiple_crossings(self, mock_normalize, mock_wrapper):
+        """Tracking follows Mode_A across 6 frequencies with 3 modes and repeated order reversals.
+
+        Mode_A decreases smoothly.  Mode_B crosses above A at freqs 1, 3, 5.
+        Mode_C spikes above both at freq 2.  At freq 4, A is still highest so
+        untracked accidentally picks A — shows tracking isn't always needed but
+        is critical wherever the ordering flips.
+
+        freq  solver order (highest → lowest)   tracked   untracked
+          0   A(3.00) B(2.50) C(1.50)           3.00      3.00
+          1   B(3.20) A(2.85) C(1.50)           2.85      3.20  ← B overtakes
+          2   C(3.50) A(2.70) B(2.40)           2.70      3.50  ← C spikes
+          3   B(3.00) A(2.55) C(1.50)           2.55      3.00  ← B again
+          4   A(2.40) B(2.30) C(1.50)           2.40      2.40  ← A still highest
+          5   B(3.50) A(2.25) C(1.50)           2.25      3.50  ← B again
+        """
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+        modes_per_freq = [
+            [self._make_mock_mode(3.00), self._make_mock_mode(2.50), self._make_mock_mode(1.50)],
+            [self._make_mock_mode(3.20), self._make_mock_mode(2.85), self._make_mock_mode(1.50)],
+            [self._make_mock_mode(3.50), self._make_mock_mode(2.70), self._make_mock_mode(2.40)],
+            [self._make_mock_mode(3.00), self._make_mock_mode(2.55), self._make_mock_mode(1.50)],
+            [self._make_mock_mode(2.40), self._make_mock_mode(2.30), self._make_mock_mode(1.50)],
+            [self._make_mock_mode(3.50), self._make_mock_mode(2.25), self._make_mock_mode(1.50)],
+        ]
+        # tracked sweep (6 calls) + untracked sweep (6 calls)
+        mock_wrapper.side_effect = modes_per_freq + modes_per_freq
+
+        base_args = dict(inv_permittivities=jnp.ones((1, 5, 6, 1)), inv_permeabilities=1.0, resolution=1e-8)
+        frequencies = [1e14, 2e14, 3e14, 4e14, 5e14, 6e14]
+
+        tracked_neffs = []
+        prev_neff = None
+        for freq in frequencies:
+            _, _, neff = compute_mode(frequency=freq, target_neff=prev_neff, mode_index=0, **base_args)
+            prev_neff = float(np.real(neff))
+            tracked_neffs.append(prev_neff)
+
+        untracked_neffs = []
+        for freq in frequencies:
+            _, _, neff = compute_mode(frequency=freq, target_neff=None, mode_index=0, **base_args)
+            untracked_neffs.append(float(np.real(neff)))
+
+        expected_tracked   = [3.00, 2.85, 2.70, 2.55, 2.40, 2.25]
+        expected_untracked = [3.00, 3.20, 3.50, 3.00, 2.40, 3.50]
+
+        for i, (got, exp) in enumerate(zip(tracked_neffs, expected_tracked)):
+            assert got == pytest.approx(exp, abs=0.01), (
+                f"Tracked freq {i}: expected neff≈{exp}, got {got:.3f}"
+            )
+        for i, (got, exp) in enumerate(zip(untracked_neffs, expected_untracked)):
+            assert got == pytest.approx(exp, abs=0.01), (
+                f"Untracked freq {i}: expected neff≈{exp}, got {got:.3f}"
+            )

--- a/tests/unit/core/physics/test_modes.py
+++ b/tests/unit/core/physics/test_modes.py
@@ -6,7 +6,7 @@ import pytest
 
 from fdtdx.core.physics.modes import (
     ModeTupleType,
-    compute_mode_one_frequency,
+    compute_mode,
     compute_mode_polarization_fraction,
     sort_modes,
     tidy3d_mode_computation_wrapper,
@@ -135,50 +135,50 @@ class TestSortModes:
         # The other modes should follow
 
 
-class TestComputeModeOneFrequency:
-    """Test the compute_mode_one_frequency function."""
+class TestComputeMode:
+    """Test the compute_mode function."""
 
     def test_only_bend_radius_raises(self):
         """Setting bend_radius without bend_axis raises ValueError."""
-        inv_permittivities = jnp.ones((1, 5, 6, 1))
+        inv_permittivities = jnp.ones((1, 1, 5, 6, 1))
         with pytest.raises(ValueError, match="both be set or both be None"):
-            compute_mode_one_frequency(2e14, inv_permittivities, 1.0, 1e-8, "+", bend_radius=5e-6)
+            compute_mode([2e14], inv_permittivities, 1.0, 1e-8, "+", bend_radius=5e-6)
 
     def test_only_bend_axis_raises(self):
         """Setting bend_axis without bend_radius raises ValueError."""
-        inv_permittivities = jnp.ones((1, 5, 6, 1))
+        inv_permittivities = jnp.ones((1, 1, 5, 6, 1))
         with pytest.raises(ValueError, match="both be set or both be None"):
-            compute_mode_one_frequency(2e14, inv_permittivities, 1.0, 1e-8, "+", bend_axis=1)
+            compute_mode([2e14], inv_permittivities, 1.0, 1e-8, "+", bend_axis=1)
 
     def test_invalid_permittivities_shape(self):
         """Test that invalid permittivities shape raises exception."""
         frequency = 2e14
-        # 3D array but not squeezable to 2D
-        inv_permittivities = jnp.ones((3, 2, 2, 2))
+        # slice [0] has shape (3, 2, 2, 2) — no singleton spatial dim
+        inv_permittivities = jnp.ones((1, 3, 2, 2, 2))
         inv_permeabilities = 1.0
         resolution = 1e-8
 
         with pytest.raises(Exception, match="Invalid inv_permittivities shape"):
-            compute_mode_one_frequency(frequency, inv_permittivities, inv_permeabilities, resolution, "+")
+            compute_mode([frequency], inv_permittivities, inv_permeabilities, resolution, "+")
 
     def test_invalid_permeabilities_shape(self):
         """Test that invalid permeabilities shape raises exception."""
         frequency = 2e14
-        inv_permittivities = jnp.ones((3, 1, 5, 5))
+        inv_permittivities = jnp.ones((1, 3, 1, 5, 5))
         # Invalid: 4D array with no singleton spatial dim
         inv_permeabilities = jnp.ones((3, 2, 2, 2))
         resolution = 1e-8
 
         with pytest.raises(Exception, match="Invalid inv_permeabilities shape"):
-            compute_mode_one_frequency(frequency, inv_permittivities, inv_permeabilities, resolution, "+")
+            compute_mode([frequency], inv_permittivities, inv_permeabilities, resolution, "+")
 
     def test_invalid_transverse_coords_shape(self):
         """Transverse coordinate arrays must match the mode cross-section shape."""
-        inv_permittivities = jnp.ones((1, 2, 2, 1))
+        inv_permittivities = jnp.ones((1, 1, 2, 2, 1))
 
         with pytest.raises(ValueError, match="length 3"):
-            compute_mode_one_frequency(
-                frequency=2e14,
+            compute_mode(
+                frequencies=[2e14],
                 inv_permittivities=inv_permittivities,
                 inv_permeabilities=1.0,
                 resolution=1e-8,
@@ -205,9 +205,9 @@ class TestComputeModeOneFrequency:
             jnp.ones((3, 2, 2, 1), dtype=jnp.complex64),
         )
 
-        compute_mode_one_frequency(
-            frequency=2e14,
-            inv_permittivities=jnp.ones((1, 2, 2, 1)),
+        compute_mode(
+            frequencies=[2e14],
+            inv_permittivities=jnp.ones((1, 1, 2, 2, 1)),
             inv_permeabilities=1.0,
             resolution=1e-8,
             direction="+",
@@ -262,9 +262,9 @@ class TestAnisotropicModeComputation:
         inv_permittivities = inv_permittivities.at[1].set(1 / 3.0)  # eps_y = 3
         inv_permittivities = inv_permittivities.at[2].set(1 / 4.0)  # eps_z = 4
 
-        compute_mode_one_frequency(
-            frequency=2e14,
-            inv_permittivities=inv_permittivities,
+        compute_mode(
+            frequencies=[2e14],
+            inv_permittivities=jnp.expand_dims(inv_permittivities, 0),
             inv_permeabilities=1.0,
             resolution=1e-8,
             direction="+",
@@ -311,9 +311,9 @@ class TestAnisotropicModeComputation:
         inv_permittivities = inv_permittivities.at[1].set(1 / 3.0)  # eps_y = 3
         inv_permittivities = inv_permittivities.at[2].set(1 / 4.0)  # eps_z = 4
 
-        compute_mode_one_frequency(
-            frequency=2e14,
-            inv_permittivities=inv_permittivities,
+        compute_mode(
+            frequencies=[2e14],
+            inv_permittivities=jnp.expand_dims(inv_permittivities, 0),
             inv_permeabilities=1.0,
             resolution=1e-8,
             direction="+",
@@ -360,9 +360,9 @@ class TestAnisotropicModeComputation:
         inv_permittivities = inv_permittivities.at[1].set(1 / 3.0)  # eps_y = 3
         inv_permittivities = inv_permittivities.at[2].set(1 / 4.0)  # eps_z = 4
 
-        compute_mode_one_frequency(
-            frequency=2e14,
-            inv_permittivities=inv_permittivities,
+        compute_mode(
+            frequencies=[2e14],
+            inv_permittivities=jnp.expand_dims(inv_permittivities, 0),
             inv_permeabilities=1.0,
             resolution=1e-8,
             direction="+",
@@ -410,9 +410,9 @@ class TestAnisotropicModeComputation:
         inv_permeabilities = inv_permeabilities.at[1].set(1 / 1.2)  # mu_y = 1.2
         inv_permeabilities = inv_permeabilities.at[2].set(1 / 1.3)  # mu_z = 1.3
 
-        compute_mode_one_frequency(
-            frequency=2e14,
-            inv_permittivities=inv_permittivities,
+        compute_mode(
+            frequencies=[2e14],
+            inv_permittivities=jnp.expand_dims(inv_permittivities, 0),
             inv_permeabilities=inv_permeabilities,
             resolution=1e-8,
             direction="+",
@@ -452,9 +452,9 @@ class TestAnisotropicModeComputation:
         # Shape: (1, 1, 5, 6) - propagation along axis 0
         inv_permittivities = jnp.ones((1, 1, 5, 6)) * 0.25  # eps = 4.0
 
-        compute_mode_one_frequency(
-            frequency=2e14,
-            inv_permittivities=inv_permittivities,
+        compute_mode(
+            frequencies=[2e14],
+            inv_permittivities=jnp.expand_dims(inv_permittivities, 0),
             inv_permeabilities=1.0,
             resolution=1e-8,
             direction="+",
@@ -495,9 +495,9 @@ class TestAnisotropicModeComputation:
         inv_permittivities = inv_permittivities.at[4].set(1 / 3.0)  # inv_eps_yy
         inv_permittivities = inv_permittivities.at[8].set(1 / 4.0)  # inv_eps_zz
 
-        compute_mode_one_frequency(
-            frequency=2e14,
-            inv_permittivities=inv_permittivities,
+        compute_mode(
+            frequencies=[2e14],
+            inv_permittivities=jnp.expand_dims(inv_permittivities, 0),
             inv_permeabilities=1.0,
             resolution=1e-8,
             direction="+",
@@ -555,9 +555,9 @@ class TestAnisotropicModeComputation:
         inv_permeabilities = inv_permeabilities.at[4].set(1 / 1.2)  # inv_mu_yy
         inv_permeabilities = inv_permeabilities.at[8].set(1 / 1.3)  # inv_mu_zz
 
-        compute_mode_one_frequency(
-            frequency=2e14,
-            inv_permittivities=inv_permittivities,
+        compute_mode(
+            frequencies=[2e14],
+            inv_permittivities=jnp.expand_dims(inv_permittivities, 0),
             inv_permeabilities=inv_permeabilities,
             resolution=1e-8,
             direction="+",
@@ -706,7 +706,7 @@ class TestComputeModeBendPassthrough:
             jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
         )
 
-        compute_mode_one_frequency(2e14, jnp.ones((1, 5, 6, 1)), 1.0, 1e-8, "+")
+        compute_mode([2e14], jnp.ones((1, 1, 5, 6, 1)), 1.0, 1e-8, "+")
 
         kwargs = mock_wrapper.call_args.kwargs
         assert kwargs["bend_radius"] is None
@@ -716,22 +716,22 @@ class TestComputeModeBendPassthrough:
     @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
     @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
     def test_bend_radius_converted_meters_to_micrometers(self, mock_normalize, mock_wrapper):
-        """bend_radius is divided by 1e-6 before being passed to tidy3d (m → µm)."""
+        """bend_radius is divided by 1e-6 before being passed to tidy3d (m to um)."""
         mock_wrapper.return_value = [self._make_mock_mode()]
         mock_normalize.return_value = (
             jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
             jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
         )
 
-        compute_mode_one_frequency(2e14, jnp.ones((1, 5, 6, 1)), 1.0, 1e-8, "+", bend_radius=5e-6, bend_axis=0)
+        compute_mode([2e14], jnp.ones((1, 1, 5, 6, 1)), 1.0, 1e-8, "+", bend_radius=5e-6, bend_axis=0)
 
         kwargs = mock_wrapper.call_args.kwargs
-        assert kwargs["bend_radius"] == pytest.approx(5.0)  # 5e-6 m = 5.0 µm
+        assert kwargs["bend_radius"] == pytest.approx(5.0)  # 5e-6 m = 5.0 um
 
     @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
     @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
     def test_bend_axis_remapped_z_propagation(self, mock_normalize, mock_wrapper):
-        """For z-propagation, transverse axes are [0,1]: physical bend_axis=1 → tidy3d index 1."""
+        """For z-propagation, transverse axes are [0,1]: physical bend_axis=1 -> tidy3d index 1."""
         mock_wrapper.return_value = [self._make_mock_mode()]
         mock_normalize.return_value = (
             jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
@@ -739,7 +739,7 @@ class TestComputeModeBendPassthrough:
         )
 
         # z-propagation: inv_permittivities shape (1, 5, 6, 1), singleton at dim 3
-        compute_mode_one_frequency(2e14, jnp.ones((1, 5, 6, 1)), 1.0, 1e-8, "+", bend_radius=10e-6, bend_axis=1)
+        compute_mode([2e14], jnp.ones((1, 1, 5, 6, 1)), 1.0, 1e-8, "+", bend_radius=10e-6, bend_axis=1)
 
         kwargs = mock_wrapper.call_args.kwargs
         assert kwargs["bend_axis"] == 1  # transverse_axes=[0,1], index(1)=1
@@ -747,7 +747,7 @@ class TestComputeModeBendPassthrough:
     @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
     @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
     def test_bend_axis_remapped_x_propagation(self, mock_normalize, mock_wrapper):
-        """For x-propagation, transverse axes are [1,2]: physical bend_axis=2 → tidy3d index 1."""
+        """For x-propagation, transverse axes are [1,2]: physical bend_axis=2 -> tidy3d index 1."""
         mock_wrapper.return_value = [self._make_mock_mode()]
         mock_normalize.return_value = (
             jnp.ones((3, 1, 5, 6), dtype=jnp.complex64),
@@ -755,7 +755,7 @@ class TestComputeModeBendPassthrough:
         )
 
         # x-propagation: inv_permittivities shape (1, 1, 5, 6), singleton at dim 1
-        compute_mode_one_frequency(2e14, jnp.ones((1, 1, 5, 6)), 1.0, 1e-8, "+", bend_radius=10e-6, bend_axis=2)
+        compute_mode([2e14], jnp.ones((1, 1, 1, 5, 6)), 1.0, 1e-8, "+", bend_radius=10e-6, bend_axis=2)
 
         kwargs = mock_wrapper.call_args.kwargs
         assert kwargs["bend_axis"] == 1  # transverse_axes=[1,2], index(2)=1
@@ -774,121 +774,8 @@ class TestComputeModeBendPassthrough:
         # z-propagation with transverse dims 5 (x) and 6 (y)
         # coords[0] = np.arange(6) * resolution/1e-6, so last = 5 * resolution/1e-6
         # coords[1] = np.arange(7) * resolution/1e-6, so last = 6 * resolution/1e-6
-        compute_mode_one_frequency(2e14, jnp.ones((1, 5, 6, 1)), 1.0, resolution, "+", bend_radius=5e-6, bend_axis=0)
+        compute_mode([2e14], jnp.ones((1, 1, 5, 6, 1)), 1.0, resolution, "+", bend_radius=5e-6, bend_axis=0)
 
         kwargs = mock_wrapper.call_args.kwargs
         expected = (0.5 * 5 * resolution / 1e-6, 0.5 * 6 * resolution / 1e-6)
         assert kwargs["plane_center"] == pytest.approx(expected)
-
-
-class TestComputeModeTargetNeff:
-    """Tests for the target_neff parameter in compute_mode_one_frequency."""
-
-    def _make_mock_mode(self, neff, shape=(5, 6)):
-        return ModeTupleType(
-            neff=float(neff),
-            Ex=np.ones(shape, dtype=np.complex64) * float(neff),
-            Ey=np.zeros(shape, dtype=np.complex64),
-            Ez=np.zeros(shape, dtype=np.complex64),
-            Hx=np.zeros(shape, dtype=np.complex64),
-            Hy=np.ones(shape, dtype=np.complex64) * float(neff),
-            Hz=np.zeros(shape, dtype=np.complex64),
-        )
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_target_neff_selects_closest_mode(self, mock_normalize, mock_wrapper):
-        """target_neff picks mode closest in real(neff), overriding mode_index ordering.
-
-        Three modes sorted highest-to-lowest: [3.0, 2.0, 1.0].
-        target_neff=1.9 is closest to 2.0 (|1.9-2.0|=0.1 vs |1.9-3.0|=1.1).
-        mode_index=0 would have returned the 3.0 mode; target_neff overrides this.
-        """
-        mock_wrapper.return_value = [
-            self._make_mock_mode(3.0),
-            self._make_mock_mode(2.0),
-            self._make_mock_mode(1.0),
-        ]
-        mock_normalize.return_value = (
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-        )
-
-        _, _, neff = compute_mode_one_frequency(
-            frequency=2e14,
-            inv_permittivities=jnp.ones((1, 5, 6, 1)),
-            inv_permeabilities=1.0,
-            resolution=1e-8,
-            target_neff=1.9,
-        )
-
-        assert abs(float(np.real(neff)) - 2.0) < 0.01, (
-            f"Expected neff≈2.0 with target_neff=1.9, got {float(np.real(neff)):.3f}"
-        )
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_target_neff_passed_to_wrapper(self, mock_normalize, mock_wrapper):
-        """target_neff kwarg is forwarded to tidy3d_mode_computation_wrapper."""
-        mock_wrapper.return_value = [self._make_mock_mode(2.0)]
-        mock_normalize.return_value = (
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-        )
-
-        compute_mode_one_frequency(
-            frequency=2e14,
-            inv_permittivities=jnp.ones((1, 5, 6, 1)),
-            inv_permeabilities=1.0,
-            resolution=1e-8,
-            target_neff=2.5,
-        )
-
-        kwargs = mock_wrapper.call_args.kwargs
-        assert "target_neff" in kwargs or any("target_neff" in str(a) for a in mock_wrapper.call_args.args), (
-            "target_neff should be forwarded to tidy3d_mode_computation_wrapper"
-        )
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_tracking_prevents_mode_hop_when_ordering_reverses(self, mock_normalize, mock_wrapper):
-        """Mode ordering reversal: tracking follows the same physical mode; untracked switches.
-
-        freq 0: [Mode_A(2.5), Mode_B(2.3)]  → mode_index=0 returns Mode_A (neff≈2.5)
-        freq 1: [Mode_B(2.7), Mode_A(2.4)]  → mode_index=0 would return Mode_B (WRONG)
-                                               target_neff=2.5 → returns Mode_A (CORRECT)
-
-        This is the load-bearing test for neff-proximity tracking: it fails if the
-        selection logic is removed or if target_neff is not forwarded correctly.
-        """
-        mock_normalize.return_value = (
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-        )
-        modes_freq0 = [self._make_mock_mode(2.5), self._make_mock_mode(2.3)]
-        # At freq 1 the ordering reverses: Mode_B overtakes Mode_A in neff
-        modes_freq1 = [self._make_mock_mode(2.7), self._make_mock_mode(2.4)]
-
-        base_args = dict(
-            inv_permittivities=jnp.ones((1, 5, 6, 1)),
-            inv_permeabilities=1.0,
-            resolution=1e-8,
-        )
-
-        # Three calls consume from side_effect in order:
-        #   call 1 (no tracking)  → modes_freq0 → neff0 = 2.5
-        #   call 2 (tracking)     → modes_freq1 → picks 2.4 (|2.4-2.5| < |2.7-2.5|)
-        #   call 3 (no tracking)  → modes_freq1 → mode_index=0 picks 2.7 (wrong mode)
-        mock_wrapper.side_effect = [modes_freq0, modes_freq1, modes_freq1]
-
-        _, _, neff0 = compute_mode_one_frequency(frequency=2e14, target_neff=None, mode_index=0, **base_args)
-        _, _, neff1_tracked = compute_mode_one_frequency(frequency=3e14, target_neff=float(np.real(neff0)), **base_args)
-        _, _, neff1_untracked = compute_mode_one_frequency(frequency=3e14, target_neff=None, mode_index=0, **base_args)
-
-        assert float(np.real(neff0)) == pytest.approx(2.5, abs=0.01)
-        assert float(np.real(neff1_tracked)) == pytest.approx(2.4, abs=0.01), (
-            f"Tracking should follow Mode_A (neff≈2.4), got {float(np.real(neff1_tracked)):.3f}"
-        )
-        assert float(np.real(neff1_untracked)) == pytest.approx(2.7, abs=0.01), (
-            f"Without tracking, mode_index=0 picks Mode_B (neff≈2.7), got {float(np.real(neff1_untracked)):.3f}"
-        )

--- a/tests/unit/core/physics/test_modes.py
+++ b/tests/unit/core/physics/test_modes.py
@@ -221,8 +221,13 @@ class TestComputeMode:
 
         normalize_kwargs = mock_normalize.call_args.kwargs
         assert normalize_kwargs["axis"] == 2
-        expected_area = jnp.asarray([[[2e-12], [3e-12]], [[4e-12], [6e-12]]], dtype=jnp.float32)
-        assert jnp.allclose(normalize_kwargs["area_weights"], expected_area)
+        # Yee-staggered areas: area_EuHv = primal_x x dual_y, area_EvHu = dual_x x primal_y
+        # primal_x = [1e-6, 2e-6], primal_y = [2e-6, 3e-6]
+        # dual_x   = [0.5e-6, 1.5e-6], dual_y = [1e-6, 2.5e-6]
+        expected_EuHv = jnp.asarray([[[1e-12], [2.5e-12]], [[2e-12], [5e-12]]], dtype=jnp.float32)
+        expected_EvHu = jnp.asarray([[[1e-12], [1.5e-12]], [[3e-12], [4.5e-12]]], dtype=jnp.float32)
+        assert jnp.allclose(normalize_kwargs["area_EuHv"], expected_EuHv)
+        assert jnp.allclose(normalize_kwargs["area_EvHu"], expected_EvHu)
 
 
 class TestAnisotropicModeComputation:

--- a/tests/unit/core/physics/test_modes.py
+++ b/tests/unit/core/physics/test_modes.py
@@ -8,6 +8,7 @@ from fdtdx.core.physics.modes import (
     ModeTupleType,
     compute_mode,
     compute_mode_polarization_fraction,
+    compute_modes_multi_freq,
     sort_modes,
     tidy3d_mode_computation_wrapper,
 )
@@ -774,3 +775,262 @@ class TestComputeModeBendPassthrough:
         kwargs = mock_wrapper.call_args.kwargs
         expected = (0.5 * 5 * resolution / 1e-6, 0.5 * 6 * resolution / 1e-6)
         assert kwargs["plane_center"] == pytest.approx(expected)
+
+
+class TestComputeModesMultiFreq:
+    """Tests for compute_modes_multi_freq — multi-frequency mode solving with continuity tracking."""
+
+    def _make_mock_mode(self, neff=1.5, shape=(5, 6)):
+        return ModeTupleType(
+            neff=neff + 0.01j,
+            Ex=np.ones(shape, dtype=np.complex64),
+            Ey=np.ones(shape, dtype=np.complex64),
+            Ez=np.ones(shape, dtype=np.complex64),
+            Hx=np.ones(shape, dtype=np.complex64),
+            Hy=np.ones(shape, dtype=np.complex64),
+            Hz=np.ones(shape, dtype=np.complex64),
+        )
+
+    def test_empty_frequencies_raises(self):
+        """An empty frequencies list raises ValueError before any computation."""
+        inv_permittivities = jnp.ones((1, 5, 6, 1))
+        with pytest.raises(ValueError, match="non-empty"):
+            compute_modes_multi_freq([], inv_permittivities, 1.0, resolution=1e-8)
+
+    def test_invalid_permittivities_shape_raises(self):
+        """Invalid inv_permittivities shape raises the same exception as compute_mode."""
+        inv_permittivities = jnp.ones((3, 2, 2, 2))
+        with pytest.raises(Exception, match="Invalid shape of inv_permittivities"):
+            compute_modes_multi_freq([2e14], inv_permittivities, 1.0, resolution=1e-8)
+
+    def test_invalid_permeabilities_shape_raises(self):
+        """Invalid inv_permeabilities shape raises the same exception as compute_mode."""
+        inv_permittivities = jnp.ones((3, 1, 5, 5))
+        inv_permeabilities = jnp.ones((3, 2, 2, 2))
+        with pytest.raises(Exception, match="Invalid shape of inv_permeabilities"):
+            compute_modes_multi_freq([2e14], inv_permittivities, inv_permeabilities, resolution=1e-8)
+
+    def test_only_bend_radius_raises(self):
+        """Setting bend_radius without bend_axis raises ValueError."""
+        inv_permittivities = jnp.ones((1, 5, 6, 1))
+        with pytest.raises(ValueError, match="both be set or both be None"):
+            compute_modes_multi_freq([2e14], inv_permittivities, 1.0, resolution=1e-8, bend_radius=5e-6)
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_single_frequency_returns_correct_shapes(self, mock_normalize, mock_wrapper):
+        """A single-element frequencies list returns shapes (1, 3, *spatial)."""
+        mock_wrapper.return_value = [self._make_mock_mode()]
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+
+        mode_Es, mode_Hs, mode_neffs = compute_modes_multi_freq(
+            frequencies=[2e14],
+            inv_permittivities=jnp.ones((1, 5, 6, 1)),
+            inv_permeabilities=1.0,
+            resolution=1e-8,
+        )
+
+        assert mode_Es.shape == (1, 3, 5, 6, 1)
+        assert mode_Hs.shape == (1, 3, 5, 6, 1)
+        assert mode_neffs.shape == (1,)
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_two_frequencies_wrapper_called_twice(self, mock_normalize, mock_wrapper):
+        """With two frequencies, tidy3d_mode_computation_wrapper is called once per frequency."""
+        mock_wrapper.side_effect = [
+            [self._make_mock_mode(neff=1.5)],
+            [self._make_mock_mode(neff=1.48)],
+        ]
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+
+        compute_modes_multi_freq(
+            frequencies=[2e14, 1.9e14],
+            inv_permittivities=jnp.ones((1, 5, 6, 1)),
+            inv_permeabilities=1.0,
+            resolution=1e-8,
+        )
+
+        assert mock_wrapper.call_count == 2
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_tracking_follows_neff_proximity(self, mock_normalize, mock_wrapper):
+        """At freq-1 the mode closest in neff to the freq-0 anchor is selected.
+
+        Setup: anchor at freq-0 has neff=3.0 (highest, mode_index=0).
+        At freq-1 two candidates: neff=2.8 and neff=2.0.
+        Proximity to 3.0: |3.0-2.8|=0.2 < |3.0-2.0|=1.0, so 2.8 should be tracked.
+        """
+
+        def _make_mode_neff(neff, shape=(5, 6)):
+            return ModeTupleType(
+                neff=float(neff),
+                Ex=np.ones(shape, dtype=np.complex64) * float(neff),
+                Ey=np.zeros(shape, dtype=np.complex64),
+                Ez=np.zeros(shape, dtype=np.complex64),
+                Hx=np.zeros(shape, dtype=np.complex64),
+                Hy=np.ones(shape, dtype=np.complex64) * float(neff),
+                Hz=np.zeros(shape, dtype=np.complex64),
+            )
+
+        # freq-0: three candidates sorted by neff; mode_index=0 picks neff=3.0
+        # freq-1: two candidates; proximity to 3.0 picks 2.8 over 2.0
+        mock_wrapper.side_effect = [
+            [_make_mode_neff(3.0), _make_mode_neff(2.0), _make_mode_neff(1.0)],
+            [_make_mode_neff(2.0), _make_mode_neff(2.8)],
+        ]
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+
+        _, _, mode_neffs = compute_modes_multi_freq(
+            frequencies=[2e14, 1.9e14],
+            inv_permittivities=jnp.ones((1, 5, 6, 1)),
+            inv_permeabilities=1.0,
+            resolution=1e-8,
+            mode_index=0,
+            filter_pol=None,
+        )
+
+        # neff at freq-1 should be 2.8, not 2.0
+        assert abs(float(np.real(mode_neffs[1])) - 2.8) < 0.01, (
+            f"Expected tracked neff≈2.8 at freq-1, got {float(np.real(mode_neffs[1])):.3f}"
+        )
+
+    def test_resolution_required_without_transverse_coords(self):
+        """ValueError when neither resolution nor transverse_coords is provided."""
+        inv_permittivities = jnp.ones((1, 5, 6, 1))
+        with pytest.raises(ValueError, match="resolution is required"):
+            compute_modes_multi_freq([2e14], inv_permittivities, 1.0)
+
+    def test_transverse_coords_wrong_length_raises(self):
+        """ValueError when transverse_coords has != 2 arrays."""
+        inv_permittivities = jnp.ones((1, 5, 6, 1))
+        bad_coords = [np.linspace(0, 5e-6, 6), np.linspace(0, 6e-6, 7), np.linspace(0, 1e-6, 2)]
+        with pytest.raises(ValueError, match="exactly two coordinate arrays"):
+            compute_modes_multi_freq([2e14], inv_permittivities, 1.0, transverse_coords=bad_coords)
+
+    def test_transverse_coords_wrong_shape_raises(self):
+        """ValueError when a transverse_coords array has the wrong length."""
+        inv_permittivities = jnp.ones((1, 5, 6, 1))
+        bad_coords = [np.linspace(0, 5e-6, 4), np.linspace(0, 6e-6, 7)]  # x should have 6 edges
+        with pytest.raises(ValueError, match="must be 1D with length"):
+            compute_modes_multi_freq([2e14], inv_permittivities, 1.0, transverse_coords=bad_coords)
+
+    def test_transverse_coords_non_increasing_raises(self):
+        """ValueError when a transverse_coords array is not strictly increasing."""
+        inv_permittivities = jnp.ones((1, 5, 6, 1))
+        bad_coords = [np.array([0.0, 2e-6, 1e-6, 3e-6, 4e-6, 5e-6]), np.linspace(0, 6e-6, 7)]
+        with pytest.raises(ValueError, match="strictly increasing"):
+            compute_modes_multi_freq([2e14], inv_permittivities, 1.0, transverse_coords=bad_coords)
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_transverse_coords_path(self, mock_normalize, mock_wrapper):
+        """Non-uniform transverse_coords are accepted and passed to the tidy3d wrapper."""
+        mock_wrapper.return_value = [self._make_mock_mode()]
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+        x_edges = np.array([0.0, 1e-6, 3e-6, 6e-6, 10e-6, 15e-6])  # non-uniform, 6 edges for 5 cells
+        y_edges = np.linspace(0, 6e-6, 7)  # 7 edges for 6 cells
+        inv_permittivities = jnp.ones((1, 5, 6, 1))
+
+        mode_Es, _, _ = compute_modes_multi_freq([2e14], inv_permittivities, 1.0, transverse_coords=[x_edges, y_edges])
+
+        assert mode_Es.shape == (1, 3, 5, 6, 1)
+        assert mock_wrapper.called
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_propagation_axis_0(self, mock_normalize, mock_wrapper):
+        """Propagation along x (axis 0) — singleton on dim 1."""
+        mock_wrapper.return_value = [self._make_mock_mode(shape=(6, 7))]
+        mock_normalize.return_value = (
+            jnp.ones((3, 1, 6, 7), dtype=jnp.complex64),
+            jnp.ones((3, 1, 6, 7), dtype=jnp.complex64),
+        )
+        inv_permittivities = jnp.ones((1, 1, 6, 7))  # propagation_axis = 0
+
+        mode_Es, _, _ = compute_modes_multi_freq([2e14], inv_permittivities, 1.0, resolution=1e-8)
+
+        assert mode_Es.shape == (1, 3, 1, 6, 7)
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_propagation_axis_1(self, mock_normalize, mock_wrapper):
+        """Propagation along y (axis 1) — singleton on dim 2."""
+        mock_wrapper.return_value = [self._make_mock_mode(shape=(5, 7))]
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 1, 7), dtype=jnp.complex64),
+            jnp.ones((3, 5, 1, 7), dtype=jnp.complex64),
+        )
+        inv_permittivities = jnp.ones((1, 5, 1, 7))  # propagation_axis = 1
+
+        mode_Es, _, _ = compute_modes_multi_freq([2e14], inv_permittivities, 1.0, resolution=1e-8)
+
+        assert mode_Es.shape == (1, 3, 5, 1, 7)
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_3component_permittivity(self, mock_normalize, mock_wrapper):
+        """3-component (diagonal anisotropic) permittivity is permuted by propagation axis."""
+        mock_wrapper.return_value = [self._make_mock_mode()]
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+        inv_permittivities = jnp.ones((3, 5, 6, 1))  # 3-component, propagation_axis = 2
+
+        mode_Es, _, _ = compute_modes_multi_freq([2e14], inv_permittivities, 1.0, resolution=1e-8)
+
+        assert mode_Es.shape == (1, 3, 5, 6, 1)
+        assert mock_wrapper.called
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_array_permeability(self, mock_normalize, mock_wrapper):
+        """Array (non-scalar) inv_permeabilities are accepted and sliced correctly."""
+        mock_wrapper.return_value = [self._make_mock_mode()]
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+        inv_permittivities = jnp.ones((1, 5, 6, 1))
+        inv_permeabilities = jnp.ones((1, 5, 6, 1))  # array permeability
+
+        mode_Es, _, _ = compute_modes_multi_freq([2e14], inv_permittivities, inv_permeabilities, resolution=1e-8)
+
+        assert mode_Es.shape == (1, 3, 5, 6, 1)
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_bend_radius_passed_to_wrapper(self, mock_normalize, mock_wrapper):
+        """bend_radius and bend_axis are converted and forwarded to tidy3d wrapper."""
+        mock_wrapper.return_value = [self._make_mock_mode()]
+        mock_normalize.return_value = (
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
+        )
+
+        compute_modes_multi_freq(
+            [2e14],
+            jnp.ones((1, 5, 6, 1)),
+            1.0,
+            resolution=1e-8,
+            bend_radius=5e-6,
+            bend_axis=0,
+        )
+
+        kwargs = mock_wrapper.call_args.kwargs
+        assert kwargs["bend_radius"] == pytest.approx(5.0)  # metres → µm
+        assert kwargs["bend_axis"] == 0  # propagation_axis=2 → transverse [0,1] → bend_axis=0

--- a/tests/unit/core/physics/test_modes.py
+++ b/tests/unit/core/physics/test_modes.py
@@ -6,7 +6,7 @@ import pytest
 
 from fdtdx.core.physics.modes import (
     ModeTupleType,
-    compute_mode,
+    compute_mode_one_frequency,
     compute_mode_polarization_fraction,
     sort_modes,
     tidy3d_mode_computation_wrapper,
@@ -135,20 +135,20 @@ class TestSortModes:
         # The other modes should follow
 
 
-class TestComputeMode:
-    """Test the compute_mode function."""
+class TestComputeModeOneFrequency:
+    """Test the compute_mode_one_frequency function."""
 
     def test_only_bend_radius_raises(self):
         """Setting bend_radius without bend_axis raises ValueError."""
         inv_permittivities = jnp.ones((1, 5, 6, 1))
         with pytest.raises(ValueError, match="both be set or both be None"):
-            compute_mode(2e14, inv_permittivities, 1.0, 1e-8, "+", bend_radius=5e-6)
+            compute_mode_one_frequency(2e14, inv_permittivities, 1.0, 1e-8, "+", bend_radius=5e-6)
 
     def test_only_bend_axis_raises(self):
         """Setting bend_axis without bend_radius raises ValueError."""
         inv_permittivities = jnp.ones((1, 5, 6, 1))
         with pytest.raises(ValueError, match="both be set or both be None"):
-            compute_mode(2e14, inv_permittivities, 1.0, 1e-8, "+", bend_axis=1)
+            compute_mode_one_frequency(2e14, inv_permittivities, 1.0, 1e-8, "+", bend_axis=1)
 
     def test_invalid_permittivities_shape(self):
         """Test that invalid permittivities shape raises exception."""
@@ -159,7 +159,7 @@ class TestComputeMode:
         resolution = 1e-8
 
         with pytest.raises(Exception, match="Invalid inv_permittivities shape"):
-            compute_mode(frequency, inv_permittivities, inv_permeabilities, resolution, "+")
+            compute_mode_one_frequency(frequency, inv_permittivities, inv_permeabilities, resolution, "+")
 
     def test_invalid_permeabilities_shape(self):
         """Test that invalid permeabilities shape raises exception."""
@@ -170,14 +170,14 @@ class TestComputeMode:
         resolution = 1e-8
 
         with pytest.raises(Exception, match="Invalid inv_permeabilities shape"):
-            compute_mode(frequency, inv_permittivities, inv_permeabilities, resolution, "+")
+            compute_mode_one_frequency(frequency, inv_permittivities, inv_permeabilities, resolution, "+")
 
     def test_invalid_transverse_coords_shape(self):
         """Transverse coordinate arrays must match the mode cross-section shape."""
         inv_permittivities = jnp.ones((1, 2, 2, 1))
 
         with pytest.raises(ValueError, match="length 3"):
-            compute_mode(
+            compute_mode_one_frequency(
                 frequency=2e14,
                 inv_permittivities=inv_permittivities,
                 inv_permeabilities=1.0,
@@ -205,7 +205,7 @@ class TestComputeMode:
             jnp.ones((3, 2, 2, 1), dtype=jnp.complex64),
         )
 
-        compute_mode(
+        compute_mode_one_frequency(
             frequency=2e14,
             inv_permittivities=jnp.ones((1, 2, 2, 1)),
             inv_permeabilities=1.0,
@@ -262,7 +262,7 @@ class TestAnisotropicModeComputation:
         inv_permittivities = inv_permittivities.at[1].set(1 / 3.0)  # eps_y = 3
         inv_permittivities = inv_permittivities.at[2].set(1 / 4.0)  # eps_z = 4
 
-        compute_mode(
+        compute_mode_one_frequency(
             frequency=2e14,
             inv_permittivities=inv_permittivities,
             inv_permeabilities=1.0,
@@ -311,7 +311,7 @@ class TestAnisotropicModeComputation:
         inv_permittivities = inv_permittivities.at[1].set(1 / 3.0)  # eps_y = 3
         inv_permittivities = inv_permittivities.at[2].set(1 / 4.0)  # eps_z = 4
 
-        compute_mode(
+        compute_mode_one_frequency(
             frequency=2e14,
             inv_permittivities=inv_permittivities,
             inv_permeabilities=1.0,
@@ -360,7 +360,7 @@ class TestAnisotropicModeComputation:
         inv_permittivities = inv_permittivities.at[1].set(1 / 3.0)  # eps_y = 3
         inv_permittivities = inv_permittivities.at[2].set(1 / 4.0)  # eps_z = 4
 
-        compute_mode(
+        compute_mode_one_frequency(
             frequency=2e14,
             inv_permittivities=inv_permittivities,
             inv_permeabilities=1.0,
@@ -410,7 +410,7 @@ class TestAnisotropicModeComputation:
         inv_permeabilities = inv_permeabilities.at[1].set(1 / 1.2)  # mu_y = 1.2
         inv_permeabilities = inv_permeabilities.at[2].set(1 / 1.3)  # mu_z = 1.3
 
-        compute_mode(
+        compute_mode_one_frequency(
             frequency=2e14,
             inv_permittivities=inv_permittivities,
             inv_permeabilities=inv_permeabilities,
@@ -452,7 +452,7 @@ class TestAnisotropicModeComputation:
         # Shape: (1, 1, 5, 6) - propagation along axis 0
         inv_permittivities = jnp.ones((1, 1, 5, 6)) * 0.25  # eps = 4.0
 
-        compute_mode(
+        compute_mode_one_frequency(
             frequency=2e14,
             inv_permittivities=inv_permittivities,
             inv_permeabilities=1.0,
@@ -495,7 +495,7 @@ class TestAnisotropicModeComputation:
         inv_permittivities = inv_permittivities.at[4].set(1 / 3.0)  # inv_eps_yy
         inv_permittivities = inv_permittivities.at[8].set(1 / 4.0)  # inv_eps_zz
 
-        compute_mode(
+        compute_mode_one_frequency(
             frequency=2e14,
             inv_permittivities=inv_permittivities,
             inv_permeabilities=1.0,
@@ -555,7 +555,7 @@ class TestAnisotropicModeComputation:
         inv_permeabilities = inv_permeabilities.at[4].set(1 / 1.2)  # inv_mu_yy
         inv_permeabilities = inv_permeabilities.at[8].set(1 / 1.3)  # inv_mu_zz
 
-        compute_mode(
+        compute_mode_one_frequency(
             frequency=2e14,
             inv_permittivities=inv_permittivities,
             inv_permeabilities=inv_permeabilities,
@@ -706,7 +706,7 @@ class TestComputeModeBendPassthrough:
             jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
         )
 
-        compute_mode(2e14, jnp.ones((1, 5, 6, 1)), 1.0, 1e-8, "+")
+        compute_mode_one_frequency(2e14, jnp.ones((1, 5, 6, 1)), 1.0, 1e-8, "+")
 
         kwargs = mock_wrapper.call_args.kwargs
         assert kwargs["bend_radius"] is None
@@ -723,7 +723,7 @@ class TestComputeModeBendPassthrough:
             jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
         )
 
-        compute_mode(2e14, jnp.ones((1, 5, 6, 1)), 1.0, 1e-8, "+", bend_radius=5e-6, bend_axis=0)
+        compute_mode_one_frequency(2e14, jnp.ones((1, 5, 6, 1)), 1.0, 1e-8, "+", bend_radius=5e-6, bend_axis=0)
 
         kwargs = mock_wrapper.call_args.kwargs
         assert kwargs["bend_radius"] == pytest.approx(5.0)  # 5e-6 m = 5.0 µm
@@ -739,7 +739,7 @@ class TestComputeModeBendPassthrough:
         )
 
         # z-propagation: inv_permittivities shape (1, 5, 6, 1), singleton at dim 3
-        compute_mode(2e14, jnp.ones((1, 5, 6, 1)), 1.0, 1e-8, "+", bend_radius=10e-6, bend_axis=1)
+        compute_mode_one_frequency(2e14, jnp.ones((1, 5, 6, 1)), 1.0, 1e-8, "+", bend_radius=10e-6, bend_axis=1)
 
         kwargs = mock_wrapper.call_args.kwargs
         assert kwargs["bend_axis"] == 1  # transverse_axes=[0,1], index(1)=1
@@ -755,7 +755,7 @@ class TestComputeModeBendPassthrough:
         )
 
         # x-propagation: inv_permittivities shape (1, 1, 5, 6), singleton at dim 1
-        compute_mode(2e14, jnp.ones((1, 1, 5, 6)), 1.0, 1e-8, "+", bend_radius=10e-6, bend_axis=2)
+        compute_mode_one_frequency(2e14, jnp.ones((1, 1, 5, 6)), 1.0, 1e-8, "+", bend_radius=10e-6, bend_axis=2)
 
         kwargs = mock_wrapper.call_args.kwargs
         assert kwargs["bend_axis"] == 1  # transverse_axes=[1,2], index(2)=1
@@ -774,7 +774,7 @@ class TestComputeModeBendPassthrough:
         # z-propagation with transverse dims 5 (x) and 6 (y)
         # coords[0] = np.arange(6) * resolution/1e-6, so last = 5 * resolution/1e-6
         # coords[1] = np.arange(7) * resolution/1e-6, so last = 6 * resolution/1e-6
-        compute_mode(2e14, jnp.ones((1, 5, 6, 1)), 1.0, resolution, "+", bend_radius=5e-6, bend_axis=0)
+        compute_mode_one_frequency(2e14, jnp.ones((1, 5, 6, 1)), 1.0, resolution, "+", bend_radius=5e-6, bend_axis=0)
 
         kwargs = mock_wrapper.call_args.kwargs
         expected = (0.5 * 5 * resolution / 1e-6, 0.5 * 6 * resolution / 1e-6)
@@ -782,7 +782,7 @@ class TestComputeModeBendPassthrough:
 
 
 class TestComputeModeTargetNeff:
-    """Tests for the target_neff parameter in compute_mode."""
+    """Tests for the target_neff parameter in compute_mode_one_frequency."""
 
     def _make_mock_mode(self, neff, shape=(5, 6)):
         return ModeTupleType(
@@ -814,7 +814,7 @@ class TestComputeModeTargetNeff:
             jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
         )
 
-        _, _, neff = compute_mode(
+        _, _, neff = compute_mode_one_frequency(
             frequency=2e14,
             inv_permittivities=jnp.ones((1, 5, 6, 1)),
             inv_permeabilities=1.0,
@@ -836,7 +836,7 @@ class TestComputeModeTargetNeff:
             jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
         )
 
-        compute_mode(
+        compute_mode_one_frequency(
             frequency=2e14,
             inv_permittivities=jnp.ones((1, 5, 6, 1)),
             inv_permeabilities=1.0,
@@ -881,9 +881,9 @@ class TestComputeModeTargetNeff:
         #   call 3 (no tracking)  → modes_freq1 → mode_index=0 picks 2.7 (wrong mode)
         mock_wrapper.side_effect = [modes_freq0, modes_freq1, modes_freq1]
 
-        _, _, neff0 = compute_mode(frequency=2e14, target_neff=None, mode_index=0, **base_args)
-        _, _, neff1_tracked = compute_mode(frequency=3e14, target_neff=float(np.real(neff0)), **base_args)
-        _, _, neff1_untracked = compute_mode(frequency=3e14, target_neff=None, mode_index=0, **base_args)
+        _, _, neff0 = compute_mode_one_frequency(frequency=2e14, target_neff=None, mode_index=0, **base_args)
+        _, _, neff1_tracked = compute_mode_one_frequency(frequency=3e14, target_neff=float(np.real(neff0)), **base_args)
+        _, _, neff1_untracked = compute_mode_one_frequency(frequency=3e14, target_neff=None, mode_index=0, **base_args)
 
         assert float(np.real(neff0)) == pytest.approx(2.5, abs=0.01)
         assert float(np.real(neff1_tracked)) == pytest.approx(2.4, abs=0.01), (

--- a/tests/unit/core/physics/test_modes.py
+++ b/tests/unit/core/physics/test_modes.py
@@ -158,7 +158,7 @@ class TestComputeMode:
         inv_permeabilities = 1.0
         resolution = 1e-8
 
-        with pytest.raises(Exception, match="Invalid shape of inv_permittivities"):
+        with pytest.raises(Exception, match="Invalid inv_permittivities shape"):
             compute_mode(frequency, inv_permittivities, inv_permeabilities, resolution, "+")
 
     def test_invalid_permeabilities_shape(self):
@@ -169,7 +169,7 @@ class TestComputeMode:
         inv_permeabilities = jnp.ones((3, 2, 2, 2))
         resolution = 1e-8
 
-        with pytest.raises(Exception, match="Invalid shape of inv_permeabilities"):
+        with pytest.raises(Exception, match="Invalid inv_permeabilities shape"):
             compute_mode(frequency, inv_permittivities, inv_permeabilities, resolution, "+")
 
     def test_invalid_transverse_coords_shape(self):
@@ -828,37 +828,6 @@ class TestComputeModeTargetNeff:
 
     @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
     @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_target_neff_none_uses_mode_index(self, mock_normalize, mock_wrapper):
-        """When target_neff is None, mode_index selects from the sorted list (default behaviour).
-
-        Three modes sorted highest-to-lowest: [3.0, 2.0, 1.0].
-        mode_index=0 picks the highest-neff mode (3.0).
-        """
-        mock_wrapper.return_value = [
-            self._make_mock_mode(3.0),
-            self._make_mock_mode(2.0),
-            self._make_mock_mode(1.0),
-        ]
-        mock_normalize.return_value = (
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-        )
-
-        _, _, neff = compute_mode(
-            frequency=2e14,
-            inv_permittivities=jnp.ones((1, 5, 6, 1)),
-            inv_permeabilities=1.0,
-            resolution=1e-8,
-            mode_index=0,
-            target_neff=None,
-        )
-
-        assert abs(float(np.real(neff)) - 3.0) < 0.01, (
-            f"Expected neff≈3.0 with mode_index=0 (no target_neff), got {float(np.real(neff)):.3f}"
-        )
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
     def test_target_neff_passed_to_wrapper(self, mock_normalize, mock_wrapper):
         """target_neff kwarg is forwarded to tidy3d_mode_computation_wrapper."""
         mock_wrapper.return_value = [self._make_mock_mode(2.0)]
@@ -923,109 +892,3 @@ class TestComputeModeTargetNeff:
         assert float(np.real(neff1_untracked)) == pytest.approx(2.7, abs=0.01), (
             f"Without tracking, mode_index=0 picks Mode_B (neff≈2.7), got {float(np.real(neff1_untracked)):.3f}"
         )
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_tracking_follows_mode_across_four_frequencies(self, mock_normalize, mock_wrapper):
-        """Tracking correctly follows Mode_A across 4 frequencies while mode_index=0 hops to Mode_B.
-
-        Mode_A decreases smoothly (normal dispersion).
-        Mode_B crosses above Mode_A at freq 1 and stays there — without tracking,
-        mode_index=0 switches to Mode_B at every subsequent frequency.
-
-        freq 0: [Mode_A(3.0), Mode_B(2.2)]  → seed: mode_index=0 → 3.0
-        freq 1: [Mode_B(3.5), Mode_A(2.9)]  → tracked: 2.9  untracked: 3.5
-        freq 2: [Mode_B(3.6), Mode_A(2.8)]  → tracked: 2.8  untracked: 3.6
-        freq 3: [Mode_B(3.7), Mode_A(2.7)]  → tracked: 2.7  untracked: 3.7
-        """
-        mock_normalize.return_value = (
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-        )
-        modes_per_freq = [
-            [self._make_mock_mode(3.0), self._make_mock_mode(2.2)],
-            [self._make_mock_mode(3.5), self._make_mock_mode(2.9)],
-            [self._make_mock_mode(3.6), self._make_mock_mode(2.8)],
-            [self._make_mock_mode(3.7), self._make_mock_mode(2.7)],
-        ]
-        # tracked sweep (4 calls) then untracked sweep (4 calls)
-        mock_wrapper.side_effect = modes_per_freq + modes_per_freq
-
-        base_args = dict(inv_permittivities=jnp.ones((1, 5, 6, 1)), inv_permeabilities=1.0, resolution=1e-8)
-        frequencies = [1e14, 2e14, 3e14, 4e14]
-
-        tracked_neffs = []
-        prev_neff = None
-        for freq in frequencies:
-            _, _, neff = compute_mode(frequency=freq, target_neff=prev_neff, mode_index=0, **base_args)
-            prev_neff = float(np.real(neff))
-            tracked_neffs.append(prev_neff)
-
-        untracked_neffs = []
-        for freq in frequencies:
-            _, _, neff = compute_mode(frequency=freq, target_neff=None, mode_index=0, **base_args)
-            untracked_neffs.append(float(np.real(neff)))
-
-        expected_tracked = [3.0, 2.9, 2.8, 2.7]
-        expected_untracked = [3.0, 3.5, 3.6, 3.7]
-
-        for i, (got, exp) in enumerate(zip(tracked_neffs, expected_tracked)):
-            assert got == pytest.approx(exp, abs=0.01), f"Tracked freq {i}: expected neff≈{exp}, got {got:.3f}"
-        for i, (got, exp) in enumerate(zip(untracked_neffs, expected_untracked)):
-            assert got == pytest.approx(exp, abs=0.01), f"Untracked freq {i}: expected neff≈{exp}, got {got:.3f}"
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_tracking_three_modes_multiple_crossings(self, mock_normalize, mock_wrapper):
-        """Tracking follows Mode_A across 6 frequencies with 3 modes and repeated order reversals.
-
-        Mode_A decreases smoothly.  Mode_B crosses above A at freqs 1, 3, 5.
-        Mode_C spikes above both at freq 2.  At freq 4, A is still highest so
-        untracked accidentally picks A — shows tracking isn't always needed but
-        is critical wherever the ordering flips.
-
-        freq  solver order (highest → lowest)   tracked   untracked
-          0   A(3.00) B(2.50) C(1.50)           3.00      3.00
-          1   B(3.20) A(2.85) C(1.50)           2.85      3.20  ← B overtakes
-          2   C(3.50) A(2.70) B(2.40)           2.70      3.50  ← C spikes
-          3   B(3.00) A(2.55) C(1.50)           2.55      3.00  ← B again
-          4   A(2.40) B(2.30) C(1.50)           2.40      2.40  ← A still highest
-          5   B(3.50) A(2.25) C(1.50)           2.25      3.50  ← B again
-        """
-        mock_normalize.return_value = (
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-            jnp.ones((3, 5, 6, 1), dtype=jnp.complex64),
-        )
-        modes_per_freq = [
-            [self._make_mock_mode(3.00), self._make_mock_mode(2.50), self._make_mock_mode(1.50)],
-            [self._make_mock_mode(3.20), self._make_mock_mode(2.85), self._make_mock_mode(1.50)],
-            [self._make_mock_mode(3.50), self._make_mock_mode(2.70), self._make_mock_mode(2.40)],
-            [self._make_mock_mode(3.00), self._make_mock_mode(2.55), self._make_mock_mode(1.50)],
-            [self._make_mock_mode(2.40), self._make_mock_mode(2.30), self._make_mock_mode(1.50)],
-            [self._make_mock_mode(3.50), self._make_mock_mode(2.25), self._make_mock_mode(1.50)],
-        ]
-        # tracked sweep (6 calls) + untracked sweep (6 calls)
-        mock_wrapper.side_effect = modes_per_freq + modes_per_freq
-
-        base_args = dict(inv_permittivities=jnp.ones((1, 5, 6, 1)), inv_permeabilities=1.0, resolution=1e-8)
-        frequencies = [1e14, 2e14, 3e14, 4e14, 5e14, 6e14]
-
-        tracked_neffs = []
-        prev_neff = None
-        for freq in frequencies:
-            _, _, neff = compute_mode(frequency=freq, target_neff=prev_neff, mode_index=0, **base_args)
-            prev_neff = float(np.real(neff))
-            tracked_neffs.append(prev_neff)
-
-        untracked_neffs = []
-        for freq in frequencies:
-            _, _, neff = compute_mode(frequency=freq, target_neff=None, mode_index=0, **base_args)
-            untracked_neffs.append(float(np.real(neff)))
-
-        expected_tracked = [3.00, 2.85, 2.70, 2.55, 2.40, 2.25]
-        expected_untracked = [3.00, 3.20, 3.50, 3.00, 2.40, 3.50]
-
-        for i, (got, exp) in enumerate(zip(tracked_neffs, expected_tracked)):
-            assert got == pytest.approx(exp, abs=0.01), f"Tracked freq {i}: expected neff≈{exp}, got {got:.3f}"
-        for i, (got, exp) in enumerate(zip(untracked_neffs, expected_untracked)):
-            assert got == pytest.approx(exp, abs=0.01), f"Untracked freq {i}: expected neff≈{exp}, got {got:.3f}"

--- a/tests/unit/core/test_grid.py
+++ b/tests/unit/core/test_grid.py
@@ -224,9 +224,7 @@ class TestYeeFaceAreas:
 
     def test_z_propagation_area_ordering(self):
         """propagation_axis=2: u=x, v=y — area_EuHv=primal_x*dual_y, area_EvHu=dual_x*primal_y."""
-        EuHv, EvHu = yee_face_areas_from_edges(
-            edges_u=self._X, edges_v=self._Y, u_axis=0, v_axis=1
-        )
+        EuHv, EvHu = yee_face_areas_from_edges(edges_u=self._X, edges_v=self._Y, u_axis=0, v_axis=1)
         assert EuHv.shape == (2, 2, 1)
         expected_EuHv = (self._px[:, None, None] * self._dy[None, :, None]).astype(jnp.float32)
         expected_EvHu = (self._dx[:, None, None] * self._py[None, :, None]).astype(jnp.float32)
@@ -235,9 +233,7 @@ class TestYeeFaceAreas:
 
     def test_x_propagation_area_ordering(self):
         """propagation_axis=0: u=y, v=z — area_EuHv=primal_y*dual_z, area_EvHu=dual_y*primal_z."""
-        EuHv, EvHu = yee_face_areas_from_edges(
-            edges_u=self._Y, edges_v=self._Z, u_axis=1, v_axis=2
-        )
+        EuHv, EvHu = yee_face_areas_from_edges(edges_u=self._Y, edges_v=self._Z, u_axis=1, v_axis=2)
         assert EuHv.shape == (1, 2, 2)
         expected_EuHv = (self._py[None, :, None] * self._dz[None, None, :]).astype(jnp.float32)
         expected_EvHu = (self._dy[None, :, None] * self._pz[None, None, :]).astype(jnp.float32)
@@ -250,9 +246,7 @@ class TestYeeFaceAreas:
         For y-propagation the Yee convention gives u=z, v=x, which is non-sorted order.
         Using sorted order (u=x, v=z) silently swaps the two area arrays on non-uniform grids.
         """
-        EuHv, EvHu = yee_face_areas_from_edges(
-            edges_u=self._Z, edges_v=self._X, u_axis=2, v_axis=0
-        )
+        EuHv, EvHu = yee_face_areas_from_edges(edges_u=self._Z, edges_v=self._X, u_axis=2, v_axis=0)
         assert EuHv.shape == (2, 1, 2)
         expected_EuHv = (self._pz[None, None, :] * self._dx[:, None, None]).astype(jnp.float32)
         expected_EvHu = (self._dz[None, None, :] * self._px[:, None, None]).astype(jnp.float32)
@@ -273,9 +267,7 @@ class TestYeeFaceAreas:
             EuHv_grid, EvHu_grid = grid.yee_face_areas(prop_axis, tuple(slice_t))
 
             edges = [self._X, self._Y, self._Z]
-            EuHv_ref, EvHu_ref = yee_face_areas_from_edges(
-                edges_u=edges[u], edges_v=edges[v], u_axis=u, v_axis=v
-            )
+            EuHv_ref, EvHu_ref = yee_face_areas_from_edges(edges_u=edges[u], edges_v=edges[v], u_axis=u, v_axis=v)
             assert jnp.allclose(EuHv_grid, EuHv_ref), f"EuHv mismatch for propagation_axis={prop_axis}"
             assert jnp.allclose(EvHu_grid, EvHu_ref), f"EvHu mismatch for propagation_axis={prop_axis}"
 

--- a/tests/unit/core/test_grid.py
+++ b/tests/unit/core/test_grid.py
@@ -8,6 +8,7 @@ from fdtdx.core.grid import (
     calculate_spatial_offsets_yee,
     calculate_time_offset_yee,
     polygon_to_mask,
+    yee_face_areas_from_edges,
 )
 
 
@@ -193,6 +194,90 @@ class TestRectilinearGrid:
 
         with pytest.raises(ValueError, match="mirror-symmetric"):
             grid.reduce_symmetric((-1, 0, 0))
+
+
+class TestYeeFaceAreas:
+    """Tests for Yee-staggered face-area computation on non-uniform grids.
+
+    The Yee convention maps propagation_axis to (u, v) as:
+      0 (x-prop) -> u=1 (y),  v=2 (z)
+      1 (y-prop) -> u=2 (z),  v=0 (x)
+      2 (z-prop) -> u=0 (x),  v=1 (y)
+
+    Grid used throughout (2x2x2 cells, all spacings intentionally distinct
+    so that swapping any two axes produces a detectably wrong result):
+      x-edges: [0, 1, 3] um  ->  primal_x=[1,2],  dual_x=[0.5, 1.5]
+      y-edges: [0, 4, 7] um  ->  primal_y=[4,3],  dual_y=[2,   3.5]
+      z-edges: [0, 9, 10] um ->  primal_z=[9,1],  dual_z=[4.5, 5  ]
+    """
+
+    _X = jnp.asarray([0.0, 1e-6, 3e-6])
+    _Y = jnp.asarray([0.0, 4e-6, 7e-6])
+    _Z = jnp.asarray([0.0, 9e-6, 10e-6])
+
+    _px = jnp.asarray([1e-6, 2e-6])
+    _dx = jnp.asarray([0.5e-6, 1.5e-6])
+    _py = jnp.asarray([4e-6, 3e-6])
+    _dy = jnp.asarray([2e-6, 3.5e-6])
+    _pz = jnp.asarray([9e-6, 1e-6])
+    _dz = jnp.asarray([4.5e-6, 5e-6])
+
+    def test_z_propagation_area_ordering(self):
+        """propagation_axis=2: u=x, v=y — area_EuHv=primal_x*dual_y, area_EvHu=dual_x*primal_y."""
+        EuHv, EvHu = yee_face_areas_from_edges(
+            edges_u=self._X, edges_v=self._Y, u_axis=0, v_axis=1
+        )
+        assert EuHv.shape == (2, 2, 1)
+        expected_EuHv = (self._px[:, None, None] * self._dy[None, :, None]).astype(jnp.float32)
+        expected_EvHu = (self._dx[:, None, None] * self._py[None, :, None]).astype(jnp.float32)
+        assert jnp.allclose(EuHv, expected_EuHv)
+        assert jnp.allclose(EvHu, expected_EvHu)
+
+    def test_x_propagation_area_ordering(self):
+        """propagation_axis=0: u=y, v=z — area_EuHv=primal_y*dual_z, area_EvHu=dual_y*primal_z."""
+        EuHv, EvHu = yee_face_areas_from_edges(
+            edges_u=self._Y, edges_v=self._Z, u_axis=1, v_axis=2
+        )
+        assert EuHv.shape == (1, 2, 2)
+        expected_EuHv = (self._py[None, :, None] * self._dz[None, None, :]).astype(jnp.float32)
+        expected_EvHu = (self._dy[None, :, None] * self._pz[None, None, :]).astype(jnp.float32)
+        assert jnp.allclose(EuHv, expected_EuHv)
+        assert jnp.allclose(EvHu, expected_EvHu)
+
+    def test_y_propagation_area_ordering(self):
+        """propagation_axis=1: u=z, v=x — area_EuHv=primal_z*dual_x, area_EvHu=dual_z*primal_x.
+
+        For y-propagation the Yee convention gives u=z, v=x, which is non-sorted order.
+        Using sorted order (u=x, v=z) silently swaps the two area arrays on non-uniform grids.
+        """
+        EuHv, EvHu = yee_face_areas_from_edges(
+            edges_u=self._Z, edges_v=self._X, u_axis=2, v_axis=0
+        )
+        assert EuHv.shape == (2, 1, 2)
+        expected_EuHv = (self._pz[None, None, :] * self._dx[:, None, None]).astype(jnp.float32)
+        expected_EvHu = (self._dz[None, None, :] * self._px[:, None, None]).astype(jnp.float32)
+        assert jnp.allclose(EuHv, expected_EuHv)
+        assert jnp.allclose(EvHu, expected_EvHu)
+        # EuHv must not equal EvHu (they are the same only on uniform grids)
+        assert not jnp.array_equal(EuHv, expected_EvHu)
+
+    def test_rectilinear_grid_yee_face_areas_all_axes(self):
+        """RectilinearGrid.yee_face_areas agrees with yee_face_areas_from_edges for all three axes."""
+        grid = RectilinearGrid(x_edges=self._X, y_edges=self._Y, z_edges=self._Z)
+        full = ((0, 1), (0, 1), (0, 1))
+
+        for prop_axis in (0, 1, 2):
+            u, v = [(1, 2), (2, 0), (0, 1)][prop_axis]
+            slice_t = list(full)
+            slice_t[prop_axis] = (0, 0)
+            EuHv_grid, EvHu_grid = grid.yee_face_areas(prop_axis, tuple(slice_t))
+
+            edges = [self._X, self._Y, self._Z]
+            EuHv_ref, EvHu_ref = yee_face_areas_from_edges(
+                edges_u=edges[u], edges_v=edges[v], u_axis=u, v_axis=v
+            )
+            assert jnp.allclose(EuHv_grid, EuHv_ref), f"EuHv mismatch for propagation_axis={prop_axis}"
+            assert jnp.allclose(EvHu_grid, EvHu_ref), f"EvHu mismatch for propagation_axis={prop_axis}"
 
 
 def test_calculate_spatial_offsets_yee_basic():

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -386,7 +386,7 @@ class TestModeOverlapDetectorComputeOverlap:
         assert jnp.allclose(x_edges, jnp.asarray([0.0, 1.0, 3.0]))
         assert jnp.allclose(y_edges, jnp.asarray([0.0, 3.0, 7.0]))
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
     def test_apply_passes_nonuniform_mode_coordinates(self, mock_compute_mode, random_key, single_frequency):
         """Mode detector apply should not require a scalar grid spacing on stretched grids."""
         grid = RectilinearGrid(
@@ -529,7 +529,7 @@ class TestModeOverlapDetectorMultiFrequency:
             jnp.zeros((n,), dtype=jnp.complex64),
         )
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
     def test_apply_calls_compute_mode_once(
         self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
@@ -540,7 +540,7 @@ class TestModeOverlapDetectorMultiFrequency:
         det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
         assert mock_compute.call_count == 1
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
     def test_apply_passes_frequency_list(
         self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
@@ -551,9 +551,9 @@ class TestModeOverlapDetectorMultiFrequency:
         det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
         kwargs = mock_compute.call_args.kwargs
         expected = [wc.get_frequency() for wc in two_frequencies]
-        assert kwargs["frequency"] == expected
+        assert kwargs["frequencies"] == expected
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
     def test_apply_stores_stacked_mode_fields(
         self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
@@ -565,7 +565,7 @@ class TestModeOverlapDetectorMultiFrequency:
         assert det._mode_E.shape == (2, 3, 8, 8, 1)
         assert det._mode_H.shape == (2, 3, 8, 8, 1)
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
     def test_freq0_overlap_independent_of_freq1_phasor(
         self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
@@ -580,7 +580,7 @@ class TestModeOverlapDetectorMultiFrequency:
         result = det.compute_overlap(state=state)
         assert jnp.isclose(jnp.abs(result[0]), 0.0)
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
     def test_freq1_overlap_independent_of_freq0_phasor(
         self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
@@ -595,7 +595,7 @@ class TestModeOverlapDetectorMultiFrequency:
         result = det.compute_overlap(state=state)
         assert jnp.isclose(jnp.abs(result[1]), 0.0)
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
     def test_mode_frequency_correspondence(
         self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -386,7 +386,7 @@ class TestModeOverlapDetectorComputeOverlap:
         assert jnp.allclose(x_edges, jnp.asarray([0.0, 1.0, 3.0]))
         assert jnp.allclose(y_edges, jnp.asarray([0.0, 3.0, 7.0]))
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_apply_passes_nonuniform_mode_coordinates(self, mock_compute_mode, random_key, single_frequency):
         """Mode detector apply should not require a scalar grid spacing on stretched grids."""
         grid = RectilinearGrid(
@@ -529,7 +529,7 @@ class TestModeOverlapDetectorMultiFrequency:
             jnp.zeros((n,), dtype=jnp.complex64),
         )
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_apply_calls_compute_mode_once(
         self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
@@ -540,7 +540,7 @@ class TestModeOverlapDetectorMultiFrequency:
         det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
         assert mock_compute.call_count == 1
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_apply_passes_frequency_list(
         self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
@@ -553,7 +553,7 @@ class TestModeOverlapDetectorMultiFrequency:
         expected = [wc.get_frequency() for wc in two_frequencies]
         assert kwargs["frequencies"] == expected
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_apply_stores_stacked_mode_fields(
         self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
@@ -565,7 +565,7 @@ class TestModeOverlapDetectorMultiFrequency:
         assert det._mode_E.shape == (2, 3, 8, 8, 1)
         assert det._mode_H.shape == (2, 3, 8, 8, 1)
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_freq0_overlap_independent_of_freq1_phasor(
         self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
@@ -580,7 +580,7 @@ class TestModeOverlapDetectorMultiFrequency:
         result = det.compute_overlap(state=state)
         assert jnp.isclose(jnp.abs(result[0]), 0.0)
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_freq1_overlap_independent_of_freq0_phasor(
         self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
@@ -595,7 +595,7 @@ class TestModeOverlapDetectorMultiFrequency:
         result = det.compute_overlap(state=state)
         assert jnp.isclose(jnp.abs(result[1]), 0.0)
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode_multiple_frequencies")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_mode_frequency_correspondence(
         self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -386,8 +386,8 @@ class TestModeOverlapDetectorComputeOverlap:
         assert jnp.allclose(x_edges, jnp.asarray([0.0, 1.0, 3.0]))
         assert jnp.allclose(y_edges, jnp.asarray([0.0, 3.0, 7.0]))
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
-    def test_apply_passes_nonuniform_mode_coordinates(self, mock_compute_mode, random_key, single_frequency):
+    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
+    def test_apply_passes_nonuniform_mode_coordinates(self, mock_compute_modes_tracked, random_key, single_frequency):
         """Mode detector apply should not require a scalar grid spacing on stretched grids."""
         grid = RectilinearGrid(
             x_edges=jnp.asarray([0.0, 1.0, 3.0]),
@@ -395,13 +395,17 @@ class TestModeOverlapDetectorComputeOverlap:
             z_edges=jnp.asarray([0.0, 1.0]),
         )
         config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
-        mock_compute_mode.return_value = _make_mock_mode(shape=(3, 2, 2, 1))
+        mock_compute_modes_tracked.return_value = (
+            jnp.ones((1, 3, 2, 2, 1), dtype=jnp.complex64),
+            jnp.ones((1, 3, 2, 2, 1), dtype=jnp.complex64),
+            jnp.zeros((1,), dtype=jnp.complex64),
+        )
         det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
         det = det.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
 
         det.apply(random_key, jnp.ones((1, 2, 2, 1), dtype=jnp.float32), 1.0)
 
-        kwargs = mock_compute_mode.call_args.kwargs
+        kwargs = mock_compute_modes_tracked.call_args.kwargs
         assert kwargs["resolution"] == grid.min_spacing
         assert kwargs["transverse_coords"] is not None
 
@@ -511,50 +515,73 @@ class TestModeOverlapDetectorBentWaveguide:
 class TestModeOverlapDetectorMultiFrequency:
     """Tests for multi-frequency support in ModeOverlapDetector.
 
-    apply() calls compute_mode once per frequency. Each call is independent so
-    apply() is fully jit-compatible.
+    apply() delegates all frequency solves to compute_modes_tracked (a single
+    jax.pure_callback), which is fully compatible with jax.jit.  Field-overlap
+    continuity tracking happens inside the callback where numpy arrays are
+    concrete, so it never breaks JAX tracing.
     """
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
-    def test_apply_calls_compute_mode_once_per_frequency(
-        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
+    def _mock_tracked(self, n: int, shape=(3, 8, 8, 1)) -> tuple:
+        """Return value for a mocked compute_modes_tracked with n frequencies."""
+        return (
+            jnp.ones((n, *shape), dtype=jnp.complex64),
+            jnp.ones((n, *shape), dtype=jnp.complex64),
+            jnp.zeros((n,), dtype=jnp.complex64),
+        )
+
+    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
+    def test_apply_calls_compute_modes_tracked_once(
+        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
-        """apply() calls compute_mode once per wave character (2 calls for 2 frequencies)."""
-        mock_compute_mode.return_value = _make_mock_mode()
+        """apply() calls compute_modes_tracked exactly once regardless of frequency count."""
+        mock_tracked.return_value = self._mock_tracked(2)
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
-        assert mock_compute_mode.call_count == 2
+        assert mock_tracked.call_count == 1
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
+    def test_apply_passes_all_frequencies(
+        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
+    ):
+        """apply() passes all wave-character frequencies to compute_modes_tracked."""
+        mock_tracked.return_value = self._mock_tracked(2)
+        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
+        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
+        kwargs = mock_tracked.call_args.kwargs
+        expected = [wc.get_frequency() for wc in two_frequencies]
+        assert kwargs["frequencies"] == expected
+
+    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
     def test_apply_stores_stacked_mode_fields(
-        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """_mode_E and _mode_H have shape (num_freqs, 3, *spatial) after apply()."""
-        mock_compute_mode.return_value = _make_mock_mode()
+        mock_tracked.return_value = self._mock_tracked(2)
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
         assert det._mode_E.shape == (2, 3, 8, 8, 1)
         assert det._mode_H.shape == (2, 3, 8, 8, 1)
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
     def test_apply_stores_stacked_neff(
-        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """_mode_neff has shape (num_freqs,) after apply()."""
-        mock_compute_mode.return_value = _make_mock_mode()
+        mock_tracked.return_value = self._mock_tracked(2)
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
         assert det._mode_neff.shape == (2,)
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
     def test_compute_overlap_returns_array_per_frequency(
-        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """compute_overlap() returns a (num_freqs,) complex array for two frequencies."""
-        mock_compute_mode.return_value = _make_mock_mode()
+        mock_tracked.return_value = self._mock_tracked(2)
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
@@ -563,12 +590,12 @@ class TestModeOverlapDetectorMultiFrequency:
         assert result.shape == (2,)
         assert jnp.iscomplexobj(result)
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
     def test_freq0_overlap_independent_of_freq1_phasor(
-        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """Populating only the freq-1 phasor slot leaves the freq-0 overlap at zero."""
-        mock_compute_mode.return_value = _make_mock_mode()
+        mock_tracked.return_value = self._mock_tracked(2)
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
@@ -578,12 +605,12 @@ class TestModeOverlapDetectorMultiFrequency:
         result = det.compute_overlap(state=state)
         assert jnp.isclose(jnp.abs(result[0]), 0.0)
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
     def test_freq1_overlap_independent_of_freq0_phasor(
-        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """Populating only the freq-0 phasor slot leaves the freq-1 overlap at zero."""
-        mock_compute_mode.return_value = _make_mock_mode()
+        mock_tracked.return_value = self._mock_tracked(2)
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
@@ -593,9 +620,9 @@ class TestModeOverlapDetectorMultiFrequency:
         result = det.compute_overlap(state=state)
         assert jnp.isclose(jnp.abs(result[1]), 0.0)
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
     def test_mode_frequency_correspondence(
-        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """Each frequency's overlap uses its own mode, not the other frequency's mode.
 
@@ -606,11 +633,11 @@ class TestModeOverlapDetectorMultiFrequency:
         mode_H_f0 = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[1].set(1.0)
         mode_E_f1 = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[0].set(2.0)
         mode_H_f1 = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[1].set(2.0)
-        neff = jnp.asarray(1.5 + 0j, dtype=jnp.complex64)
-        mock_compute_mode.side_effect = [
-            (mode_E_f0, mode_H_f0, neff),
-            (mode_E_f1, mode_H_f1, neff),
-        ]
+        mock_tracked.return_value = (
+            jnp.stack([mode_E_f0, mode_E_f1]),
+            jnp.stack([mode_H_f0, mode_H_f1]),
+            jnp.array([1.5 + 0j, 1.5 + 0j], dtype=jnp.complex64),
+        )
 
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
@@ -626,12 +653,12 @@ class TestModeOverlapDetectorMultiFrequency:
         ratio = jnp.abs(result[1]) / jnp.abs(result[0])
         assert jnp.isclose(ratio, 2.0, atol=0.01)
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
     def test_single_frequency_returns_shape_1(
-        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, single_frequency
+        self, mock_tracked, simulation_config, plane_grid_slice, random_key, single_frequency
     ):
         """With one wave character, compute_overlap() returns shape (1,)."""
-        mock_compute_mode.return_value = _make_mock_mode()
+        mock_tracked.return_value = self._mock_tracked(1)
         det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
@@ -639,9 +666,9 @@ class TestModeOverlapDetectorMultiFrequency:
         result = det.compute_overlap(state=state)
         assert result.shape == (1,)
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
     def test_compute_overlap_without_apply_raises_multifreq(
-        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """compute_overlap() still raises when apply() has not been called (multi-freq case)."""
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -142,7 +142,7 @@ class TestModeOverlapDetectorPlaceOnGrid:
         assert placed is not None
 
     def test_multiple_wave_chars_succeeds(self, simulation_config, plane_grid_slice, random_key, two_frequencies):
-        """Multiple wave characters are now supported."""
+        """place_on_grid succeeds with multiple wave characters."""
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         placed = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         assert placed is not None
@@ -298,7 +298,7 @@ class TestModeOverlapDetectorComputeOverlap:
 
         assert jnp.isclose(jnp.abs(overlap), 0.0)
 
-    def test_compute_overlap_to_mode_scaled_quarter(
+    def test_compute_overlap_to_mode_matches_formula(
         self,
         simulation_config,
         plane_grid_slice,
@@ -309,7 +309,7 @@ class TestModeOverlapDetectorComputeOverlap:
         inv_permittivity,
         inv_permeability,
     ):
-        """Overlap coefficient includes the 1/4 normalization factor."""
+        """Overlap coefficient matches bidirectional_mode_overlap directly (1/4 is inside the formula)."""
         det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         state = det.init_state()
@@ -329,17 +329,14 @@ class TestModeOverlapDetectorComputeOverlap:
         phasors = state["phasor"]
         phasors_E = phasors[0, 0, :3]
         phasors_H = phasors[0, 0, 3:]
-        expected = (
-            bidirectional_mode_overlap(
-                mode_E=mode_E,
-                mode_H=mode_H,
-                sim_E=phasors_E,
-                sim_H=phasors_H,
-                propagation_axis=det.propagation_axis,
-                area_EuHv=det._cached_area_EuHv,
-                area_EvHu=det._cached_area_EvHu,
-            )
-            / 4.0
+        expected = bidirectional_mode_overlap(
+            mode_E=mode_E,
+            mode_H=mode_H,
+            sim_E=phasors_E,
+            sim_H=phasors_H,
+            propagation_axis=det.propagation_axis,
+            area_EuHv=det._cached_area_EuHv,
+            area_EvHu=det._cached_area_EvHu,
         )
 
         overlap = det.compute_overlap_to_mode(state=state, mode_E=mode_E, mode_H=mode_H)
@@ -352,7 +349,7 @@ class TestModeOverlapDetectorComputeOverlap:
         Grid: x in [0,1,3] (widths 1, 2), y in [0,3,7] (widths 3, 4).
         Dual y-widths: [1.5, 3.5] (distance between adjacent y-cell centers).
         area_EuHv = outer([1, 2], [1.5, 3.5]) -> sum = 15.
-        With 1/4 normalization: 15 / 4 = 3.75.
+        bidirectional_mode_overlap includes 0.25: 0.25 * 15 = 3.75.
         """
         grid = RectilinearGrid(
             x_edges=jnp.asarray([0.0, 1.0, 3.0]),
@@ -438,7 +435,7 @@ class TestModeOverlapDetectorComputeOverlapPath:
         det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
 
-        # apply() now stacks modes along a leading freq axis: (num_freqs, 3, *spatial)
+        # stacked along a leading freq axis: (num_freqs, 3, *spatial)
         single_mode_E = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64) * 0.5
         single_mode_H = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64) * 0.5
         stacked_mode_E = jnp.stack([single_mode_E])  # (1, 3, 8, 8, 1)
@@ -514,8 +511,7 @@ class TestModeOverlapDetectorBentWaveguide:
 class TestModeOverlapDetectorMultiFrequency:
     """Tests for multi-frequency support in ModeOverlapDetector.
 
-    apply() now calls compute_mode once per frequency (not the deleted compute_modes_multi_freq),
-    with neff-proximity tracking between calls.
+    apply() calls compute_mode once per frequency with neff-proximity tracking between calls.
     """
 
     @patch("fdtdx.objects.detectors.mode.compute_mode")

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -20,14 +20,6 @@ def _make_mock_mode(shape=(3, 8, 8, 1), value=1.0, dtype=jnp.complex64):
     return mode_E, mode_H, neff
 
 
-def _make_multi_mock_mode(n_freqs, shape=(3, 8, 8, 1), value=1.0, dtype=jnp.complex64):
-    """Return (mode_Es, mode_Hs, mode_neffs) stacked along a leading freq axis."""
-    mode_Es = jnp.ones((n_freqs, *shape), dtype=dtype) * value
-    mode_Hs = jnp.ones((n_freqs, *shape), dtype=dtype) * value
-    mode_neffs = jnp.ones((n_freqs,), dtype=dtype) * (1.5 + 0j)
-    return mode_Es, mode_Hs, mode_neffs
-
-
 @pytest.fixture
 def single_frequency():
     """Single optical frequency wave character."""
@@ -397,10 +389,8 @@ class TestModeOverlapDetectorComputeOverlap:
         assert jnp.allclose(x_edges, jnp.asarray([0.0, 1.0, 3.0]))
         assert jnp.allclose(y_edges, jnp.asarray([0.0, 3.0, 7.0]))
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
-    def test_apply_passes_nonuniform_mode_coordinates(
-        self, mock_compute_modes_multi_freq, random_key, single_frequency
-    ):
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    def test_apply_passes_nonuniform_mode_coordinates(self, mock_compute_mode, random_key, single_frequency):
         """Mode detector apply should not require a scalar grid spacing on stretched grids."""
         grid = RectilinearGrid(
             x_edges=jnp.asarray([0.0, 1.0, 3.0]),
@@ -408,13 +398,13 @@ class TestModeOverlapDetectorComputeOverlap:
             z_edges=jnp.asarray([0.0, 1.0]),
         )
         config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
-        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(1, shape=(3, 2, 2, 1))
+        mock_compute_mode.return_value = _make_mock_mode(shape=(3, 2, 2, 1))
         det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
         det = det.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
 
         det.apply(random_key, jnp.ones((1, 2, 2, 1), dtype=jnp.float32), 1.0)
 
-        kwargs = mock_compute_modes_multi_freq.call_args.kwargs
+        kwargs = mock_compute_mode.call_args.kwargs
         assert kwargs["resolution"] == grid.min_spacing
         assert kwargs["transverse_coords"] is not None
 
@@ -522,62 +512,75 @@ class TestModeOverlapDetectorBentWaveguide:
 
 
 class TestModeOverlapDetectorMultiFrequency:
-    """Tests for multi-frequency support in ModeOverlapDetector."""
+    """Tests for multi-frequency support in ModeOverlapDetector.
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
-    def test_apply_calls_compute_modes_multi_freq_once(
-        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+    apply() now calls compute_mode once per frequency (not the deleted compute_modes_multi_freq),
+    with neff-proximity tracking between calls.
+    """
+
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    def test_apply_calls_compute_mode_once_per_frequency(
+        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
-        """apply() calls compute_modes_multi_freq exactly once for all wave characters."""
-        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        """apply() calls compute_mode once per wave character (2 calls for 2 frequencies)."""
+        mock_compute_mode.return_value = _make_mock_mode()
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
-        assert mock_compute_modes_multi_freq.call_count == 1
+        assert mock_compute_mode.call_count == 2
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
-    def test_apply_passes_correct_frequencies(
-        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    def test_apply_passes_target_neff_to_second_call(
+        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
-        """apply() passes all wave character frequencies as a list to compute_modes_multi_freq."""
-        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        """First call gets target_neff=None; second call gets float(real(neff)) from first call.
+
+        This ensures neff-proximity tracking across frequencies to prevent mode hopping.
+        """
+        neff_from_first = jnp.asarray(2.5 + 0.01j, dtype=jnp.complex64)
+        result_f0 = _make_mock_mode()
+        result_f0 = (result_f0[0], result_f0[1], neff_from_first)
+        result_f1 = _make_mock_mode()
+        mock_compute_mode.side_effect = [result_f0, result_f1]
+
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
 
-        expected_freqs = [wc.get_frequency() for wc in two_frequencies]
-        actual_freqs = mock_compute_modes_multi_freq.call_args.kwargs["frequencies"]
-        assert actual_freqs == expected_freqs
+        first_call_kwargs = mock_compute_mode.call_args_list[0].kwargs
+        second_call_kwargs = mock_compute_mode.call_args_list[1].kwargs
+        assert first_call_kwargs["target_neff"] is None
+        assert second_call_kwargs["target_neff"] == pytest.approx(float(jnp.real(neff_from_first)))
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_apply_stores_stacked_mode_fields(
-        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """_mode_E and _mode_H have shape (num_freqs, 3, *spatial) after apply()."""
-        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        mock_compute_mode.return_value = _make_mock_mode()
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
         assert det._mode_E.shape == (2, 3, 8, 8, 1)
         assert det._mode_H.shape == (2, 3, 8, 8, 1)
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_apply_stores_stacked_neff(
-        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """_mode_neff has shape (num_freqs,) after apply()."""
-        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        mock_compute_mode.return_value = _make_mock_mode()
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
         assert det._mode_neff.shape == (2,)
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_compute_overlap_returns_array_per_frequency(
-        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """compute_overlap() returns a (num_freqs,) complex array for two frequencies."""
-        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        mock_compute_mode.return_value = _make_mock_mode()
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
@@ -586,41 +589,39 @@ class TestModeOverlapDetectorMultiFrequency:
         assert result.shape == (2,)
         assert jnp.iscomplexobj(result)
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_freq0_overlap_independent_of_freq1_phasor(
-        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """Populating only the freq-1 phasor slot leaves the freq-0 overlap at zero."""
-        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        mock_compute_mode.return_value = _make_mock_mode()
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
         state = det.init_state()
-        # Set only the freq-1 (index=1) phasor slot to non-zero
         phasor = state["phasor"].at[0, 1, :].set(1.0)
         state = {"phasor": phasor}
         result = det.compute_overlap(state=state)
         assert jnp.isclose(jnp.abs(result[0]), 0.0)
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_freq1_overlap_independent_of_freq0_phasor(
-        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """Populating only the freq-0 phasor slot leaves the freq-1 overlap at zero."""
-        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        mock_compute_mode.return_value = _make_mock_mode()
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
         state = det.init_state()
-        # Set only the freq-0 (index=0) phasor slot to non-zero
         phasor = state["phasor"].at[0, 0, :].set(1.0)
         state = {"phasor": phasor}
         result = det.compute_overlap(state=state)
         assert jnp.isclose(jnp.abs(result[1]), 0.0)
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_mode_frequency_correspondence(
-        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """Each frequency's overlap uses its own mode, not the other frequency's mode.
 
@@ -631,36 +632,32 @@ class TestModeOverlapDetectorMultiFrequency:
         mode_H_f0 = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[1].set(1.0)
         mode_E_f1 = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[0].set(2.0)
         mode_H_f1 = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[1].set(2.0)
-        neffs = jnp.ones((2,), dtype=jnp.complex64) * 1.5
-        mock_compute_modes_multi_freq.return_value = (
-            jnp.stack([mode_E_f0, mode_E_f1]),  # (2, 3, 8, 8, 1)
-            jnp.stack([mode_H_f0, mode_H_f1]),
-            neffs,
-        )
+        neff = jnp.asarray(1.5 + 0j, dtype=jnp.complex64)
+        mock_compute_mode.side_effect = [
+            (mode_E_f0, mode_H_f0, neff),
+            (mode_E_f1, mode_H_f1, neff),
+        ]
 
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
 
-        # Populate both phasor slots identically with Ex=1, Hy=0.5
         state = det.init_state()
         phasor = state["phasor"].at[0, :, 0].set(1.0).at[0, :, 4].set(0.5)
         state = {"phasor": phasor}
 
         result = det.compute_overlap(state=state)
 
-        # freq-1 mode has Ex=2, Hy=2 vs Ex=1, Hy=1 for freq-0.
-        # The integrand has two terms: cross(mode_E, conj(pH)) + cross(conj(pE), mode_H).
-        # Each term is linear in one mode field, so doubling both mode fields → 2x total.
+        # freq-1 mode has Ex=2, Hy=2 vs Ex=1, Hy=1 for freq-0 — doubling both fields → 2x overlap
         ratio = jnp.abs(result[1]) / jnp.abs(result[0])
         assert jnp.isclose(ratio, 2.0, atol=0.01)
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_single_frequency_returns_shape_1(
-        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, single_frequency
+        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, single_frequency
     ):
         """With one wave character, compute_overlap() returns shape (1,)."""
-        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(1)
+        mock_compute_mode.return_value = _make_mock_mode()
         det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
@@ -668,9 +665,9 @@ class TestModeOverlapDetectorMultiFrequency:
         result = det.compute_overlap(state=state)
         assert result.shape == (1,)
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_compute_overlap_without_apply_raises_multifreq(
-        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """compute_overlap() still raises when apply() has not been called (multi-freq case)."""
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -7,8 +7,25 @@ import pytest
 
 from fdtdx.config import SimulationConfig
 from fdtdx.core.grid import RectilinearGrid
+from fdtdx.core.physics.metrics import bidirectional_mode_overlap
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.detectors.mode import ModeOverlapDetector
+
+
+def _make_mock_mode(shape=(3, 8, 8, 1), value=1.0, dtype=jnp.complex64):
+    """Return (mode_E, mode_H, neff) with constant field arrays."""
+    mode_E = jnp.ones(shape, dtype=dtype) * value
+    mode_H = jnp.ones(shape, dtype=dtype) * value
+    neff = jnp.asarray(1.5 + 0j, dtype=dtype)
+    return mode_E, mode_H, neff
+
+
+def _make_multi_mock_mode(n_freqs, shape=(3, 8, 8, 1), value=1.0, dtype=jnp.complex64):
+    """Return (mode_Es, mode_Hs, mode_neffs) stacked along a leading freq axis."""
+    mode_Es = jnp.ones((n_freqs, *shape), dtype=dtype) * value
+    mode_Hs = jnp.ones((n_freqs, *shape), dtype=dtype) * value
+    mode_neffs = jnp.ones((n_freqs,), dtype=dtype) * (1.5 + 0j)
+    return mode_Es, mode_Hs, mode_neffs
 
 
 @pytest.fixture
@@ -132,13 +149,11 @@ class TestModeOverlapDetectorPlaceOnGrid:
         placed = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         assert placed is not None
 
-    def test_multiple_wave_chars_raises_not_implemented(
-        self, simulation_config, plane_grid_slice, random_key, two_frequencies
-    ):
-        """Multiple wave characters raise NotImplementedError (not yet supported)."""
+    def test_multiple_wave_chars_succeeds(self, simulation_config, plane_grid_slice, random_key, two_frequencies):
+        """Multiple wave characters are now supported."""
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
-        with pytest.raises(NotImplementedError):
-            det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        placed = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        assert placed is not None
 
 
 class TestModeOverlapDetectorComputeOverlap:
@@ -319,20 +334,34 @@ class TestModeOverlapDetectorComputeOverlap:
         mode_E = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[0].set(1.0)
         mode_H = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[1].set(1.0)
 
-        # Manually replicate the formula to verify the 1/4 factor
         phasors = state["phasor"]
         phasors_E = phasors[0, 0, :3]
         phasors_H = phasors[0, 0, 3:]
-        E_cross_H = jnp.cross(mode_E, jnp.conj(phasors_H), axis=0)[det.propagation_axis]
-        E_cross_H_back = jnp.cross(jnp.conj(phasors_E), mode_H, axis=0)[det.propagation_axis]
-        expected = jnp.sum((E_cross_H + E_cross_H_back) * det._face_area_weights()) / 4.0
+        expected = (
+            bidirectional_mode_overlap(
+                mode_E=mode_E,
+                mode_H=mode_H,
+                sim_E=phasors_E,
+                sim_H=phasors_H,
+                propagation_axis=det.propagation_axis,
+                area_EuHv=det._cached_area_EuHv,
+                area_EvHu=det._cached_area_EvHu,
+            )
+            / 4.0
+        )
 
         overlap = det.compute_overlap_to_mode(state=state, mode_E=mode_E, mode_H=mode_H)
 
         assert jnp.isclose(overlap, expected)
 
     def test_compute_overlap_integrates_nonuniform_face_area(self, random_key, single_frequency):
-        """A constant overlap integrand integrates to the detector face area."""
+        """Overlap uses Yee-staggered area weights (primal_u x dual_v) for the Ex/Hy term.
+
+        Grid: x in [0,1,3] (widths 1, 2), y in [0,3,7] (widths 3, 4).
+        Dual y-widths: [1.5, 3.5] (distance between adjacent y-cell centers).
+        area_EuHv = outer([1, 2], [1.5, 3.5]) -> sum = 15.
+        With 1/4 normalization: 15 / 4 = 3.75.
+        """
         grid = RectilinearGrid(
             x_edges=jnp.asarray([0.0, 1.0, 3.0]),
             y_edges=jnp.asarray([0.0, 3.0, 7.0]),
@@ -350,7 +379,7 @@ class TestModeOverlapDetectorComputeOverlap:
 
         overlap = det.compute_overlap_to_mode(state=state, mode_E=mode_E, mode_H=mode_H)
 
-        assert jnp.allclose(overlap, jnp.asarray(21.0 / 4.0, dtype=jnp.complex64))
+        assert jnp.allclose(overlap, jnp.asarray(15.0 / 4.0, dtype=jnp.complex64))
 
     def test_transverse_edge_coordinates_follow_detector_slice(self, random_key, single_frequency):
         """Mode solving receives the physical edge arrays for the transverse detector axes."""
@@ -368,8 +397,10 @@ class TestModeOverlapDetectorComputeOverlap:
         assert jnp.allclose(x_edges, jnp.asarray([0.0, 1.0, 3.0]))
         assert jnp.allclose(y_edges, jnp.asarray([0.0, 3.0, 7.0]))
 
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
-    def test_apply_passes_nonuniform_mode_coordinates(self, mock_compute_mode, random_key, single_frequency):
+    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    def test_apply_passes_nonuniform_mode_coordinates(
+        self, mock_compute_modes_multi_freq, random_key, single_frequency
+    ):
         """Mode detector apply should not require a scalar grid spacing on stretched grids."""
         grid = RectilinearGrid(
             x_edges=jnp.asarray([0.0, 1.0, 3.0]),
@@ -377,17 +408,13 @@ class TestModeOverlapDetectorComputeOverlap:
             z_edges=jnp.asarray([0.0, 1.0]),
         )
         config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
-        mock_compute_mode.return_value = (
-            jnp.ones((3, 2, 2, 1), dtype=jnp.complex64),
-            jnp.ones((3, 2, 2, 1), dtype=jnp.complex64),
-            jnp.asarray(1.5 + 0j, dtype=jnp.complex64),
-        )
+        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(1, shape=(3, 2, 2, 1))
         det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
         det = det.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
 
         det.apply(random_key, jnp.ones((1, 2, 2, 1), dtype=jnp.float32), 1.0)
 
-        kwargs = mock_compute_mode.call_args.kwargs
+        kwargs = mock_compute_modes_multi_freq.call_args.kwargs
         assert kwargs["resolution"] == grid.min_spacing
         assert kwargs["transverse_coords"] is not None
 
@@ -421,21 +448,24 @@ class TestModeOverlapDetectorComputeOverlapPath:
         det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
 
-        # Manually set mode fields (simulating what apply() would do)
-        mode_E = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64) * 0.5
-        mode_H = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64) * 0.5
-        det = det.aset("_mode_E", mode_E, create_new_ok=True)
-        det = det.aset("_mode_H", mode_H, create_new_ok=True)
+        # apply() now stacks modes along a leading freq axis: (num_freqs, 3, *spatial)
+        single_mode_E = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64) * 0.5
+        single_mode_H = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64) * 0.5
+        stacked_mode_E = jnp.stack([single_mode_E])  # (1, 3, 8, 8, 1)
+        stacked_mode_H = jnp.stack([single_mode_H])  # (1, 3, 8, 8, 1)
+        det = det.aset("_mode_E", stacked_mode_E, create_new_ok=True)
+        det = det.aset("_mode_H", stacked_mode_H, create_new_ok=True)
 
         state = det.init_state()
         state = det.update(jnp.array(0), constant_E_field, constant_H_field, state, inv_permittivity, inv_permeability)
 
-        # compute_overlap() should work and give same result as compute_overlap_to_mode()
+        # compute_overlap() returns (num_freqs,) array; compare element to direct call
         result_stored = det.compute_overlap(state=state)
-        result_explicit = det.compute_overlap_to_mode(state=state, mode_E=mode_E, mode_H=mode_H)
+        result_explicit = det.compute_overlap_to_mode(state=state, mode_E=single_mode_E, mode_H=single_mode_H)
 
         assert jnp.iscomplexobj(result_stored)
-        assert jnp.isclose(result_stored, result_explicit)
+        assert result_stored.shape == (1,)
+        assert jnp.isclose(result_stored[0], result_explicit)
 
 
 class TestModeOverlapDetectorBentWaveguide:
@@ -489,3 +519,162 @@ class TestModeOverlapDetectorBentWaveguide:
         det = ModeOverlapDetector(wave_characters=single_frequency, direction="+", bend_radius=5e-6, bend_axis=0)
         with pytest.raises(ValueError, match="must differ from the propagation axis"):
             det.place_on_grid(x_plane, simulation_config, random_key)
+
+
+class TestModeOverlapDetectorMultiFrequency:
+    """Tests for multi-frequency support in ModeOverlapDetector."""
+
+    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    def test_apply_calls_compute_modes_multi_freq_once(
+        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+    ):
+        """apply() calls compute_modes_multi_freq exactly once for all wave characters."""
+        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
+        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
+        assert mock_compute_modes_multi_freq.call_count == 1
+
+    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    def test_apply_passes_correct_frequencies(
+        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+    ):
+        """apply() passes all wave character frequencies as a list to compute_modes_multi_freq."""
+        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
+        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
+
+        expected_freqs = [wc.get_frequency() for wc in two_frequencies]
+        actual_freqs = mock_compute_modes_multi_freq.call_args.kwargs["frequencies"]
+        assert actual_freqs == expected_freqs
+
+    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    def test_apply_stores_stacked_mode_fields(
+        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+    ):
+        """_mode_E and _mode_H have shape (num_freqs, 3, *spatial) after apply()."""
+        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
+        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
+        assert det._mode_E.shape == (2, 3, 8, 8, 1)
+        assert det._mode_H.shape == (2, 3, 8, 8, 1)
+
+    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    def test_apply_stores_stacked_neff(
+        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+    ):
+        """_mode_neff has shape (num_freqs,) after apply()."""
+        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
+        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
+        assert det._mode_neff.shape == (2,)
+
+    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    def test_compute_overlap_returns_array_per_frequency(
+        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+    ):
+        """compute_overlap() returns a (num_freqs,) complex array for two frequencies."""
+        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
+        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
+        state = det.init_state()
+        result = det.compute_overlap(state=state)
+        assert result.shape == (2,)
+        assert jnp.iscomplexobj(result)
+
+    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    def test_freq0_overlap_independent_of_freq1_phasor(
+        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+    ):
+        """Populating only the freq-1 phasor slot leaves the freq-0 overlap at zero."""
+        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
+        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
+        state = det.init_state()
+        # Set only the freq-1 (index=1) phasor slot to non-zero
+        phasor = state["phasor"].at[0, 1, :].set(1.0)
+        state = {"phasor": phasor}
+        result = det.compute_overlap(state=state)
+        assert jnp.isclose(jnp.abs(result[0]), 0.0)
+
+    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    def test_freq1_overlap_independent_of_freq0_phasor(
+        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+    ):
+        """Populating only the freq-0 phasor slot leaves the freq-1 overlap at zero."""
+        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(2)
+        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
+        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
+        state = det.init_state()
+        # Set only the freq-0 (index=0) phasor slot to non-zero
+        phasor = state["phasor"].at[0, 0, :].set(1.0)
+        state = {"phasor": phasor}
+        result = det.compute_overlap(state=state)
+        assert jnp.isclose(jnp.abs(result[1]), 0.0)
+
+    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    def test_mode_frequency_correspondence(
+        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+    ):
+        """Each frequency's overlap uses its own mode, not the other frequency's mode.
+
+        Strategy: give each frequency a distinct mode_E (Ex=1 for freq-0, Ex=2 for freq-1).
+        Set both phasor slots identically. The overlap magnitudes should differ proportionally.
+        """
+        mode_E_f0 = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[0].set(1.0)
+        mode_H_f0 = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[1].set(1.0)
+        mode_E_f1 = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[0].set(2.0)
+        mode_H_f1 = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[1].set(2.0)
+        neffs = jnp.ones((2,), dtype=jnp.complex64) * 1.5
+        mock_compute_modes_multi_freq.return_value = (
+            jnp.stack([mode_E_f0, mode_E_f1]),  # (2, 3, 8, 8, 1)
+            jnp.stack([mode_H_f0, mode_H_f1]),
+            neffs,
+        )
+
+        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
+        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
+
+        # Populate both phasor slots identically with Ex=1, Hy=0.5
+        state = det.init_state()
+        phasor = state["phasor"].at[0, :, 0].set(1.0).at[0, :, 4].set(0.5)
+        state = {"phasor": phasor}
+
+        result = det.compute_overlap(state=state)
+
+        # freq-1 mode has Ex=2, Hy=2 vs Ex=1, Hy=1 for freq-0.
+        # The integrand has two terms: cross(mode_E, conj(pH)) + cross(conj(pE), mode_H).
+        # Each term is linear in one mode field, so doubling both mode fields → 2x total.
+        ratio = jnp.abs(result[1]) / jnp.abs(result[0])
+        assert jnp.isclose(ratio, 2.0, atol=0.01)
+
+    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    def test_single_frequency_returns_shape_1(
+        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, single_frequency
+    ):
+        """With one wave character, compute_overlap() returns shape (1,)."""
+        mock_compute_modes_multi_freq.return_value = _make_multi_mock_mode(1)
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
+        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
+        state = det.init_state()
+        result = det.compute_overlap(state=state)
+        assert result.shape == (1,)
+
+    @patch("fdtdx.objects.detectors.mode.compute_modes_multi_freq")
+    def test_compute_overlap_without_apply_raises_multifreq(
+        self, mock_compute_modes_multi_freq, simulation_config, plane_grid_slice, random_key, two_frequencies
+    ):
+        """compute_overlap() still raises when apply() has not been called (multi-freq case)."""
+        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
+        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        state = det.init_state()
+        with pytest.raises(Exception, match="apply"):
+            det.compute_overlap(state=state)

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -511,7 +511,8 @@ class TestModeOverlapDetectorBentWaveguide:
 class TestModeOverlapDetectorMultiFrequency:
     """Tests for multi-frequency support in ModeOverlapDetector.
 
-    apply() calls compute_mode once per frequency with neff-proximity tracking between calls.
+    apply() calls compute_mode once per frequency. Each call is independent so
+    apply() is fully jit-compatible.
     """
 
     @patch("fdtdx.objects.detectors.mode.compute_mode")
@@ -524,29 +525,6 @@ class TestModeOverlapDetectorMultiFrequency:
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
         assert mock_compute_mode.call_count == 2
-
-    @patch("fdtdx.objects.detectors.mode.compute_mode")
-    def test_apply_passes_target_neff_to_second_call(
-        self, mock_compute_mode, simulation_config, plane_grid_slice, random_key, two_frequencies
-    ):
-        """First call gets target_neff=None; second call gets float(real(neff)) from first call.
-
-        This ensures neff-proximity tracking across frequencies to prevent mode hopping.
-        """
-        neff_from_first = jnp.asarray(2.5 + 0.01j, dtype=jnp.complex64)
-        result_f0 = _make_mock_mode()
-        result_f0 = (result_f0[0], result_f0[1], neff_from_first)
-        result_f1 = _make_mock_mode()
-        mock_compute_mode.side_effect = [result_f0, result_f1]
-
-        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
-        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
-        det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
-
-        first_call_kwargs = mock_compute_mode.call_args_list[0].kwargs
-        second_call_kwargs = mock_compute_mode.call_args_list[1].kwargs
-        assert first_call_kwargs["target_neff"] is None
-        assert second_call_kwargs["target_neff"] == pytest.approx(float(jnp.real(neff_from_first)))
 
     @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_apply_stores_stacked_mode_fields(

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -386,8 +386,8 @@ class TestModeOverlapDetectorComputeOverlap:
         assert jnp.allclose(x_edges, jnp.asarray([0.0, 1.0, 3.0]))
         assert jnp.allclose(y_edges, jnp.asarray([0.0, 3.0, 7.0]))
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
-    def test_apply_passes_nonuniform_mode_coordinates(self, mock_compute_modes_tracked, random_key, single_frequency):
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    def test_apply_passes_nonuniform_mode_coordinates(self, mock_compute_mode, random_key, single_frequency):
         """Mode detector apply should not require a scalar grid spacing on stretched grids."""
         grid = RectilinearGrid(
             x_edges=jnp.asarray([0.0, 1.0, 3.0]),
@@ -395,7 +395,7 @@ class TestModeOverlapDetectorComputeOverlap:
             z_edges=jnp.asarray([0.0, 1.0]),
         )
         config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
-        mock_compute_modes_tracked.return_value = (
+        mock_compute_mode.return_value = (
             jnp.ones((1, 3, 2, 2, 1), dtype=jnp.complex64),
             jnp.ones((1, 3, 2, 2, 1), dtype=jnp.complex64),
             jnp.zeros((1,), dtype=jnp.complex64),
@@ -405,7 +405,7 @@ class TestModeOverlapDetectorComputeOverlap:
 
         det.apply(random_key, jnp.ones((1, 2, 2, 1), dtype=jnp.float32), 1.0)
 
-        kwargs = mock_compute_modes_tracked.call_args.kwargs
+        kwargs = mock_compute_mode.call_args.kwargs
         assert kwargs["resolution"] == grid.min_spacing
         assert kwargs["transverse_coords"] is not None
 
@@ -515,87 +515,62 @@ class TestModeOverlapDetectorBentWaveguide:
 class TestModeOverlapDetectorMultiFrequency:
     """Tests for multi-frequency support in ModeOverlapDetector.
 
-    apply() delegates all frequency solves to compute_modes_tracked (a single
+    apply() delegates all frequency solves to compute_mode (a single
     jax.pure_callback), which is fully compatible with jax.jit.  Field-overlap
     continuity tracking happens inside the callback where numpy arrays are
     concrete, so it never breaks JAX tracing.
     """
 
-    def _mock_tracked(self, n: int, shape=(3, 8, 8, 1)) -> tuple:
-        """Return value for a mocked compute_modes_tracked with n frequencies."""
+    def _mock_compute(self, n: int, shape=(3, 8, 8, 1)) -> tuple:
+        """Return value for a mocked compute_mode with n frequencies."""
         return (
             jnp.ones((n, *shape), dtype=jnp.complex64),
             jnp.ones((n, *shape), dtype=jnp.complex64),
             jnp.zeros((n,), dtype=jnp.complex64),
         )
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
-    def test_apply_calls_compute_modes_tracked_once(
-        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    def test_apply_calls_compute_mode_once(
+        self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
-        """apply() calls compute_modes_tracked exactly once regardless of frequency count."""
-        mock_tracked.return_value = self._mock_tracked(2)
+        """apply() calls compute_mode exactly once regardless of frequency count."""
+        mock_compute.return_value = self._mock_compute(2)
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
-        assert mock_tracked.call_count == 1
+        assert mock_compute.call_count == 1
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
-    def test_apply_passes_all_frequencies(
-        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    def test_apply_passes_frequency_list(
+        self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
-        """apply() passes all wave-character frequencies to compute_modes_tracked."""
-        mock_tracked.return_value = self._mock_tracked(2)
+        """apply() passes all wave-character frequencies to compute_mode."""
+        mock_compute.return_value = self._mock_compute(2)
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
-        kwargs = mock_tracked.call_args.kwargs
+        kwargs = mock_compute.call_args.kwargs
         expected = [wc.get_frequency() for wc in two_frequencies]
-        assert kwargs["frequencies"] == expected
+        assert kwargs["frequency"] == expected
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_apply_stores_stacked_mode_fields(
-        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """_mode_E and _mode_H have shape (num_freqs, 3, *spatial) after apply()."""
-        mock_tracked.return_value = self._mock_tracked(2)
+        mock_compute.return_value = self._mock_compute(2)
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
         assert det._mode_E.shape == (2, 3, 8, 8, 1)
         assert det._mode_H.shape == (2, 3, 8, 8, 1)
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
-    def test_apply_stores_stacked_neff(
-        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
-    ):
-        """_mode_neff has shape (num_freqs,) after apply()."""
-        mock_tracked.return_value = self._mock_tracked(2)
-        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
-        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
-        det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
-        assert det._mode_neff.shape == (2,)
-
-    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
-    def test_compute_overlap_returns_array_per_frequency(
-        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
-    ):
-        """compute_overlap() returns a (num_freqs,) complex array for two frequencies."""
-        mock_tracked.return_value = self._mock_tracked(2)
-        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
-        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
-        det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
-        state = det.init_state()
-        result = det.compute_overlap(state=state)
-        assert result.shape == (2,)
-        assert jnp.iscomplexobj(result)
-
-    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_freq0_overlap_independent_of_freq1_phasor(
-        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """Populating only the freq-1 phasor slot leaves the freq-0 overlap at zero."""
-        mock_tracked.return_value = self._mock_tracked(2)
+        mock_compute.return_value = self._mock_compute(2)
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
@@ -605,12 +580,12 @@ class TestModeOverlapDetectorMultiFrequency:
         result = det.compute_overlap(state=state)
         assert jnp.isclose(jnp.abs(result[0]), 0.0)
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_freq1_overlap_independent_of_freq0_phasor(
-        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """Populating only the freq-0 phasor slot leaves the freq-1 overlap at zero."""
-        mock_tracked.return_value = self._mock_tracked(2)
+        mock_compute.return_value = self._mock_compute(2)
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
@@ -620,9 +595,9 @@ class TestModeOverlapDetectorMultiFrequency:
         result = det.compute_overlap(state=state)
         assert jnp.isclose(jnp.abs(result[1]), 0.0)
 
-    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
     def test_mode_frequency_correspondence(
-        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
+        self, mock_compute, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
         """Each frequency's overlap uses its own mode, not the other frequency's mode.
 
@@ -633,7 +608,7 @@ class TestModeOverlapDetectorMultiFrequency:
         mode_H_f0 = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[1].set(1.0)
         mode_E_f1 = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[0].set(2.0)
         mode_H_f1 = jnp.zeros((3, 8, 8, 1), dtype=jnp.complex64).at[1].set(2.0)
-        mock_tracked.return_value = (
+        mock_compute.return_value = (
             jnp.stack([mode_E_f0, mode_E_f1]),
             jnp.stack([mode_H_f0, mode_H_f1]),
             jnp.array([1.5 + 0j, 1.5 + 0j], dtype=jnp.complex64),
@@ -652,27 +627,3 @@ class TestModeOverlapDetectorMultiFrequency:
         # freq-1 mode has Ex=2, Hy=2 vs Ex=1, Hy=1 for freq-0 — doubling both fields → 2x overlap
         ratio = jnp.abs(result[1]) / jnp.abs(result[0])
         assert jnp.isclose(ratio, 2.0, atol=0.01)
-
-    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
-    def test_single_frequency_returns_shape_1(
-        self, mock_tracked, simulation_config, plane_grid_slice, random_key, single_frequency
-    ):
-        """With one wave character, compute_overlap() returns shape (1,)."""
-        mock_tracked.return_value = self._mock_tracked(1)
-        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
-        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
-        det = det.apply(random_key, jnp.ones((1, 8, 8, 1), dtype=jnp.float32), 1.0)
-        state = det.init_state()
-        result = det.compute_overlap(state=state)
-        assert result.shape == (1,)
-
-    @patch("fdtdx.objects.detectors.mode.compute_modes_tracked")
-    def test_compute_overlap_without_apply_raises_multifreq(
-        self, mock_tracked, simulation_config, plane_grid_slice, random_key, two_frequencies
-    ):
-        """compute_overlap() still raises when apply() has not been called (multi-freq case)."""
-        det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
-        det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
-        state = det.init_state()
-        with pytest.raises(Exception, match="apply"):
-            det.compute_overlap(state=state)

--- a/tests/unit/objects/sources/test_mode.py
+++ b/tests/unit/objects/sources/test_mode.py
@@ -217,7 +217,7 @@ class TestModePlaneSourceApply:
         with pytest.raises(NotImplementedError):
             placed.apply(jax_key, inv_perm, 1.0)
 
-    @patch("fdtdx.objects.sources.mode.compute_mode")
+    @patch("fdtdx.objects.sources.mode.compute_mode_one_frequency")
     def test_apply_stores_inv_permittivity(self, mock_compute_mode, micro_config, jax_key):
         """Test that apply() stores inv_permittivity slice."""
         mock_E = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64)
@@ -243,7 +243,7 @@ class TestModePlaneSourceApply:
         assert applied._inv_permittivity is not None
         assert applied._inv_permittivity.shape == (1, 8, 8, 1)
 
-    @patch("fdtdx.objects.sources.mode.compute_mode")
+    @patch("fdtdx.objects.sources.mode.compute_mode_one_frequency")
     def test_apply_with_anisotropic_permeability(self, mock_compute_mode, micro_config, jax_key):
         """Test apply() with anisotropic permeability array."""
         mock_E = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64)
@@ -286,7 +286,7 @@ class TestModePlaneSourcePlot:
             placed.plot(save_path)
 
     @patch("fdtdx.objects.sources.mode.plt")
-    @patch("fdtdx.objects.sources.mode.compute_mode")
+    @patch("fdtdx.objects.sources.mode.compute_mode_one_frequency")
     def test_plot_calls_matplotlib(self, mock_compute_mode, mock_plt, mode_source, micro_config, jax_key, tmp_path):
         """Test that plot() calls matplotlib functions correctly."""
         mock_E = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64)
@@ -319,7 +319,7 @@ class TestModePlaneSourcePlot:
 class TestModePlaneSourceGetEHVariation:
     """Tests for get_EH_variation method with mocks."""
 
-    @patch("fdtdx.objects.sources.mode.compute_mode")
+    @patch("fdtdx.objects.sources.mode.compute_mode_one_frequency")
     @patch("fdtdx.objects.sources.mode.calculate_time_offset_yee")
     def test_get_EH_variation_returns_correct_shapes(self, mock_time_offset, mock_compute_mode, micro_config, jax_key):
         """Test that get_EH_variation returns arrays with correct shapes."""
@@ -353,7 +353,7 @@ class TestModePlaneSourceGetEHVariation:
         assert time_E.shape == (3, 8, 8, 1)
         assert time_H.shape == (3, 8, 8, 1)
 
-    @patch("fdtdx.objects.sources.mode.compute_mode")
+    @patch("fdtdx.objects.sources.mode.compute_mode_one_frequency")
     @patch("fdtdx.objects.sources.mode.calculate_time_offset_yee")
     def test_get_EH_variation_calls_compute_mode(self, mock_time_offset, mock_compute_mode, micro_config, jax_key):
         """Test that get_EH_variation calls compute_mode with correct args."""
@@ -390,7 +390,7 @@ class TestModePlaneSourceGetEHVariation:
         assert call_kwargs["filter_pol"] == "te"
         assert call_kwargs["direction"] == "-"
 
-    @patch("fdtdx.objects.sources.mode.compute_mode")
+    @patch("fdtdx.objects.sources.mode.compute_mode_one_frequency")
     @patch("fdtdx.objects.sources.mode.calculate_time_offset_yee")
     def test_nonuniform_grid_passes_mode_and_time_coordinates(self, mock_time_offset, mock_compute_mode, jax_key):
         """Non-uniform mode sources pass local edge coordinates to both mode helpers."""

--- a/tests/unit/objects/sources/test_mode.py
+++ b/tests/unit/objects/sources/test_mode.py
@@ -217,12 +217,12 @@ class TestModePlaneSourceApply:
         with pytest.raises(NotImplementedError):
             placed.apply(jax_key, inv_perm, 1.0)
 
-    @patch("fdtdx.objects.sources.mode.compute_mode_one_frequency")
+    @patch("fdtdx.objects.sources.mode.compute_mode")
     def test_apply_stores_inv_permittivity(self, mock_compute_mode, micro_config, jax_key):
         """Test that apply() stores inv_permittivity slice."""
-        mock_E = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64)
-        mock_H = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64)
-        mock_neff = jnp.array(1.5 + 0j, dtype=jnp.complex64)
+        mock_E = jnp.ones((1, 3, 8, 8, 1), dtype=jnp.complex64)
+        mock_H = jnp.ones((1, 3, 8, 8, 1), dtype=jnp.complex64)
+        mock_neff = jnp.array([1.5 + 0j], dtype=jnp.complex64)
         mock_compute_mode.return_value = (mock_E, mock_H, mock_neff)
 
         source = ModePlaneSource(
@@ -243,12 +243,12 @@ class TestModePlaneSourceApply:
         assert applied._inv_permittivity is not None
         assert applied._inv_permittivity.shape == (1, 8, 8, 1)
 
-    @patch("fdtdx.objects.sources.mode.compute_mode_one_frequency")
+    @patch("fdtdx.objects.sources.mode.compute_mode")
     def test_apply_with_anisotropic_permeability(self, mock_compute_mode, micro_config, jax_key):
         """Test apply() with anisotropic permeability array."""
-        mock_E = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64)
-        mock_H = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64)
-        mock_neff = jnp.array(1.5 + 0j, dtype=jnp.complex64)
+        mock_E = jnp.ones((1, 3, 8, 8, 1), dtype=jnp.complex64)
+        mock_H = jnp.ones((1, 3, 8, 8, 1), dtype=jnp.complex64)
+        mock_neff = jnp.array([1.5 + 0j], dtype=jnp.complex64)
         mock_compute_mode.return_value = (mock_E, mock_H, mock_neff)
 
         source = ModePlaneSource(
@@ -286,12 +286,12 @@ class TestModePlaneSourcePlot:
             placed.plot(save_path)
 
     @patch("fdtdx.objects.sources.mode.plt")
-    @patch("fdtdx.objects.sources.mode.compute_mode_one_frequency")
+    @patch("fdtdx.objects.sources.mode.compute_mode")
     def test_plot_calls_matplotlib(self, mock_compute_mode, mock_plt, mode_source, micro_config, jax_key, tmp_path):
         """Test that plot() calls matplotlib functions correctly."""
-        mock_E = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64)
-        mock_H = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64)
-        mock_neff = jnp.array(1.5 + 0j, dtype=jnp.complex64)
+        mock_E = jnp.ones((1, 3, 8, 8, 1), dtype=jnp.complex64)
+        mock_H = jnp.ones((1, 3, 8, 8, 1), dtype=jnp.complex64)
+        mock_neff = jnp.array([1.5 + 0j], dtype=jnp.complex64)
         mock_compute_mode.return_value = (mock_E, mock_H, mock_neff)
 
         mock_fig = MagicMock()
@@ -319,13 +319,13 @@ class TestModePlaneSourcePlot:
 class TestModePlaneSourceGetEHVariation:
     """Tests for get_EH_variation method with mocks."""
 
-    @patch("fdtdx.objects.sources.mode.compute_mode_one_frequency")
+    @patch("fdtdx.objects.sources.mode.compute_mode")
     @patch("fdtdx.objects.sources.mode.calculate_time_offset_yee")
     def test_get_EH_variation_returns_correct_shapes(self, mock_time_offset, mock_compute_mode, micro_config, jax_key):
         """Test that get_EH_variation returns arrays with correct shapes."""
-        mock_E = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64) * 2.0
-        mock_H = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64) * 0.5
-        mock_neff = jnp.array(1.5 + 0j, dtype=jnp.complex64)
+        mock_E = jnp.ones((1, 3, 8, 8, 1), dtype=jnp.complex64) * 2.0
+        mock_H = jnp.ones((1, 3, 8, 8, 1), dtype=jnp.complex64) * 0.5
+        mock_neff = jnp.array([1.5 + 0j], dtype=jnp.complex64)
         mock_compute_mode.return_value = (mock_E, mock_H, mock_neff)
 
         mock_time_offset.return_value = (
@@ -353,13 +353,13 @@ class TestModePlaneSourceGetEHVariation:
         assert time_E.shape == (3, 8, 8, 1)
         assert time_H.shape == (3, 8, 8, 1)
 
-    @patch("fdtdx.objects.sources.mode.compute_mode_one_frequency")
+    @patch("fdtdx.objects.sources.mode.compute_mode")
     @patch("fdtdx.objects.sources.mode.calculate_time_offset_yee")
     def test_get_EH_variation_calls_compute_mode(self, mock_time_offset, mock_compute_mode, micro_config, jax_key):
         """Test that get_EH_variation calls compute_mode with correct args."""
-        mock_E = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64)
-        mock_H = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64)
-        mock_neff = jnp.array(1.5 + 0j, dtype=jnp.complex64)
+        mock_E = jnp.ones((1, 3, 8, 8, 1), dtype=jnp.complex64)
+        mock_H = jnp.ones((1, 3, 8, 8, 1), dtype=jnp.complex64)
+        mock_neff = jnp.array([1.5 + 0j], dtype=jnp.complex64)
         mock_compute_mode.return_value = (mock_E, mock_H, mock_neff)
 
         mock_time_offset.return_value = (
@@ -390,7 +390,7 @@ class TestModePlaneSourceGetEHVariation:
         assert call_kwargs["filter_pol"] == "te"
         assert call_kwargs["direction"] == "-"
 
-    @patch("fdtdx.objects.sources.mode.compute_mode_one_frequency")
+    @patch("fdtdx.objects.sources.mode.compute_mode")
     @patch("fdtdx.objects.sources.mode.calculate_time_offset_yee")
     def test_nonuniform_grid_passes_mode_and_time_coordinates(self, mock_time_offset, mock_compute_mode, jax_key):
         """Non-uniform mode sources pass local edge coordinates to both mode helpers."""
@@ -401,9 +401,9 @@ class TestModePlaneSourceGetEHVariation:
         )
         config = SimulationConfig(time=1e-8, grid=grid, backend="cpu", dtype=jnp.float32)
         mock_compute_mode.return_value = (
-            jnp.ones((3, 3, 2, 1), dtype=jnp.complex64),
-            jnp.ones((3, 3, 2, 1), dtype=jnp.complex64),
-            jnp.array(1.5 + 0j, dtype=jnp.complex64),
+            jnp.ones((1, 3, 3, 2, 1), dtype=jnp.complex64),
+            jnp.ones((1, 3, 3, 2, 1), dtype=jnp.complex64),
+            jnp.array([1.5 + 0j], dtype=jnp.complex64),
         )
         mock_time_offset.return_value = (
             jnp.zeros((3, 3, 2, 1)),


### PR DESCRIPTION
WIP

Addresses https://github.com/ymahlau/fdtdx/issues/330

### Motivation

ModeOverlapDetector previously only accepted a single WaveCharacter, requiring one FDTD run per wavelength for broadband S-parameter sweeps. This PR adds multi-frequency support so all wavelengths are solved and accumulated in a single run. Along the way, it fixes two independent correctness bugs found during review: a wrong normalization convention in bidirectional_mode_overlap and a silent area swap in RectilinearGrid.yee_face_areas for y-propagating modes on non-uniform grids.

### Implementation choices

TODO