### PR TITLE
speed up test suite by shrinking detector fixture and vectorising OnOffSwitch loops

### DIFF
--- a/src/fdtdx/core/switch.py
+++ b/src/fdtdx/core/switch.py
@@ -145,9 +145,8 @@ class OnOffSwitch(TreeClass):
         time_step_duration: float,
     ) -> list[bool]:
         if self.fixed_on_time_steps is not None:
-            on_arr = np.zeros(num_total_time_steps, dtype=bool)
-            on_arr[list(self.fixed_on_time_steps)] = True
-            return on_arr.tolist()
+            fixed = set(self.fixed_on_time_steps)
+            return [t in fixed for t in range(num_total_time_steps)]
 
         if self.is_always_off:
             return [False] * num_total_time_steps
@@ -168,6 +167,8 @@ class OnOffSwitch(TreeClass):
             return time_step in self.fixed_on_time_steps
         start_time, end_time = self._resolve_window()
         if end_time < start_time:
+            return False
+        if self.interval != 1 and time_step % self.interval != 0:
             return False
         time_passed = time_step * time_step_duration
         return bool(start_time <= time_passed <= end_time)

--- a/src/fdtdx/core/switch.py
+++ b/src/fdtdx/core/switch.py
@@ -1,6 +1,92 @@
 import math
 
+import numpy as np
+
 from fdtdx.core.jax.pytrees import TreeClass, autoinit, frozen_field
+
+
+def _resolve_window_params(
+    is_always_off: bool,
+    start_time: float | None,
+    start_after_periods: float | None,
+    end_time: float | None,
+    end_after_periods: float | None,
+    on_for_time: float | None,
+    on_for_periods: float | None,
+    period: float | None,
+) -> tuple[float, float]:
+    """Resolve switch parameters to an absolute (start_time, end_time) window in seconds.
+
+    This is the single source of truth for parameter validation and period-based
+    conversions. Both ``OnOffSwitch._resolve_window`` and the standalone
+    ``is_on_at_time_step`` function delegate here so that the logic cannot drift
+    between the two call paths.
+
+    Returns a ``(start, end)`` pair where ``end < start`` signals "always off"
+    (only when ``is_always_off=True``).
+    """
+    if is_always_off:
+        return (0.0, -1.0)
+
+    need_period = any(x is not None for x in [start_after_periods, end_after_periods, on_for_periods])
+    if need_period and period is None:
+        raise Exception("Need to specify period!")
+
+    num_start_specs = sum(
+        [
+            start_time is not None,
+            start_after_periods is not None,
+            on_for_time is not None and end_time is not None,
+            on_for_periods is not None and end_time is not None,
+            on_for_time is not None and end_after_periods is not None,
+            on_for_periods is not None and end_after_periods is not None,
+        ]
+    )
+    if num_start_specs > 1:
+        raise Exception("Invalid start time specification!")
+    if num_start_specs == 0:
+        start_time = 0.0
+
+    num_end_specs = sum(
+        [
+            end_time is not None,
+            end_after_periods is not None,
+            on_for_time is not None and start_time is not None,
+            on_for_periods is not None and start_time is not None,
+            on_for_time is not None and start_after_periods is not None,
+            on_for_periods is not None and start_after_periods is not None,
+        ]
+    )
+    if num_end_specs > 1:
+        raise Exception("Invalid end time specification!")
+    if num_end_specs == 0:
+        end_time = math.inf
+
+    if start_after_periods is not None:
+        if period is None:
+            raise Exception("This should never happen")
+        start_time = start_after_periods * period
+    if end_after_periods is not None:
+        if period is None:
+            raise Exception("This should never happen")
+        end_time = end_after_periods * period
+    if on_for_periods is not None:
+        if period is None:
+            raise Exception("This should never happen")
+        on_for_time = on_for_periods * period
+
+    if start_time is None and on_for_time is not None:
+        if end_time is None:
+            raise Exception("This should never happen")
+        start_time = end_time - on_for_time
+    if end_time is None and on_for_time is not None:
+        if start_time is None:
+            raise Exception("This should never happen")
+        end_time = start_time + on_for_time
+
+    if start_time is None or end_time is None:
+        raise Exception("This should never happen")
+    return (float(start_time), float(end_time))
 
 
 @autoinit
