### PR TITLE
Revert "prevent TracerArrayConversionError in mode solver under jax.jit"

### DIFF
--- a/src/fdtdx/core/grid.py
+++ b/src/fdtdx/core/grid.py
@@ -145,9 +145,6 @@ class RectilinearGrid(TreeClass):
     _min_spacings: tuple[float, float, float] = frozen_private_field()
     _is_uniform: bool = frozen_private_field()
     _uniform_spacing: float | None = frozen_private_field()
-    _x_edges_tuple: tuple[float, ...] = frozen_private_field()
-    _y_edges_tuple: tuple[float, ...] = frozen_private_field()
-    _z_edges_tuple: tuple[float, ...] = frozen_private_field()
 
     def __post_init__(self):
         object.__setattr__(self, "x_edges", jnp.asarray(self.x_edges))
@@ -168,9 +165,6 @@ class RectilinearGrid(TreeClass):
         object.__setattr__(self, "_min_spacings", min_spacings)
         object.__setattr__(self, "_is_uniform", is_uniform)
         object.__setattr__(self, "_uniform_spacing", float(np.round(spacing, decimals=14)) if is_uniform else None)
-        object.__setattr__(self, "_x_edges_tuple", tuple(edge_arrays_np[0].tolist()))
-        object.__setattr__(self, "_y_edges_tuple", tuple(edge_arrays_np[1].tolist()))
-        object.__setattr__(self, "_z_edges_tuple", tuple(edge_arrays_np[2].tolist()))
 
     @classmethod
     def uniform(cls, shape: tuple[int, int, int], spacing: float, origin: tuple[float, float, float] = (0, 0, 0)):
@@ -279,16 +273,6 @@ class RectilinearGrid(TreeClass):
     def edges(self, axis: int) -> jax.Array:
         """Return edge coordinates for ``axis``."""
         return (self.x_edges, self.y_edges, self.z_edges)[axis]
-
-    def edges_np(self, axis: int) -> np.ndarray:
-        """Return edge coordinates for ``axis`` as a concrete numpy array.
-
-        Unlike ``edges()``, this never returns an abstract JAX tracer, because
-        the backing data is stored as a plain Python tuple (pytree auxiliary
-        data) rather than as a JAX array leaf.  Use this in non-differentiable
-        code paths (e.g. mode solvers) that require concrete values.
-        """
-        return np.asarray((self._x_edges_tuple, self._y_edges_tuple, self._z_edges_tuple)[axis])
 
     def cell_widths(self, axis: int) -> jax.Array:
         """Return cell widths for ``axis``."""
@@ -474,7 +458,7 @@ def calculate_time_offset_yee(
     effective_index: jax.Array | float | None = None,
     e_polarization: jax.Array | None = None,
     h_polarization: jax.Array | None = None,
-    coordinate_edges: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
+    coordinate_edges: tuple[jax.Array, jax.Array, jax.Array] | None = None,
     center_physical: jax.Array | None = None,
 ) -> tuple[jax.Array, jax.Array]:
     if inv_permittivities.ndim == 4:
@@ -494,8 +478,8 @@ def calculate_time_offset_yee(
     if coordinate_edges is None:
         # Build uniform coordinate edges from scalar resolution so the rest of
         # the function has one physical-space code path.
-        e = [np.arange(spatial_shape[ax] + 1, dtype=np.float32) * resolution for ax in range(3)]
-        resolved_edges: tuple[np.ndarray, np.ndarray, np.ndarray] = (e[0], e[1], e[2])
+        e = [jnp.arange(spatial_shape[ax] + 1, dtype=jnp.float32) * resolution for ax in range(3)]
+        resolved_edges: tuple[jax.Array, jax.Array, jax.Array] = (e[0], e[1], e[2])
         center_list: list = [float(center[0]) * resolution, float(center[1]) * resolution]
         center_list.insert(propagation_axis, 0.0)
         center_physical = jnp.asarray(center_list, dtype=wave_vector.dtype)
@@ -504,7 +488,7 @@ def calculate_time_offset_yee(
             raise ValueError("center_physical must be provided with coordinate_edges")
         resolved_edges = coordinate_edges
 
-    def component_positions(axis: int, offset: float) -> np.ndarray:
+    def component_positions(axis: int, offset: float) -> jax.Array:
         edges = resolved_edges[axis]
         centers = 0.5 * (edges[:-1] + edges[1:])
         if offset == 0:

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -100,7 +100,7 @@ def compute_mode(
     dtype: jnp.dtype = jnp.float32,
     bend_radius: float | None = None,
     bend_axis: int | None = None,
-    transverse_coords: Sequence[np.ndarray] | None = None,
+    transverse_coords: Sequence[ArrayLike] | None = None,
 ) -> tuple[
     jax.Array,  # E
     jax.Array,  # H

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -2,7 +2,6 @@ from typing import Literal, Self, Sequence
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 
 from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
@@ -101,15 +100,12 @@ class ModeOverlapDetector(PhasorDetector):
         """Return detector-plane face areas for mode-overlap integration."""
         return self._cached_face_area_weights
 
-    def _transverse_edge_coordinates(self) -> tuple[np.ndarray, np.ndarray] | None:
+    def _transverse_edge_coordinates(self) -> tuple[jax.Array, jax.Array] | None:
         """Return physical transverse edge coordinates for the mode solver.
 
         Tidy3D can solve modes on rectilinear non-uniform grids when supplied
         with edge-coordinate arrays.  Returning ``None`` keeps the uniform scalar
         spacing path for legacy configurations and older tests.
-
-        Returns numpy arrays (not JAX arrays) so coordinates remain concrete
-        when this method is called inside a jax.jit-traced function.
         """
         grid = self._config.resolved_grid
         if grid is None:
@@ -120,7 +116,7 @@ class ModeOverlapDetector(PhasorDetector):
             if axis == self.propagation_axis:
                 continue
             lower, upper = self.grid_slice_tuple[axis]
-            transverse_edges.append(grid.edges_np(axis)[lower : upper + 1])
+            transverse_edges.append(grid.edges(axis)[lower : upper + 1])
         return tuple(transverse_edges)
 
     def _mode_solver_resolution(self) -> float:

--- a/src/fdtdx/objects/sources/linear_polarization.py
+++ b/src/fdtdx/objects/sources/linear_polarization.py
@@ -3,7 +3,6 @@ from typing import Self
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 
 from fdtdx.core.grid import calculate_time_offset_yee
 from fdtdx.core.jax.pytrees import autoinit, frozen_field
@@ -63,16 +62,13 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
     #: whether to normalize the polarization vector
     normalize_by_energy: bool = frozen_field(default=True)
 
-    def _local_edge_coordinates(self) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    def _local_edge_coordinates(self) -> tuple[jax.Array, jax.Array, jax.Array] | None:
         """Return source-local physical edge coordinates for Yee metrics.
 
         Coordinates are shifted so the lower corner of this source slice is the
         local origin.  Uniform grids can use the legacy scalar path, but
         non-uniform grids need these explicit edge arrays for time-of-flight
         corrections and physical profile sampling.
-
-        Returns numpy arrays so coordinates remain concrete when this method is
-        called inside a jax.jit-traced function.
         """
         grid = self._config.resolved_grid
         if grid is None:
@@ -80,7 +76,7 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
         local_edges = []
         for axis in range(3):
             lower, upper = self.grid_slice_tuple[axis]
-            edges = grid.edges_np(axis)[lower : upper + 1]
+            edges = grid.edges(axis)[lower : upper + 1]
             local_edges.append(edges - edges[0])
         return tuple(local_edges)
 
@@ -163,8 +159,8 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
             assert local_edges is not None
             horizontal_edges = local_edges[self.horizontal_axis]
             vertical_edges = local_edges[self.vertical_axis]
-            horizontal_centers = jnp.asarray(0.5 * (horizontal_edges[:-1] + horizontal_edges[1:]))
-            vertical_centers = jnp.asarray(0.5 * (vertical_edges[:-1] + vertical_edges[1:]))
+            horizontal_centers = 0.5 * (horizontal_edges[:-1] + horizontal_edges[1:])
+            vertical_centers = 0.5 * (vertical_edges[:-1] + vertical_edges[1:])
             w, h = jnp.meshgrid(horizontal_centers, vertical_centers, indexing="ij")
         else:
             w, h = jnp.meshgrid(
@@ -325,8 +321,8 @@ class GaussianPlaneSource(LinearlyPolarizedPlaneSource):
             assert local_edges is not None
             horizontal_edges = local_edges[self.horizontal_axis]
             vertical_edges = local_edges[self.vertical_axis]
-            horizontal_centers = jnp.asarray(0.5 * (horizontal_edges[:-1] + horizontal_edges[1:]))
-            vertical_centers = jnp.asarray(0.5 * (vertical_edges[:-1] + vertical_edges[1:]))
+            horizontal_centers = 0.5 * (horizontal_edges[:-1] + horizontal_edges[1:])
+            vertical_centers = 0.5 * (vertical_edges[:-1] + vertical_edges[1:])
             h_grid, v_grid = jnp.meshgrid(horizontal_centers, vertical_centers, indexing="ij")
             h_center = center[0]
             v_center = center[1]

--- a/src/fdtdx/objects/sources/mode.py
+++ b/src/fdtdx/objects/sources/mode.py
@@ -3,7 +3,6 @@ from typing import Literal, Self
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 from matplotlib import pyplot as plt
 
 from fdtdx.core.grid import calculate_time_offset_yee
@@ -27,15 +26,12 @@ class ModePlaneSource(TFSFPlaneSource):
 
     _neff: jax.Array = private_field()  # not required for sim, used for inspection
 
-    def _local_edge_coordinates(self) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
-        """Return local physical edge coordinates for this source slice as numpy arrays.
+    def _local_edge_coordinates(self) -> tuple[jax.Array, jax.Array, jax.Array] | None:
+        """Return local physical edge coordinates for this source slice.
 
         Non-uniform mode sources need edge coordinates for both Tidy3D mode
         solving and Yee time offsets.  Coordinates are shifted so the source
         slice lower corner is at zero on each axis.
-
-        Returns numpy arrays (not JAX arrays) so these coordinates remain
-        concrete when this method is called inside a jax.jit-traced function.
         """
         grid = self._config.resolved_grid
         if grid is None:
@@ -44,11 +40,11 @@ class ModePlaneSource(TFSFPlaneSource):
         local_edges = []
         for axis in range(3):
             lower, upper = self.grid_slice_tuple[axis]
-            edges = grid.edges_np(axis)[lower : upper + 1]
+            edges = grid.edges(axis)[lower : upper + 1]
             local_edges.append(edges - edges[0])
         return tuple(local_edges)
 
-    def _transverse_edge_coordinates(self) -> tuple[np.ndarray, np.ndarray] | None:
+    def _transverse_edge_coordinates(self) -> tuple[jax.Array, jax.Array] | None:
         """Return local transverse edge coordinates for Tidy3D mode solving."""
         local_edges = self._local_edge_coordinates()
         if local_edges is None:

--- a/tests/unit/objects/sources/test_mode.py
+++ b/tests/unit/objects/sources/test_mode.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 import pytest
 
 from fdtdx.config import SimulationConfig
@@ -428,65 +427,6 @@ class TestModePlaneSourceGetEHVariation:
         time_kwargs = mock_time_offset.call_args.kwargs
         assert time_kwargs["coordinate_edges"] is not None
         assert jnp.allclose(time_kwargs["center_physical"], jnp.asarray([3.0, 2.5, 0.0], dtype=jnp.float32))
-
-
-class TestModePlaneSourceJitSafety:
-    """Regression tests for TracerArrayConversionError under jax.jit."""
-
-    def test_local_edge_coordinates_returns_numpy_with_rectilinear_grid(self, jax_key):
-        """_local_edge_coordinates() must return numpy arrays, not JAX arrays.
-
-        Regression: edges came from grid.edges() which returns jax.Array.  Under
-        jax.jit those become abstract tracers; passing them to compute_mode's
-        np.asarray() call raised TracerArrayConversionError.
-        """
-        grid = RectilinearGrid(
-            x_edges=jnp.asarray([0.0, 1e-6, 3e-6, 6e-6]),
-            y_edges=jnp.asarray([0.0, 2e-6, 5e-6]),
-            z_edges=jnp.asarray([0.0, 1e-6]),
-        )
-        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu", dtype=jnp.float32)
-        source = ModePlaneSource(
-            partial_grid_shape=(3, 2, 1),
-            wave_character=WaveCharacter(wavelength=1.55e-6),
-            direction="-",
-        ).place_on_grid(((0, 3), (0, 2), (0, 1)), config, jax_key)
-
-        edges = source._local_edge_coordinates()
-        assert edges is not None
-        for coord in edges:
-            assert isinstance(coord, np.ndarray), (
-                f"Expected numpy.ndarray, got {type(coord)}. "
-                "JAX arrays become abstract tracers under jax.jit and cause "
-                "TracerArrayConversionError in compute_mode."
-            )
-
-    def test_rectilinear_grid_edges_np_concrete_under_jit_tracing(self):
-        """RectilinearGrid.edges_np() must stay concrete when the grid is a JIT-traced pytree leaf.
-
-        frozen_private_field values are excluded from pytree traversal, so JAX
-        never makes them abstract.  This is the mechanism that prevents
-        TracerArrayConversionError in compute_mode.
-        """
-        grid = RectilinearGrid(
-            x_edges=jnp.asarray([0.0, 1e-6, 3e-6, 6e-6]),
-            y_edges=jnp.asarray([0.0, 2e-6, 5e-6]),
-            z_edges=jnp.asarray([0.0, 1e-6]),
-        )
-
-        captured = {}
-
-        def fn(g):
-            captured["x_np"] = g.edges_np(0)
-            captured["y_np"] = g.edges_np(1)
-            return g.x_edges + g.y_edges[0]
-
-        jax.make_jaxpr(fn)(grid)
-
-        for key in ("x_np", "y_np"):
-            assert isinstance(captured[key], np.ndarray), (
-                f"edges_np({key}) must be numpy.ndarray under tracing, got {type(captured[key])}"
-            )
 
 
 class TestModePlaneSourceProperties:


### PR DESCRIPTION
Reverts ymahlau/fdtdx#331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `RectilinearGrid.edges_np()` convenience method.
  * Updated coordinate function signatures to use JAX arrays instead of NumPy arrays across grid and source modules.

* **Internal Improvements**
  * Grid coordinate handling now consistently uses JAX arrays internally instead of cached NumPy tuples.
  * Removed redundant array conversion dependencies from multiple source and detector modules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ymahlau/fdtdx/pull/337)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->