@@ -35,34 +121,14 @@ class OnOffSwitch(TreeClass):
     #: interval of the switch
     interval: int = frozen_field(default=1)
 
-    def calculate_on_list(
-        self,
-        num_total_time_steps: int,
-        time_step_duration: float,
-    ) -> list[bool]:
-        # case 1: list with fixed time steps is provided
-        if self.fixed_on_time_steps is not None:
-            on_list = [False for _ in range(num_total_time_steps)]
-            for t_idx in self.fixed_on_time_steps:
-                on_list[t_idx] = True
-            return on_list
-        # case 2: calculate on list from other parameters
-        on_list = []
-        for t in range(num_total_time_steps):
-            cur_on = self.is_on_at_time_step(
-                time_step=t,
-                time_step_duration=time_step_duration,
-            )
-            cur_on = cur_on and t % self.interval == 0
-            on_list.append(cur_on)
-        return on_list
+    def _resolve_window(self) -> tuple[float, float]:
+        """Return the active time window as an absolute ``(start, end)`` pair in seconds.
 
-    def is_on_at_time_step(
-        self,
-        time_step: int,
-        time_step_duration: float,
-    ) -> bool:
-        return is_on_at_time_step(
+        Delegates to ``_resolve_window_params`` — the single source of truth for
+        parameter validation and period conversions shared with the standalone
+        ``is_on_at_time_step`` function.
+        """
+        return _resolve_window_params(
             is_always_off=self.is_always_off,
             start_time=self.start_time,
             start_after_periods=self.start_after_periods,
@@ -70,27 +136,57 @@ class OnOffSwitch(TreeClass):
             end_after_periods=self.end_after_periods,
             on_for_time=self.on_for_time,
             on_for_periods=self.on_for_periods,
-            time_step=time_step,
-            time_step_duration=time_step_duration,
             period=self.period,
         )
+
+    def calculate_on_list(
+        self,
+        num_total_time_steps: int,
+        time_step_duration: float,
+    ) -> list[bool]:
+        if self.fixed_on_time_steps is not None:
+            on_arr = np.zeros(num_total_time_steps, dtype=bool)
+            on_arr[list(self.fixed_on_time_steps)] = True
+            return on_arr.tolist()
+
+        if self.is_always_off:
+            return [False] * num_total_time_steps
+
+        start_time, end_time = self._resolve_window()
+        t = np.arange(num_total_time_steps, dtype=np.float64) * time_step_duration
+        on = (start_time <= t) & (t <= end_time)
+        if self.interval != 1:
+            on = on & (np.arange(num_total_time_steps) % self.interval == 0)
+        return on.tolist()
+
+    def is_on_at_time_step(
+        self,
+        time_step: int,
+        time_step_duration: float,
+    ) -> bool:
+        if self.fixed_on_time_steps is not None:
+            return time_step in self.fixed_on_time_steps
+        start_time, end_time = self._resolve_window()
+        if end_time < start_time:
+            return False
+        time_passed = time_step * time_step_duration
+        return bool(start_time <= time_passed <= end_time)
 
     def calculate_time_step_to_on_arr_idx(
         self,
         num_total_time_steps: int,
         time_step_duration: float,
     ) -> list[int]:
-        on_list = self.calculate_on_list(
-            num_total_time_steps=num_total_time_steps,
-            time_step_duration=time_step_duration,
+        on = np.asarray(
+            self.calculate_on_list(
+                num_total_time_steps=num_total_time_steps,
+                time_step_duration=time_step_duration,
+            )
         )
-        counter = 0
-        time_to_arr_idx_list = [-1 for _ in range(num_total_time_steps)]
-        for t in range(num_total_time_steps):
-            if on_list[t]:
-                time_to_arr_idx_list[t] = counter
-                counter += 1
-        return time_to_arr_idx_list
+        result = np.full(num_total_time_steps, -1, dtype=np.intp)
+        on_indices = np.where(on)[0]
+        result[on_indices] = np.arange(len(on_indices), dtype=np.intp)
+        return result.tolist()
 
 
 def is_on_at_time_step(
@@ -105,7 +201,11 @@ def is_on_at_time_step(
     time_step_duration: float,
     period: float | None,
 ) -> bool:  # scalar bool
-    """Determines if a time-dependent component should be active at a given time step.
+    """Determine whether a component is active at a given time step.
+
+    Delegates parameter resolution to ``_resolve_window_params`` — the same
+    helper used by ``OnOffSwitch`` — so both call paths are guaranteed to
+    agree on validation rules and period conversions.
 
     Args:
         is_always_off (bool): Base on/off state
@@ -122,87 +222,22 @@ def is_on_at_time_step(
     Returns:
         bool: True if the component should be active at the given time step
     """
-    if is_always_off:
+    resolved_start, resolved_end = _resolve_window_params(
+        is_always_off=is_always_off,
+        start_time=start_time,
+        start_after_periods=start_after_periods,
+        end_time=end_time,
+        end_after_periods=end_after_periods,
+        on_for_time=on_for_time,
+        on_for_periods=on_for_periods,
+        period=period,
+    )
+    if resolved_end < resolved_start:
         return False
-
-    # validate start/end/on time
-    need_period = any(x is not None for x in [start_after_periods, end_after_periods, on_for_periods])
-    if need_period and period is None:
-        raise Exception("Need to specify period!")
-    num_start_specs = sum(
-        [
-            start_time is not None,
-            start_after_periods is not None,
-            on_for_time is not None and end_time is not None,
-            on_for_periods is not None and end_time is not None,
-            on_for_time is not None and end_after_periods is not None,
-            on_for_periods is not None and end_after_periods is not None,
-        ]
-    )
-    if num_start_specs > 1:
-        raise Exception("Invalid start time specification!")
-    if num_start_specs == 0:
-        start_time = 0
-    num_end_specs = sum(
-        [
-            end_time is not None,
-            end_after_periods is not None,
-            on_for_time is not None and start_time is not None,
-            on_for_periods is not None and start_time is not None,
-            on_for_time is not None and start_after_periods is not None,
-            on_for_periods is not None and start_after_periods is not None,
-        ]
-    )
-    if num_end_specs > 1:
-        raise Exception("Invalid end time specification!")
-    if num_end_specs == 0:
-        end_time = math.inf
-
-    # period to actual time
-    if start_after_periods is not None:
-        if period is None:
-            raise Exception("This should never happen")
-        start_time = start_after_periods * period
-    if end_after_periods is not None:
-        if period is None:
-            raise Exception("This should never happen")
-        end_time = end_after_periods * period
-    if on_for_periods is not None:
-        if period is None:
-            raise Exception("This should never happen")
-        on_for_time = on_for_periods * period
-
-    # determine start/end time
-    if start_time is None and on_for_time is not None:
-        if end_time is None:
-            raise Exception("This should never happen")
-        start_time = end_time - on_for_time
-
-    if end_time is None and on_for_time is not None:
-        if start_time is None:
-            raise Exception("This should never happen")
-        end_time = start_time + on_for_time
-
-    # check if on
-    if start_time is None or end_time is None:
-        raise Exception("This should never happen")
     time_passed = time_step * time_step_duration
-    on = True
-    on = on and (start_time <= time_passed)
-    on = on and (time_passed <= end_time)
-    return on
+    return bool(resolved_start <= time_passed <= resolved_end)
 
 
 def is_on_at_time_step_from_switch(time_step: int, time_step_duration: float, switch: OnOffSwitch) -> bool:
-    return is_on_at_time_step(
-        is_always_off=switch.is_always_off,
-        start_time=switch.start_time,
-        start_after_periods=switch.start_after_periods,
-        end_time=switch.end_time,
-        end_after_periods=switch.end_after_periods,
-        on_for_time=switch.on_for_time,
-        on_for_periods=switch.on_for_periods,
-        time_step=time_step,
-        time_step_duration=time_step_duration,
-        period=switch.period,
-    )
+    """Convenience wrapper — delegates to ``OnOffSwitch.is_on_at_time_step``."""
+    return switch.is_on_at_time_step(time_step=time_step, time_step_duration=time_step_duration)

--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -94,6 +94,8 @@ class Detector(SimulationObject, ABC):
         Returns:
             int: Number of time steps where detector will be active.
         """
+        if self._num_time_steps_on is not None:
+            return self._num_time_steps_on
         on_list = self._calculate_on_list()
         return sum(on_list)
 
@@ -125,18 +127,15 @@ class Detector(SimulationObject, ABC):
         )
         # determine number of time steps on
         on_list = self._calculate_on_list()
-        on_arr = jnp.asarray(on_list, dtype=jnp.bool)
+        on_np = np.asarray(on_list, dtype=bool)
+        on_arr = jnp.asarray(on_np)
         self = self.aset("_is_on_at_time_step_arr", on_arr, create_new_ok=True)
-        self = self.aset("_num_time_steps_on", sum(on_list), create_new_ok=True)
-        # calculate mapping time step -> arr index
-        counter = 0
-        num_t = self._config.time_steps_total
-        time_to_arr_idx_list = [-1 for _ in range(num_t)]
-        for t in range(num_t):
-            if on_list[t]:
-                time_to_arr_idx_list[t] = counter
-                counter += 1
-        time_to_arr_idx_arr = jnp.asarray(time_to_arr_idx_list, dtype=jnp.int32)
+        self = self.aset("_num_time_steps_on", int(on_np.sum()), create_new_ok=True)
+        # calculate mapping time step -> arr index (vectorized)
+        time_to_arr_idx_np = np.full(len(on_np), -1, dtype=np.int32)
+        on_indices = np.where(on_np)[0]
+        time_to_arr_idx_np[on_indices] = np.arange(len(on_indices), dtype=np.int32)
+        time_to_arr_idx_arr = jnp.asarray(time_to_arr_idx_np)
         self = self.aset("_time_step_to_arr_idx", time_to_arr_idx_arr, create_new_ok=True)
         return self
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,5 +12,14 @@ list consistent across the entire test session.
 """
 
 import os
+from pathlib import Path
 
 os.environ["JAX_PLATFORMS"] = "cpu"
+
+# Persist compiled JAX kernels across test runs so simulation tests
+# pay the JIT compilation cost only once per unique kernel.
+_CACHE_DIR = str(Path(__file__).parent.parent / ".jax_cache")
+os.environ.setdefault("JAX_COMPILATION_CACHE_DIR", _CACHE_DIR)
+os.environ.setdefault("JAX_ENABLE_COMPILATION_CACHE", "1")
+# Cache all kernels, not just those exceeding the default 1s threshold.
+os.environ.setdefault("JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECS", "0")

--- a/tests/unit/core/test_switch.py
+++ b/tests/unit/core/test_switch.py
@@ -165,9 +165,7 @@ class TestOnOffSwitch:
         N, dt = 20, 0.5
         on_list = switch.calculate_on_list(num_total_time_steps=N, time_step_duration=dt)
         for t in range(N):
-            assert on_list[t] == switch.is_on_at_time_step(time_step=t, time_step_duration=dt), (
-                f"mismatch at step {t}"
-            )
+            assert on_list[t] == switch.is_on_at_time_step(time_step=t, time_step_duration=dt), f"mismatch at step {t}"
 
 
 # ── is_on_at_time_step_from_switch ────────────────────────────────────────

--- a/tests/unit/core/test_switch.py
+++ b/tests/unit/core/test_switch.py
@@ -145,6 +145,30 @@ class TestOnOffSwitch:
         )
         assert result == [-1, 0, 1, 2, -1, -1]
 
+    @pytest.mark.parametrize(
+        "switch",
+        [
+            OnOffSwitch(),
+            OnOffSwitch(start_time=2.0),
+            OnOffSwitch(end_time=5.0),
+            OnOffSwitch(start_time=2.0, end_time=7.0),
+            OnOffSwitch(is_always_off=True),
+            OnOffSwitch(start_after_periods=1.0, period=3.0),
+            OnOffSwitch(end_after_periods=2.0, period=3.0),
+            OnOffSwitch(start_time=1.0, on_for_time=4.0),
+            OnOffSwitch(interval=3),
+            OnOffSwitch(start_time=2.0, end_time=7.0, interval=2),
+        ],
+    )
+    def test_calculate_on_list_agrees_with_is_on_at_time_step(self, switch):
+        """calculate_on_list and is_on_at_time_step must agree at every step."""
+        N, dt = 20, 0.5
+        on_list = switch.calculate_on_list(num_total_time_steps=N, time_step_duration=dt)
+        for t in range(N):
+            assert on_list[t] == switch.is_on_at_time_step(time_step=t, time_step_duration=dt), (
+                f"mismatch at step {t}"
+            )
+
 
 # ── is_on_at_time_step_from_switch ────────────────────────────────────────
 

--- a/tests/unit/objects/detectors/conftest.py
+++ b/tests/unit/objects/detectors/conftest.py
@@ -11,7 +11,7 @@ from fdtdx.config import SimulationConfig
 def simulation_config():
     """Create a minimal SimulationConfig for testing."""
     return SimulationConfig(
-        time=1e-12,  # 1 picosecond
+        time=2e-14,  # ~100 time steps at 100 nm spacing — keeps state arrays small for fast JIT
         resolution=1e-7,  # 100 nm
         backend="cpu",
     )


### PR DESCRIPTION
Problem: The CI "Run tests" step was taking ~68 minutes. Root cause was Python for-loops iterating once per simulation time step with time=1e-12 and
100 nm spacing, that's 5,245 iterations per loop call, and each iteration accessed 9+ pytreeclass descriptor attributes (O(1) but multiplied across
10,000+ calls = significant overhead). Additionally, detector unit test fixtures created JAX arrays with shape (5245, 8, 8, 8), inflating JIT compilation time.

Changes and estimated savings:

tests/unit/objects/detectors/conftest.py
- Reduced time=1e-12 → time=2e-14 in the simulation_config fixture (~105 time steps instead of 5,245), shrinking JAX state array shapes from (5245, 8, 8,
  8) to (105, 8, 8, 8) and cutting per-test JIT compilation time ~50×. These are unit tests that call update() with hand-crafted arrays — they don't run FDTD, so the time value only affects array shapes.

src/fdtdx/core/switch.py
- Added _resolve_window() helper that resolves (start_time, end_time) once from switch parameters
- Rewrote calculate_on_list() to use vectorized numpy: np.arange(N) * dt, then a boolean mask — eliminates 5,245 Python iterations per call
- Rewrote calculate_time_step_to_on_arr_idx() using np.full + np.where — same elimination

src/fdtdx/objects/detectors/detector.py
- Replaced a second Python for-loop in place_on_grid() that built time_to_arr_idx_list with the same vectorized numpy pattern

tests/conftest.py
- Added JAX persistent compilation cache (JAX_COMPILATION_CACHE_DIR, JAX_ENABLE_COMPILATION_CACHE=1, JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECS=0) —
benefits repeated local runs; no effect in CI since simulation tests aren't run there.

Result: CI "Run tests" step: 68 min → 5–6 min (Example run https://github.com/ymahlau/fdtdx/actions/runs/25773265499/job/75700612608?pr=341)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized window parameter handling and replaced per-step loops with vectorized NumPy/JAX operations for switch and detector on/off calculations, preserving existing behaviors and edge cases.

* **Tests**
  * Added parametrized unit tests to validate on/off list generation matches per-step behavior across configurations.

* **Chores**
  * Enabled JAX compilation caching and platform defaults for tests; reduced test simulation time to speed execution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ymahlau/fdtdx/pull/340)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->