### PR TITLE
Re-apply rectilinear grid support (#312) with JAX-native edge coordinates and test fixes

### DIFF
--- a/checks/check_waveguide_modes.py
+++ b/checks/check_waveguide_modes.py
@@ -8,6 +8,7 @@ from fdtdx import (
     WaveCharacter,
     Material,
     SimulationConfig,
+    UniformGrid,
     constants,
     ArrayContainer, 
     ParameterContainer, 
@@ -42,7 +43,7 @@ def main():
 
     config = SimulationConfig(
         time=50e-15,
-        resolution=20e-9,
+        grid=UniformGrid(spacing=20e-9),
         dtype=jnp.float32,
         courant_factor=0.99,
     )

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -79,4 +79,3 @@ If you find this repository helpful for your work, please consider citing:
    05_contributing
    06_faq
    07_api
-

--- a/examples/bloch_band_structure.py
+++ b/examples/bloch_band_structure.py
@@ -90,7 +90,7 @@ def run_bloch_k(k_norm: float, key: jax.Array) -> tuple[np.ndarray, np.ndarray]:
     # Forward-only simulation; complex fields auto-promoted for non-zero Bloch k.
     config = fdtdx.SimulationConfig(
         time=SIM_TIME,
-        resolution=RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=RESOLUTION),
         dtype=jnp.float32,
         courant_factor=0.99,
     )

--- a/examples/dispersive_gaussian_pulse.py
+++ b/examples/dispersive_gaussian_pulse.py
@@ -95,7 +95,7 @@ def nondispersive_silicon_material() -> fdtdx.Material:
 
 def build_scene(dispersive: bool):
     config = fdtdx.SimulationConfig(
-        resolution=RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=RESOLUTION),
         time=SIM_TIME,
         dtype=jnp.float32,
         courant_factor=0.99,

--- a/examples/optimize_ceviche_corner.py
+++ b/examples/optimize_ceviche_corner.py
@@ -44,7 +44,7 @@ def main(
     # Define simulation configuration (time, resolution, data type, etc.)
     config = fdtdx.SimulationConfig(
         time=50e-15,
-        resolution=20e-9,
+        grid=fdtdx.UniformGrid(spacing=20e-9),
         dtype=jnp.float32,
         courant_factor=0.99,
     )

--- a/examples/simulate_gaussian_source.py
+++ b/examples/simulate_gaussian_source.py
@@ -34,7 +34,7 @@ def main():
     # Define simulation configuration (duration, resolution, data type, etc.)
     config = fdtdx.SimulationConfig(
         time=100e-15,
-        resolution=100e-9,
+        grid=fdtdx.UniformGrid(spacing=100e-9),
         dtype=jnp.float32,
         courant_factor=0.99,
     )

--- a/examples/simulate_gaussian_source_anisotropic.py
+++ b/examples/simulate_gaussian_source_anisotropic.py
@@ -34,7 +34,7 @@ def main():
     # Define simulation configuration (duration, resolution, data type, etc.)
     config = fdtdx.SimulationConfig(
         time=100e-15,
-        resolution=100e-9,
+        grid=fdtdx.UniformGrid(spacing=100e-9),
         dtype=jnp.float32,
         courant_factor=0.99,
     )

--- a/examples/simulate_gaussian_source_fully_anisotropic.py
+++ b/examples/simulate_gaussian_source_fully_anisotropic.py
@@ -34,7 +34,7 @@ def main():
     # Define simulation configuration (duration, resolution, data type, etc.)
     config = fdtdx.SimulationConfig(
         time=100e-15,
-        resolution=100e-9,
+        grid=fdtdx.UniformGrid(spacing=100e-9),
         dtype=jnp.float32,
         courant_factor=0.99,
     )

--- a/examples/width_sweep_analysis.py
+++ b/examples/width_sweep_analysis.py
@@ -29,7 +29,7 @@ def compute_modes_and_neff_complex(arrays, object):
         inv_permittivities = jax.lax.stop_gradient(
             1./(
                 1./arrays.inv_permittivities + \
-                1j * arrays.electric_conductivity / object._config.resolution / (2 * jnp.pi * object.wave_characters[0].get_frequency() * fdtdx.constants.eps0)
+                1j * arrays.electric_conductivity / object._config.uniform_spacing() / (2 * jnp.pi * object.wave_characters[0].get_frequency() * fdtdx.constants.eps0)
             )
         )
     else:
@@ -45,7 +45,7 @@ def compute_modes_and_neff_complex(arrays, object):
         frequency          = object.wave_characters[0].get_frequency(),
         inv_permittivities = inv_permittivity_slice,
         inv_permeabilities = inv_permeability_slice,
-        resolution         = object._config.resolution,
+        resolution         = object._config.uniform_spacing(),
         direction          = object.direction,
         mode_index         = object.mode_index,
         filter_pol         = object.filter_pol,
@@ -200,7 +200,7 @@ def make_waveguide_simulation(wavelength, mesh, width, height, absorber_thicknes
 
     # Define simulation configuration
     config = fdtdx.SimulationConfig(
-        resolution=resolution,
+        grid=fdtdx.UniformGrid(spacing=resolution),
         time=time,
         courant_factor=courant_factor,
     )

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -15,7 +15,8 @@ from fdtdx.config import GradientConfig, SimulationConfig
 from fdtdx.constants import wavelength_to_period
 from fdtdx.conversion.json import export_json, export_json_str, import_from_json
 from fdtdx.conversion.stl import export_stl
-from fdtdx.conversion.vti import export_arrays_snapshot_to_vti, export_vti
+from fdtdx.conversion.vti import export_arrays_snapshot_to_vti, export_vti, export_vtr
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.core.jax.pytrees import (
     TreeClass,
     autoinit,
@@ -183,6 +184,7 @@ __all__ = [
     "RealCoordinateConstraint",
     "Recorder",
     "RecordingState",
+    "RectilinearGrid",
     "RemoveFloatingMaterial",
     "SimulationConfig",
     "SimulationObject",
@@ -199,6 +201,7 @@ __all__ = [
     "TanhProjection",
     "TemporalProfile",
     "TreeClass",
+    "UniformGrid",
     "UniformMaterialObject",
     "UniformPlaneSource",
     "VerticalSymmetry2D",
@@ -222,6 +225,7 @@ __all__ = [
     "export_json_str",
     "export_stl",
     "export_vti",
+    "export_vtr",
     "extend_material_to_pml",
     "extruded_polygon_from_gds",
     "extruded_polygon_from_gds_path",

--- a/src/fdtdx/config.py
+++ b/src/fdtdx/config.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 from loguru import logger
 
 from fdtdx import constants
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.core.jax.pytrees import TreeClass, autoinit, field, frozen_field
 from fdtdx.interfaces.recorder import Recorder
 from fdtdx.typing import BackendOption
@@ -51,8 +52,13 @@ class SimulationConfig(TreeClass):
     #: Total simulation time in seconds.
     time: float = frozen_field()
 
-    #: Spatial resolution of the simulation grid in meters.
-    resolution: float = frozen_field()
+    #: Spatial grid configuration.
+    #:
+    #: ``UniformGrid`` is an unresolved policy used while the final volume shape
+    #: is still being inferred.  ``RectilinearGrid`` is the realized solver grid
+    #: with explicit physical edge coordinates.  Placement resolves policies to
+    #: ``RectilinearGrid`` so compiled FDTD code has exactly one metric source.
+    grid: UniformGrid | RectilinearGrid = field()
 
     #: Computation backend ('gpu', 'tpu', 'cpu' or 'METAL'). Defaults to "gpu".
     backend: BackendOption = frozen_field(default="gpu")
@@ -118,19 +124,66 @@ class SimulationConfig(TreeClass):
         """
         return self.courant_factor / math.sqrt(3)
 
+    def resolve_grid(self, shape: tuple[int, int, int] | None = None) -> RectilinearGrid:
+        """Return a concrete solver grid.
+
+        Args:
+            shape: Required when ``grid`` is an unresolved ``UniformGrid``.
+
+        Returns:
+            A concrete ``RectilinearGrid``.
+        """
+        if isinstance(self.grid, RectilinearGrid):
+            return self.grid
+        if shape is None:
+            raise ValueError("A grid shape is required to resolve UniformGrid.")
+        return self.grid.resolve(shape)
+
+    @property
+    def resolved_grid(self) -> RectilinearGrid | None:
+        """Return the concrete solver grid, or ``None`` if not yet resolved.
+
+        ``UniformGrid`` has no edge arrays until the simulation shape is known.
+        Callers that need coordinates, areas, or volumes should use this
+        property and fall back to ``uniform_spacing`` when it returns ``None``.
+        """
+        if isinstance(self.grid, RectilinearGrid):
+            return self.grid
+        return None
+
+    @property
+    def has_nonuniform_grid(self) -> bool:
+        """Whether the realized solver grid is non-uniform."""
+        grid = self.resolved_grid
+        return grid is not None and not grid.is_uniform
+
+    def uniform_spacing(self) -> float:
+        """Return the uniform grid spacing.
+
+        ``UniformGrid`` can answer this before placement.  ``RectilinearGrid``
+        answers only when all spacings are equal and raises for non-uniform
+        meshes, making unsupported scalar assumptions explicit.
+        """
+        if isinstance(self.grid, UniformGrid):
+            return self.grid.spacing
+        return self.grid.uniform_spacing
+
     @property
     def time_step_duration(self) -> float:
         """Calculate the duration of a single time step.
 
         The time step duration is determined by the Courant condition to ensure
-        numerical stability. It depends on the spatial resolution and the speed
-        of light.
+        numerical stability. Realized rectilinear grids use their smallest
+        per-axis spacings. Unresolved uniform grids use their configured scalar
+        spacing.
 
         Returns:
             float: Time step duration in seconds, calculated using the Courant
                 condition and spatial resolution.
         """
-        return self.courant_number * self.resolution / constants.c
+        if isinstance(self.grid, RectilinearGrid):
+            return self.grid.cfl_time_step(self.courant_factor)
+        return self.courant_number * self.grid.spacing / constants.c
 
     @property
     def time_steps_total(self) -> int:
@@ -191,5 +244,5 @@ class SimulationConfig(TreeClass):
 
 DUMMY_SIMULATION_CONFIG = SimulationConfig(
     time=-1,
-    resolution=-1,
+    grid=UniformGrid(spacing=1),
 )

--- a/src/fdtdx/conversion/vti.py
+++ b/src/fdtdx/conversion/vti.py
@@ -3,7 +3,9 @@ import zlib
 from pathlib import Path
 
 import jax
+import numpy as np
 
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.fdtd.container import ArrayContainer
 from fdtdx.typing import Slice3D
 
@@ -86,6 +88,7 @@ def export_vti(
     offset: tuple[int, int, int] = (0, 0, 0),
     grid_slice: Slice3D | None = None,
     compression_level: int = -1,
+    grid: RectilinearGrid | None = None,
 ):
     """Export a dictionary of arrays to a VTI (VTK ImageData) file.
 
@@ -103,10 +106,18 @@ def export_vti(
         compression_level (int, optional): zlib compression level. Use level 0 for no compression (fastest)
             and level 9 for highest compression (smallest file size).
             Defaults to -1, which currently corresponds to level 6 compression.
+        grid: Optional grid metadata. VTI is an image-data format and can only
+            encode uniform spacing. Passing a non-uniform grid raises and callers
+            should use :func:`export_vtr` instead.
 
     Raises:
         AssertionError: If arrays have mismatched shapes, invalid dimensions, or unsupported dtypes.
     """
+    if grid is not None:
+        if not grid.is_uniform:
+            raise ValueError("VTI export only supports uniform grids. Use export_vtr for rectilinear grids.")
+        resolution = grid.uniform_spacing
+
     if grid_slice is not None:
         assert offset == (0, 0, 0)
         offset = (grid_slice[0].start, grid_slice[1].start, grid_slice[2].start)
@@ -145,7 +156,7 @@ def export_vti(
         all_encoded_data.append(encoded_data)
         current_offset += len(encoded_data)
 
-    origin = "0 0 0"
+    origin = f"{offset[0] * resolution} {offset[1] * resolution} {offset[2] * resolution}"
     extent = f"{offset[0]} {nx + offset[0]} {offset[1]} {ny + offset[1]} {offset[2]} {nz + offset[2]}"
     spacing = f"{resolution} {resolution} {resolution}"
 
@@ -158,6 +169,102 @@ def export_vti(
       </CellData>
     </Piece>
   </ImageData>
+  <AppendedData encoding="raw">
+    _"""
+
+    with open(filename, "wb") as f:
+        f.write(xml.encode("utf-8"))
+        for d in all_encoded_data:
+            f.write(d)
+        f.write(b"\n</AppendedData>\n</VTKFile>")
+
+
+def _validate_vtk_cell_data(cell_data: dict[str, jax.Array]) -> tuple[int, int, int]:
+    """Validate common VTK cell-data constraints and return spatial shape."""
+    shape = next(iter(cell_data.values())).shape[-3:]
+    if not all(a.shape[-3:] == shape for a in cell_data.values()):
+        raise ValueError("All arrays in a VTK file need to be defined over the same underlying grid.")
+    if not all(a.ndim == 3 or a.ndim == 4 for a in cell_data.values()):
+        raise ValueError("Only 3d scalar fields (x, y, z) and vector fields (n, x, y, z) are supported.")
+    if not all(str(a.dtype) in NUMPY_TO_VTK_DTYPE for a in cell_data.values()):
+        raise ValueError(f"VTK export only supports dtypes {list(NUMPY_TO_VTK_DTYPE.keys())}.")
+    return shape
+
+
+def export_vtr(
+    cell_data: dict[str, jax.Array],
+    filename: Path | str,
+    grid: RectilinearGrid,
+    grid_slice: Slice3D | None = None,
+    compression_level: int = -1,
+):
+    """Export cell data to a VTR (VTK RectilinearGrid) file.
+
+    VTR is the rectilinear counterpart to VTI: it stores explicit x/y/z point
+    coordinates and can therefore represent non-uniform cell widths without
+    resampling.  Coordinates are written from ``RectilinearGrid`` edge arrays, while
+    cell data uses the same appended compressed binary encoding as ``export_vti``.
+
+    Args:
+        cell_data: Dictionary mapping field names to scalar ``(x, y, z)`` arrays
+            or vector ``(n, x, y, z)`` arrays.
+        filename: Output ``.vtr`` path.
+        grid: Rectilinear grid supplying physical edge coordinates.
+        grid_slice: Optional spatial slice that selects a subgrid from ``grid``.
+        compression_level: zlib compression level for appended cell data.
+
+    Raises:
+        AssertionError: If cell data shape, dimensionality, dtype, or slice
+            extent is incompatible with the selected grid coordinates.
+    """
+    shape = _validate_vtk_cell_data(cell_data)
+    if grid_slice is None:
+        grid_slice = (slice(0, shape[0]), slice(0, shape[1]), slice(0, shape[2]))
+    starts = tuple(s.start or 0 for s in grid_slice)
+    stops = tuple(s.stop for s in grid_slice)
+    assert all(stop is not None for stop in stops), "VTR grid_slice must have explicit stop values."
+    assert tuple(stop - start for start, stop in zip(starts, stops, strict=True)) == shape, (
+        "Cell data shape must match the selected RectilinearGrid slice."
+    )
+
+    coord_arrays = []
+    for axis, (start, stop) in enumerate(zip(starts, stops, strict=True)):
+        coord_arrays.append(np.asarray(grid.edges(axis)[start : stop + 1], dtype=np.float64))
+
+    all_encoded_data = []
+    current_offset = 0
+    data_xml_parts = []
+    for name, array in cell_data.items():
+        n_comp = 1
+        if array.ndim == 4:
+            n_comp = array.shape[0]
+        vtk_type = NUMPY_TO_VTK_DTYPE[str(array.dtype)]
+        data_xml_parts.append(
+            f'<DataArray type="{vtk_type}" Name="{name}" NumberOfComponents="{n_comp}" format="appended" offset="{current_offset}"/>'
+        )
+        encoded_data = encode_array(array, compression_level=compression_level)
+        all_encoded_data.append(encoded_data)
+        current_offset += len(encoded_data)
+
+    extent = f"{starts[0]} {stops[0]} {starts[1]} {stops[1]} {starts[2]} {stops[2]}"
+    coordinate_xml = "\n".join(
+        f'<DataArray type="Float64" Name="{axis_name}_COORDINATES" NumberOfComponents="1" format="ascii">'
+        f"{' '.join(str(v) for v in coords)}</DataArray>"
+        for axis_name, coords in zip(("X", "Y", "Z"), coord_arrays, strict=True)
+    )
+
+    xml = f"""<?xml version="1.0"?>
+<VTKFile type="RectilinearGrid" version="1.0" byte_order="LittleEndian" header_type="UInt32" compressor="vtkZLibDataCompressor">
+  <RectilinearGrid WholeExtent="{extent}">
+    <Piece Extent="{extent}">
+      <CellData>
+        {chr(10).join(data_xml_parts)}
+      </CellData>
+      <Coordinates>
+        {coordinate_xml}
+      </Coordinates>
+    </Piece>
+  </RectilinearGrid>
   <AppendedData encoding="raw">
     _"""
 

--- a/src/fdtdx/conversion/vti.py
+++ b/src/fdtdx/conversion/vti.py
@@ -156,7 +156,12 @@ def export_vti(
         all_encoded_data.append(encoded_data)
         current_offset += len(encoded_data)
 
-    origin = f"{offset[0] * resolution} {offset[1] * resolution} {offset[2] * resolution}"
+    if grid is not None:
+        edges = [np.asarray(grid.edges(ax)) for ax in range(3)]
+        ox, oy, oz = float(edges[0][offset[0]]), float(edges[1][offset[1]]), float(edges[2][offset[2]])
+        origin = f"{ox} {oy} {oz}"
+    else:
+        origin = f"{offset[0] * resolution} {offset[1] * resolution} {offset[2] * resolution}"
     extent = f"{offset[0]} {nx + offset[0]} {offset[1]} {ny + offset[1]} {offset[2]} {nz + offset[2]}"
     spacing = f"{resolution} {resolution} {resolution}"
 

--- a/src/fdtdx/core/grid.py
+++ b/src/fdtdx/core/grid.py
@@ -4,6 +4,430 @@ import numpy as np
 from matplotlib.path import Path
 
 from fdtdx import constants
+from fdtdx.core.jax.pytrees import TreeClass, autoinit, field, frozen_field, frozen_private_field
+
+
+@autoinit
+class UniformGrid(TreeClass):
+    """Unresolved policy for a uniform rectilinear grid.
+
+    ``UniformGrid`` is user intent, not the solver mesh itself.  It records the
+    physical cell spacing while the final simulation shape may still be unknown.
+    Object placement resolves this policy to a concrete ``RectilinearGrid`` once
+    the volume shape is known.
+
+    Keeping uniform spacing here avoids a second scalar discretization source on
+    ``SimulationConfig``.  Uniform grids and explicitly non-uniform grids both
+    enter the solver through the same realized ``RectilinearGrid`` structure.
+    """
+
+    #: Physical cell spacing in metres. Must be positive.
+    spacing: float = frozen_field()
+    #: Physical coordinate of the lower domain corner in metres. Defaults to the origin.
+    origin: tuple[float, float, float] = frozen_field(default=(0, 0, 0))
+
+    def __post_init__(self):
+        if self.spacing <= 0:
+            raise ValueError(f"Uniform grid spacing must be positive, got {self.spacing}.")
+
+    def resolve(self, shape: tuple[int, int, int]) -> "RectilinearGrid":
+        """Return a concrete solver grid for ``shape``."""
+        return RectilinearGrid.uniform(shape=shape, spacing=self.spacing, origin=self.origin)
+
+    @property
+    def is_uniform(self) -> bool:
+        """Uniform policies always represent equal cell widths."""
+        return True
+
+    @property
+    def min_spacing(self) -> float:
+        """Smallest cell width implied by this policy."""
+        return self.spacing
+
+    @property
+    def uniform_spacing(self) -> float:
+        """Scalar cell width in metres."""
+        return self.spacing
+
+    def axis_extent(self, axis: int, bounds: tuple[int, int]) -> float:
+        """Physical length covered by an index interval on one axis."""
+        del axis
+        lower, upper = bounds
+        return (upper - lower) * self.spacing
+
+    def slice_extent(
+        self, slice_tuple: tuple[tuple[int, int], tuple[int, int], tuple[int, int]]
+    ) -> tuple[float, float, float]:
+        """Physical side lengths covered by a 3D grid slice."""
+        return (
+            self.axis_extent(0, slice_tuple[0]),
+            self.axis_extent(1, slice_tuple[1]),
+            self.axis_extent(2, slice_tuple[2]),
+        )
+
+    def coord_to_index(self, axis: int, coord: float, snap: str = "nearest") -> int:
+        """Map a physical coordinate to a uniform-grid edge index."""
+        origin = self.origin[axis]
+        scaled = (coord - origin) / self.spacing
+        if snap == "nearest":
+            return round(scaled)
+        if snap == "lower":
+            return int(np.floor(scaled))
+        if snap == "upper":
+            return int(np.ceil(scaled))
+        raise ValueError(f"Unknown snapping rule: {snap}")
+
+    def length_to_cell_count(self, axis: int, length: float, snap: str = "nearest") -> int:
+        """Convert a physical length to a uniform-grid cell count."""
+        return self.coord_to_index(axis, self.origin[axis] + length, snap=snap)
+
+    def bounds_for_center(self, axis: int, center: float, size: int) -> tuple[int, int]:
+        """Convert a physical center and grid size to edge bounds."""
+        grid_center = self.coord_to_index(axis, center, snap="nearest")
+        lower = round(grid_center - size / 2)
+        return lower, lower + size
+
+    def anchor_coordinate(self, axis: int, bounds: tuple[int, int], position: float) -> float:
+        """Return a physical anchor coordinate inside a uniform interval."""
+        lower, upper = bounds
+        lower_coord = self.origin[axis] + lower * self.spacing
+        upper_coord = self.origin[axis] + upper * self.spacing
+        return lower_coord + 0.5 * (position + 1.0) * (upper_coord - lower_coord)
+
+    def bounds_for_anchor(self, axis: int, size: int, anchor: float, position: float) -> tuple[int, int]:
+        """Choose a uniform-grid interval from an object anchor."""
+        anchor_cell = self.coord_to_index(axis, anchor, snap="nearest")
+        offset = round(0.5 * (position + 1.0) * size)
+        lower = anchor_cell - offset
+        return lower, lower + size
+
+    def cell_volume(self, slice_tuple: tuple[tuple[int, int], tuple[int, int], tuple[int, int]]) -> jax.Array:
+        """Return per-cell volumes for a slice on this uniform policy."""
+        shape = tuple(upper - lower for lower, upper in slice_tuple)
+        return jnp.ones(shape) * self.spacing**3
+
+    def face_area(self, axis: int, slice_tuple: tuple[tuple[int, int], tuple[int, int], tuple[int, int]]) -> jax.Array:
+        """Return per-face areas for a slice on this uniform policy."""
+        shape = tuple(upper - lower for lower, upper in slice_tuple)
+        area_shape = tuple(shape[i] for i in range(3) if i != axis)
+        return jnp.ones(area_shape) * self.spacing**2
+
+
+@autoinit
+class RectilinearGrid(TreeClass):
+    """Realized rectilinear simulation grid described by physical cell edges.
+
+    This is the canonical solver-facing grid representation used by fdtdx
+    internals.  A uniform grid is represented by equally spaced edge arrays, not
+    by a separate scalar code path.  Keeping one realized representation is
+    important for the non-uniform grid migration: placement, PML profiles,
+    mode-solver coordinates, detector weights, and Yee update metrics should all
+    ask the grid for physical distances instead of deriving them from a global
+    ``resolution`` value.
+
+    The arrays store cell *edges* in metres.  For a grid with ``nx`` cells along
+    x, ``x_edges`` has shape ``(nx + 1,)`` and must be strictly increasing.  Cell
+    widths, centers, face areas, and volumes are derived from these arrays.
+
+    Notes:
+        This class intentionally does not encode automatic mesh generation
+        policy.  Future policy objects such as ``AutoGrid`` or
+        ``QuasiUniformGrid`` should resolve to ``RectilinearGrid`` before the
+        solver runs.
+    """
+
+    #: Physical edge coordinates along x in metres, shape ``(nx + 1,)``.
+    x_edges: jax.Array = field()
+    #: Physical edge coordinates along y in metres, shape ``(ny + 1,)``.
+    y_edges: jax.Array = field()
+    #: Physical edge coordinates along z in metres, shape ``(nz + 1,)``.
+    z_edges: jax.Array = field()
+    _min_spacings: tuple[float, float, float] = frozen_private_field()
+    _is_uniform: bool = frozen_private_field()
+    _uniform_spacing: float | None = frozen_private_field()
+
+    def __post_init__(self):
+        object.__setattr__(self, "x_edges", jnp.asarray(self.x_edges))
+        object.__setattr__(self, "y_edges", jnp.asarray(self.y_edges))
+        object.__setattr__(self, "z_edges", jnp.asarray(self.z_edges))
+        for axis, edges in enumerate((self.x_edges, self.y_edges, self.z_edges)):
+            if edges.ndim != 1:
+                raise ValueError(f"Grid edge coordinates for axis {axis} must be one-dimensional.")
+            if edges.shape[0] < 2:
+                raise ValueError(f"Grid edge coordinates for axis {axis} must contain at least two entries.")
+            if bool(jnp.any(jnp.diff(edges) <= 0)):
+                raise ValueError(f"Grid edge coordinates for axis {axis} must be strictly increasing.")
+        edge_arrays_np = tuple(np.asarray(edges) for edges in (self.x_edges, self.y_edges, self.z_edges))
+        width_arrays = tuple(np.diff(edges) for edges in edge_arrays_np)
+        min_spacings = tuple(float(np.min(widths)) for widths in width_arrays)
+        spacing = float(width_arrays[0][0])
+        is_uniform = all(np.allclose(widths, spacing) for widths in width_arrays)
+        object.__setattr__(self, "_min_spacings", min_spacings)
+        object.__setattr__(self, "_is_uniform", is_uniform)
+        object.__setattr__(self, "_uniform_spacing", float(np.round(spacing, decimals=14)) if is_uniform else None)
+
+    @classmethod
+    def uniform(cls, shape: tuple[int, int, int], spacing: float, origin: tuple[float, float, float] = (0, 0, 0)):
+        """Create a realized rectilinear grid for a uniform grid.
+
+        Args:
+            shape: Number of cells in ``(x, y, z)``.
+            spacing: Uniform cell width in metres.
+            origin: Physical coordinate of the lower domain corner.
+
+        Returns:
+            A grid whose edge arrays are equally spaced.
+        """
+        if spacing <= 0:
+            raise ValueError(f"Uniform grid spacing must be positive, got {spacing}.")
+        if any(n <= 0 for n in shape):
+            raise ValueError(f"Uniform grid shape entries must be positive, got {shape}.")
+        edge_arrays = tuple(origin[axis] + spacing * jnp.arange(shape[axis] + 1) for axis in range(3))
+        return cls(x_edges=edge_arrays[0], y_edges=edge_arrays[1], z_edges=edge_arrays[2])
+
+    @classmethod
+    def custom(
+        cls,
+        x_edges: jax.Array,
+        y_edges: jax.Array,
+        z_edges: jax.Array,
+    ):
+        """Create a realized rectilinear grid from explicit edge arrays.
+
+        This constructor is equivalent to calling ``RectilinearGrid(...)``
+        directly, but it makes the user-facing intent explicit: the caller is
+        supplying the final grid coordinates, not an automatic meshing policy.
+        """
+        return cls(x_edges=x_edges, y_edges=y_edges, z_edges=z_edges)
+
+    @property
+    def shape(self) -> tuple[int, int, int]:
+        """Number of cells along each axis."""
+        return (self.x_edges.shape[0] - 1, self.y_edges.shape[0] - 1, self.z_edges.shape[0] - 1)
+
+    @property
+    def dx(self) -> jax.Array:
+        """Cell widths along x in metres."""
+        return jnp.diff(self.x_edges)
+
+    @property
+    def dy(self) -> jax.Array:
+        """Cell widths along y in metres."""
+        return jnp.diff(self.y_edges)
+
+    @property
+    def dz(self) -> jax.Array:
+        """Cell widths along z in metres."""
+        return jnp.diff(self.z_edges)
+
+    @property
+    def min_spacing(self) -> float:
+        """Smallest cell width in the grid.
+
+        This value is the conservative spacing used for staged CFL migration.
+        The full non-uniform update should eventually use explicit local metric
+        arrays, but stability remains controlled by the smallest cell.
+        """
+        return min(self._min_spacings)
+
+    @property
+    def min_spacings(self) -> tuple[float, float, float]:
+        """Smallest cell width along each axis in metres."""
+        return self._min_spacings
+
+    def cfl_time_step(self, courant_factor: float) -> float:
+        """Return the CFL-limited time step for a rectilinear 3D grid.
+
+        The stability limit for an orthogonal FDTD grid is controlled by the
+        smallest spacing on each axis:
+
+        ``dt <= courant_factor / (c * sqrt(1/dx_min^2 + 1/dy_min^2 + 1/dz_min^2))``.
+
+        For uniform grids this is exactly the existing ``courant_factor/sqrt(3)``
+        behavior.  For anisotropic or stretched grids it avoids using one global
+        spacing for all three axes.
+        """
+        if self._is_uniform and self._uniform_spacing is not None:
+            return (courant_factor / float(np.sqrt(3.0))) * self._uniform_spacing / constants.c
+        dx_min, dy_min, dz_min = self.min_spacings
+        inv_metric = (1 / dx_min**2) + (1 / dy_min**2) + (1 / dz_min**2)
+        return courant_factor / (constants.c * float(np.sqrt(inv_metric)))
+
+    @property
+    def is_uniform(self) -> bool:
+        """Whether all cell widths match a single spacing within numerical tolerance."""
+        return self._is_uniform
+
+    @property
+    def uniform_spacing(self) -> float:
+        """Return the scalar spacing for a uniform grid or raise for non-uniform grids.
+
+        This compatibility escape hatch should only be used by code that has not
+        yet been migrated to metric-aware helpers.  It deliberately raises for
+        non-uniform grids so unsupported paths fail loudly.
+        """
+        if self._uniform_spacing is None:
+            raise ValueError("This operation still requires a uniform grid.")
+        return self._uniform_spacing
+
+    def edges(self, axis: int) -> jax.Array:
+        """Return edge coordinates for ``axis``."""
+        return (self.x_edges, self.y_edges, self.z_edges)[axis]
+
+    def cell_widths(self, axis: int) -> jax.Array:
+        """Return cell widths for ``axis``."""
+        return (self.dx, self.dy, self.dz)[axis]
+
+    def centers(self, axis: int) -> jax.Array:
+        """Return cell-center coordinates for ``axis``."""
+        edges = self.edges(axis)
+        return 0.5 * (edges[:-1] + edges[1:])
+
+    def axis_extent(self, axis: int, bounds: tuple[int, int]) -> float:
+        """Physical length covered by an index interval on one axis."""
+        lower, upper = bounds
+        edges = self.edges(axis)
+        return float(edges[upper] - edges[lower])
+
+    def slice_extent(
+        self, slice_tuple: tuple[tuple[int, int], tuple[int, int], tuple[int, int]]
+    ) -> tuple[float, float, float]:
+        """Physical side lengths covered by a 3D grid slice."""
+        return (
+            self.axis_extent(0, slice_tuple[0]),
+            self.axis_extent(1, slice_tuple[1]),
+            self.axis_extent(2, slice_tuple[2]),
+        )
+
+    def coord_to_index(self, axis: int, coord: float, snap: str = "nearest") -> int:
+        """Map a physical coordinate to a grid edge index.
+
+        Args:
+            axis: Grid axis.
+            coord: Coordinate in metres.
+            snap: Snapping rule. ``"nearest"`` chooses the closest edge,
+                ``"lower"`` chooses the previous edge, and ``"upper"`` chooses
+                the next edge.
+
+        Returns:
+            Edge index after applying the requested snapping rule.
+        """
+        edges = np.asarray(self.edges(axis))
+        if snap == "nearest":
+            return int(np.argmin(np.abs(edges - coord)))
+        if snap == "lower":
+            return int(np.searchsorted(edges, coord, side="right") - 1)
+        if snap == "upper":
+            return int(np.searchsorted(edges, coord, side="left"))
+        raise ValueError(f"Unknown snapping rule: {snap}")
+
+    def length_to_cell_count(self, axis: int, length: float, snap: str = "nearest") -> int:
+        """Convert a physical length to a number of cells from the lower domain edge.
+
+        This helper preserves the old uniform-grid behavior when ``snap`` is
+        ``"nearest"``.  For non-uniform placement, ``"upper"`` is usually the
+        safer rule because it chooses enough cells to cover the requested metric
+        size from the lower domain edge.
+        """
+        if length < 0:
+            raise ValueError(f"Length must be non-negative, got {length}.")
+        return self.coord_to_index(axis, float(self.edges(axis)[0]) + length, snap=snap)
+
+    def bounds_for_center(self, axis: int, center: float, size: int) -> tuple[int, int]:
+        """Choose a cell interval whose physical center is closest to ``center``.
+
+        Args:
+            axis: Grid axis.
+            center: Desired physical center coordinate in metres.
+            size: Number of cells in the interval.
+
+        Returns:
+            ``(lower, upper)`` edge indices with ``upper - lower == size``.
+
+        Notes:
+            This operation is used by object placement when a physical center
+            position and an already-resolved grid-cell size are known.  On a
+            non-uniform grid there is no exact analogue of ``round(x / dx)``;
+            selecting the closest physical interval center gives deterministic
+            snapping while preserving the requested grid-cell size.
+        """
+        if size <= 0:
+            raise ValueError(f"Interval size must be positive, got {size}.")
+        edges = np.asarray(self.edges(axis))
+        max_lower = edges.shape[0] - size - 1
+        if max_lower < 0:
+            raise ValueError(f"Interval of size {size} does not fit on axis {axis} with shape {self.shape[axis]}.")
+        lower_candidates = np.arange(max_lower + 1)
+        interval_centers = 0.5 * (edges[lower_candidates] + edges[lower_candidates + size])
+        lower = int(lower_candidates[np.argmin(np.abs(interval_centers - center))])
+        return lower, lower + size
+
+    def anchor_coordinate(self, axis: int, bounds: tuple[int, int], position: float) -> float:
+        """Return a physical anchor coordinate inside an interval.
+
+        ``position`` follows fdtdx object-anchor convention: ``-1`` is the lower
+        side, ``0`` is the center, and ``+1`` is the upper side.
+        """
+        lower, upper = bounds
+        edges = np.asarray(self.edges(axis))
+        lower_coord = edges[lower]
+        upper_coord = edges[upper]
+        return float(lower_coord + 0.5 * (position + 1.0) * (upper_coord - lower_coord))
+
+    def bounds_for_anchor(self, axis: int, size: int, anchor: float, position: float) -> tuple[int, int]:
+        """Choose a cell interval whose object anchor is closest to ``anchor``.
+
+        Args:
+            axis: Grid axis.
+            size: Number of cells in the interval.
+            anchor: Desired physical anchor coordinate in metres.
+            position: Object-relative anchor position, where ``-1`` is lower
+                side, ``0`` is center, and ``+1`` is upper side.
+
+        Returns:
+            ``(lower, upper)`` edge indices with ``upper - lower == size``.
+        """
+        if size <= 0:
+            raise ValueError(f"Interval size must be positive, got {size}.")
+        edges = np.asarray(self.edges(axis))
+        max_lower = edges.shape[0] - size - 1
+        if max_lower < 0:
+            raise ValueError(f"Interval of size {size} does not fit on axis {axis} with shape {self.shape[axis]}.")
+        lower_candidates = np.arange(max_lower + 1)
+        lower_edges = edges[lower_candidates]
+        upper_edges = edges[lower_candidates + size]
+        anchors = lower_edges + 0.5 * (position + 1.0) * (upper_edges - lower_edges)
+        lower = int(lower_candidates[np.argmin(np.abs(anchors - anchor))])
+        return lower, lower + size
+
+    def face_area(self, axis: int, slice_tuple: tuple[tuple[int, int], tuple[int, int], tuple[int, int]]) -> jax.Array:
+        """Return per-cell face-area weights for a detector plane.
+
+        Args:
+            axis: Normal axis of the face.
+            slice_tuple: Grid slice containing the detector volume.  The normal
+                axis is expected to have width one for a plane detector.
+
+        Returns:
+            Area weights broadcast to the detector's 3D slice shape.
+        """
+        transverse_axes = [a for a in range(3) if a != axis]
+        widths = []
+        for transverse_axis in transverse_axes:
+            lower, upper = slice_tuple[transverse_axis]
+            widths.append(self.cell_widths(transverse_axis)[lower:upper])
+        area_2d = widths[0][:, None] * widths[1][None, :]
+        shape = [1, 1, 1]
+        shape[transverse_axes[0]] = area_2d.shape[0]
+        shape[transverse_axes[1]] = area_2d.shape[1]
+        return area_2d.reshape(shape)
+
+    def cell_volume(self, slice_tuple: tuple[tuple[int, int], tuple[int, int], tuple[int, int]]) -> jax.Array:
+        """Return per-cell volume weights broadcast to a 3D slice shape."""
+        x0, x1 = slice_tuple[0]
+        y0, y1 = slice_tuple[1]
+        z0, z1 = slice_tuple[2]
+        return self.dx[x0:x1, None, None] * self.dy[None, y0:y1, None] * self.dz[None, None, z0:z1]
 
 
 def calculate_spatial_offsets_yee() -> tuple[jax.Array, jax.Array]:
@@ -34,6 +458,8 @@ def calculate_time_offset_yee(
     effective_index: jax.Array | float | None = None,
     e_polarization: jax.Array | None = None,
     h_polarization: jax.Array | None = None,
+    coordinate_edges: tuple[jax.Array, jax.Array, jax.Array] | None = None,
+    center_physical: jax.Array | None = None,
 ) -> tuple[jax.Array, jax.Array]:
     if inv_permittivities.ndim == 4:
         # Extract spatial shape from (1, Nx, Ny, Nz) or (3, Nx, Ny, Nz) or (9, Nx, Ny, Nz)
@@ -47,35 +473,50 @@ def calculate_time_offset_yee(
     if 1 not in spatial_shape:
         raise Exception(f"Expected one spatial axis to be one, but got {spatial_shape}")
 
-    # phase variation
-    x, y, z = jnp.meshgrid(
-        jnp.arange(spatial_shape[0]),
-        jnp.arange(spatial_shape[1]),
-        jnp.arange(spatial_shape[2]),
-        indexing="ij",
-    )
-    xyz = jnp.stack([x, y, z], axis=-1)
-    center_list = [center[0], center[1]]
     propagation_axis = spatial_shape.index(1)
-    center_list.insert(propagation_axis, jnp.array(0))
-    center_3d = jnp.asarray(center_list, dtype=wave_vector.dtype)[None, None, None, :]
-    xyz = xyz - center_3d
 
-    # yee grid offsets
+    if coordinate_edges is None:
+        # Build uniform coordinate edges from scalar resolution so the rest of
+        # the function has one physical-space code path.
+        e = [jnp.arange(spatial_shape[ax] + 1, dtype=jnp.float32) * resolution for ax in range(3)]
+        resolved_edges: tuple[jax.Array, jax.Array, jax.Array] = (e[0], e[1], e[2])
+        center_list: list = [float(center[0]) * resolution, float(center[1]) * resolution]
+        center_list.insert(propagation_axis, 0.0)
+        center_physical = jnp.asarray(center_list, dtype=wave_vector.dtype)
+    else:
+        if center_physical is None:
+            raise ValueError("center_physical must be provided with coordinate_edges")
+        resolved_edges = coordinate_edges
+
+    def component_positions(axis: int, offset: float) -> jax.Array:
+        edges = resolved_edges[axis]
+        centers = 0.5 * (edges[:-1] + edges[1:])
+        if offset == 0:
+            return edges[:-1]
+        if offset == 0.5:
+            return centers
+        raise ValueError(f"Unsupported Yee offset: {offset}")
+
+    def xyz_for_offsets(offsets: tuple[float, float, float]) -> jax.Array:
+        coords = [component_positions(ax, offsets[ax]) for ax in range(3)]
+        x, y, z = jnp.meshgrid(coords[0], coords[1], coords[2], indexing="ij")
+        return jnp.stack([x, y, z], axis=-1) - center_physical[None, None, None, :]
+
     xyz_E = jnp.stack(
         [
-            xyz + jnp.asarray([0.5, 0, 0])[None, None, None, :],
-            xyz + jnp.asarray([0, 0.5, 0])[None, None, None, :],
-            xyz + jnp.asarray([0, 0, 0.5])[None, None, None, :],
+            xyz_for_offsets((0.5, 0, 0)),
+            xyz_for_offsets((0, 0.5, 0)),
+            xyz_for_offsets((0, 0, 0.5)),
         ]
     )
     xyz_H = jnp.stack(
         [
-            xyz + jnp.asarray([0, 0.5, 0.5])[None, None, None, :],
-            xyz + jnp.asarray([0.5, 0, 0.5])[None, None, None, :],
-            xyz + jnp.asarray([0.5, 0.5, 0])[None, None, None, :],
+            xyz_for_offsets((0, 0.5, 0.5)),
+            xyz_for_offsets((0.5, 0, 0.5)),
+            xyz_for_offsets((0.5, 0.5, 0)),
         ]
     )
+    distance_scale = 1.0
 
     travel_offset_E = -jnp.dot(xyz_E, wave_vector)
     travel_offset_H = -jnp.dot(xyz_H, wave_vector)
@@ -163,8 +604,8 @@ def calculate_time_offset_yee(
         refractive_idx = 1 / jnp.sqrt(inv_perm_eff * inv_perm_eff_perm)
 
     velocity = (constants.c / refractive_idx)[None, ...]
-    time_offset_E = travel_offset_E * resolution / (velocity * time_step_duration)
-    time_offset_H = travel_offset_H * resolution / (velocity * time_step_duration)
+    time_offset_E = travel_offset_E * distance_scale / (velocity * time_step_duration)
+    time_offset_H = travel_offset_H * distance_scale / (velocity * time_step_duration)
     return time_offset_E, time_offset_H
 
 
@@ -191,23 +632,28 @@ def polygon_to_mask(
     assert polygon_vertices.shape[1] == 2
     min_x, min_y, max_x, max_y = boundary
 
-    # Create coordinate arrays
     x_coords = np.arange(min_x, max_x + 0.5 * resolution, resolution)
     y_coords = np.arange(min_y, max_y + 0.5 * resolution, resolution)
+    return polygon_to_mask_at_points(x_coords, y_coords, polygon_vertices)
 
-    # Create meshgrid
+
+def polygon_to_mask_at_points(
+    x_coords: np.ndarray,
+    y_coords: np.ndarray,
+    polygon_vertices: np.ndarray,
+) -> np.ndarray:
+    """Generate a 2D polygon mask at explicit sample coordinates.
+
+    This is the rectilinear-grid counterpart to ``polygon_to_mask``.  The caller
+    supplies the physical cell-center coordinates directly, so non-uniform grids
+    do not need to be resampled onto a synthetic uniform lattice.
+    """
+    assert polygon_vertices.ndim == 2
+    assert polygon_vertices.shape[1] == 2
+    x_coords = np.asarray(x_coords)
+    y_coords = np.asarray(y_coords)
     X, Y = np.meshgrid(x_coords, y_coords, indexing="ij")
-
-    # Flatten coordinates for point-in-polygon test
     points = np.column_stack((X.ravel(), Y.ravel()))
-
-    # Create matplotlib Path object from polygon vertices
     polygon_path = Path(polygon_vertices)
-
-    # Test which points are inside the polygon
     inside_polygon = polygon_path.contains_points(points)
-
-    # Reshape back to 2D grid
-    mask = inside_polygon.reshape(Y.shape).astype(bool)
-
-    return mask
+    return inside_polygon.reshape(X.shape).astype(bool)

--- a/src/fdtdx/core/grid.py
+++ b/src/fdtdx/core/grid.py
@@ -480,9 +480,11 @@ def calculate_time_offset_yee(
         # the function has one physical-space code path.
         e = [jnp.arange(spatial_shape[ax] + 1, dtype=jnp.float32) * resolution for ax in range(3)]
         resolved_edges: tuple[jax.Array, jax.Array, jax.Array] = (e[0], e[1], e[2])
-        center_list: list = [float(center[0]) * resolution, float(center[1]) * resolution]
-        center_list.insert(propagation_axis, 0.0)
-        center_physical = jnp.asarray(center_list, dtype=wave_vector.dtype)
+        c0 = jnp.asarray(center[0], dtype=wave_vector.dtype) * resolution
+        c1 = jnp.asarray(center[1], dtype=wave_vector.dtype) * resolution
+        center_parts: list[jax.Array] = [c0, c1]
+        center_parts.insert(propagation_axis, jnp.zeros((), dtype=wave_vector.dtype))
+        center_physical = jnp.stack(center_parts)
     else:
         if center_physical is None:
             raise ValueError("center_physical must be provided with coordinate_edges")

--- a/src/fdtdx/core/physics/curl.py
+++ b/src/fdtdx/core/physics/curl.py
@@ -6,9 +6,70 @@ from fdtdx.constants import c as c0
 from fdtdx.constants import eps0
 
 
+def _metric_scale(
+    config: SimulationConfig,
+    axis: int,
+    shape: tuple[int, int, int],
+    stencil: str,
+) -> jax.Array | float:
+    """Return the local derivative scale for a rectilinear Yee curl term.
+
+    fdtdx historically stores curl terms as raw finite differences and applies a
+    scalar Courant number in the update equations.  On a non-uniform grid the
+    equivalent term is ``(c * dt / courant_number) * diff / d_axis[i]``.  The
+    prefactor equals the uniform spacing on legacy grids, so uniform behavior is
+    unchanged while stretched grids get local metric factors.
+    """
+    if not config.has_nonuniform_grid:
+        return 1.0
+
+    grid = config.resolved_grid
+    assert grid is not None
+    widths = grid.cell_widths(axis)
+    if stencil == "backward":
+        prev_widths = jnp.concatenate([widths[:1], widths[:-1]])
+        widths = 0.5 * (widths + prev_widths)
+    elif stencil != "forward":
+        raise ValueError(f"Unknown derivative stencil: {stencil}")
+    reference_spacing = c0 * config.time_step_duration / config.courant_number
+    scale = reference_spacing / widths
+    broadcast_shape = [1, 1, 1]
+    broadcast_shape[axis] = shape[axis]
+    return scale.reshape(tuple(broadcast_shape))
+
+
+def _backward_edge_average(
+    current: jax.Array,
+    previous: jax.Array,
+    config: SimulationConfig | None,
+    axis: int,
+) -> jax.Array:
+    """Interpolate center-staggered samples back to an edge on a rectilinear grid.
+
+    Uniform grids use the historical arithmetic mean.  On stretched grids the
+    target edge is not halfway between neighboring cell centers, so the average
+    is weighted by the half-widths of the cells on each side of the edge.
+    """
+    if config is None or not config.has_nonuniform_grid:
+        return 0.5 * (current + previous)
+
+    grid = config.resolved_grid
+    assert grid is not None
+    widths = grid.cell_widths(axis)
+    previous_widths = jnp.concatenate([widths[:1], widths[:-1]])
+    current_half_width = 0.5 * widths
+    previous_half_width = 0.5 * previous_widths
+    broadcast_shape = [1, 1, 1]
+    broadcast_shape[axis] = current.shape[axis]
+    current_half_width = current_half_width.reshape(tuple(broadcast_shape))
+    previous_half_width = previous_half_width.reshape(tuple(broadcast_shape))
+    return (current * previous_half_width + previous * current_half_width) / (current_half_width + previous_half_width)
+
+
 def interpolate_fields(
     E_pad: jax.Array,
     H_pad: jax.Array,
+    config: SimulationConfig | None = None,
 ) -> tuple[jax.Array, jax.Array]:
     """Interpolates E and H fields onto the E_z Yee grid point (i, j, k+½).
 
@@ -28,6 +89,9 @@ def interpolate_fields(
     Args:
         E_pad: Pre-padded electric field array of shape (3, Nx+2, Ny+2, Nz+2)
         H_pad: Pre-padded magnetic field array of shape (3, Nx+2, Ny+2, Nz+2)
+        config: Optional simulation configuration.  When it carries a
+            non-uniform ``RectilinearGrid``, center-to-edge interpolations use local
+            physical distances instead of equal weights.
 
     Returns:
         Tuple of (E_interp, H_interp), each of shape (3, Nx, Ny, Nz)
@@ -36,31 +100,90 @@ def interpolate_fields(
     H_x, H_y, H_z = H_pad[0], H_pad[1], H_pad[2]
 
     # E_x: (i+½, j, k) → (i, j, k+½): x backward, z forward
-    E_x = (E_x[1:-1, 1:-1, 1:-1] + E_x[:-2, 1:-1, 1:-1] + E_x[1:-1, 1:-1, 2:] + E_x[:-2, 1:-1, 2:]) / 4.0
+    E_x_lower_z = _backward_edge_average(
+        current=E_x[1:-1, 1:-1, 1:-1],
+        previous=E_x[:-2, 1:-1, 1:-1],
+        config=config,
+        axis=0,
+    )
+    E_x_upper_z = _backward_edge_average(
+        current=E_x[1:-1, 1:-1, 2:],
+        previous=E_x[:-2, 1:-1, 2:],
+        config=config,
+        axis=0,
+    )
+    E_x = (E_x_lower_z + E_x_upper_z) / 2.0
 
     # E_y: (i, j+½, k) → (i, j, k+½): y backward, z forward
-    E_y = (E_y[1:-1, 1:-1, 1:-1] + E_y[1:-1, :-2, 1:-1] + E_y[1:-1, 1:-1, 2:] + E_y[1:-1, :-2, 2:]) / 4.0
+    E_y_lower_z = _backward_edge_average(
+        current=E_y[1:-1, 1:-1, 1:-1],
+        previous=E_y[1:-1, :-2, 1:-1],
+        config=config,
+        axis=1,
+    )
+    E_y_upper_z = _backward_edge_average(
+        current=E_y[1:-1, 1:-1, 2:],
+        previous=E_y[1:-1, :-2, 2:],
+        config=config,
+        axis=1,
+    )
+    E_y = (E_y_lower_z + E_y_upper_z) / 2.0
 
     # E_z: (i, j, k+½) → already at target
     E_z = E_z[1:-1, 1:-1, 1:-1]
 
     # H_x: (i, j+½, k+½) → (i, j, k+½): y backward only
-    H_x = (H_x[1:-1, 1:-1, 1:-1] + H_x[1:-1, :-2, 1:-1]) / 2.0
+    H_x = _backward_edge_average(
+        current=H_x[1:-1, 1:-1, 1:-1],
+        previous=H_x[1:-1, :-2, 1:-1],
+        config=config,
+        axis=1,
+    )
 
     # H_y: (i+½, j, k+½) → (i, j, k+½): x backward only
-    H_y = (H_y[1:-1, 1:-1, 1:-1] + H_y[:-2, 1:-1, 1:-1]) / 2.0
+    H_y = _backward_edge_average(
+        current=H_y[1:-1, 1:-1, 1:-1],
+        previous=H_y[:-2, 1:-1, 1:-1],
+        config=config,
+        axis=0,
+    )
 
     # H_z: (i+½, j+½, k) → (i, j, k+½): x backward, y backward, z forward
-    H_z = (
-        H_z[1:-1, 1:-1, 1:-1]
-        + H_z[:-2, 1:-1, 1:-1]
-        + H_z[1:-1, :-2, 1:-1]
-        + H_z[:-2, :-2, 1:-1]
-        + H_z[1:-1, 1:-1, 2:]
-        + H_z[:-2, 1:-1, 2:]
-        + H_z[1:-1, :-2, 2:]
-        + H_z[:-2, :-2, 2:]
-    ) / 8.0
+    H_z_lower_z_x = _backward_edge_average(
+        current=H_z[1:-1, 1:-1, 1:-1],
+        previous=H_z[:-2, 1:-1, 1:-1],
+        config=config,
+        axis=0,
+    )
+    H_z_lower_z_xy = _backward_edge_average(
+        current=H_z_lower_z_x,
+        previous=_backward_edge_average(
+            current=H_z[1:-1, :-2, 1:-1],
+            previous=H_z[:-2, :-2, 1:-1],
+            config=config,
+            axis=0,
+        ),
+        config=config,
+        axis=1,
+    )
+    H_z_upper_z_x = _backward_edge_average(
+        current=H_z[1:-1, 1:-1, 2:],
+        previous=H_z[:-2, 1:-1, 2:],
+        config=config,
+        axis=0,
+    )
+    H_z_upper_z_xy = _backward_edge_average(
+        current=H_z_upper_z_x,
+        previous=_backward_edge_average(
+            current=H_z[1:-1, :-2, 2:],
+            previous=H_z[:-2, :-2, 2:],
+            config=config,
+            axis=0,
+        ),
+        config=config,
+        axis=1,
+    )
+    H_z = (H_z_lower_z_xy + H_z_upper_z_xy) / 2.0
 
     E_interp = jnp.stack([E_x, E_y, E_z], axis=0)
     H_interp = jnp.stack([H_x, H_y, H_z], axis=0)
@@ -102,19 +225,24 @@ def curl_E(
                   (half-integer grid points). Has same shape as input (3, nx, ny, nz).
     """
 
-    dyEz = (jnp.roll(E_pad[2], -1, axis=1) - E_pad[2])[1:-1, 1:-1, 1:-1]
-    dzEy = (jnp.roll(E_pad[1], -1, axis=2) - E_pad[1])[1:-1, 1:-1, 1:-1]
-    dzEx = (jnp.roll(E_pad[0], -1, axis=2) - E_pad[0])[1:-1, 1:-1, 1:-1]
-    dxEz = (jnp.roll(E_pad[2], -1, axis=0) - E_pad[2])[1:-1, 1:-1, 1:-1]
-    dxEy = (jnp.roll(E_pad[1], -1, axis=0) - E_pad[1])[1:-1, 1:-1, 1:-1]
-    dyEx = (jnp.roll(E_pad[0], -1, axis=1) - E_pad[0])[1:-1, 1:-1, 1:-1]
+    shape = E_pad.shape[1] - 2, E_pad.shape[2] - 2, E_pad.shape[3] - 2
+    dx_scale = _metric_scale(config, axis=0, shape=shape, stencil="forward")
+    dy_scale = _metric_scale(config, axis=1, shape=shape, stencil="forward")
+    dz_scale = _metric_scale(config, axis=2, shape=shape, stencil="forward")
+
+    dyEz = (jnp.roll(E_pad[2], -1, axis=1) - E_pad[2])[1:-1, 1:-1, 1:-1] * dy_scale
+    dzEy = (jnp.roll(E_pad[1], -1, axis=2) - E_pad[1])[1:-1, 1:-1, 1:-1] * dz_scale
+    dzEx = (jnp.roll(E_pad[0], -1, axis=2) - E_pad[0])[1:-1, 1:-1, 1:-1] * dz_scale
+    dxEz = (jnp.roll(E_pad[2], -1, axis=0) - E_pad[2])[1:-1, 1:-1, 1:-1] * dx_scale
+    dxEy = (jnp.roll(E_pad[1], -1, axis=0) - E_pad[1])[1:-1, 1:-1, 1:-1] * dx_scale
+    dyEx = (jnp.roll(E_pad[0], -1, axis=1) - E_pad[0])[1:-1, 1:-1, 1:-1] * dy_scale
 
     # Auxiliary fields
     psi_Hxy, psi_Hxz, psi_Hyz, psi_Hyx, psi_Hzx, psi_Hzy = psi_H
 
     if simulate_boundaries:
         # Get H-field PML coefficients
-        b = jnp.expm1(-config.courant_number * config.resolution / c0 / eps0 * (sigma / kappa + alpha)) + 1
+        b = jnp.expm1(-config.time_step_duration / eps0 * (sigma / kappa + alpha)) + 1
         a = jnp.nan_to_num((b - 1.0) * sigma / (sigma + alpha * kappa) / kappa, nan=0.0, posinf=0.0, neginf=0.0)
 
         # Update auxiliary fields
@@ -169,19 +297,24 @@ def curl_H(
                   (integer grid points). Has same shape as input (3, nx, ny, nz).
     """
 
-    dyHz = (H_pad[2] - jnp.roll(H_pad[2], 1, axis=1))[1:-1, 1:-1, 1:-1]
-    dzHy = (H_pad[1] - jnp.roll(H_pad[1], 1, axis=2))[1:-1, 1:-1, 1:-1]
-    dzHx = (H_pad[0] - jnp.roll(H_pad[0], 1, axis=2))[1:-1, 1:-1, 1:-1]
-    dxHz = (H_pad[2] - jnp.roll(H_pad[2], 1, axis=0))[1:-1, 1:-1, 1:-1]
-    dxHy = (H_pad[1] - jnp.roll(H_pad[1], 1, axis=0))[1:-1, 1:-1, 1:-1]
-    dyHx = (H_pad[0] - jnp.roll(H_pad[0], 1, axis=1))[1:-1, 1:-1, 1:-1]
+    shape = H_pad.shape[1] - 2, H_pad.shape[2] - 2, H_pad.shape[3] - 2
+    dx_scale = _metric_scale(config, axis=0, shape=shape, stencil="backward")
+    dy_scale = _metric_scale(config, axis=1, shape=shape, stencil="backward")
+    dz_scale = _metric_scale(config, axis=2, shape=shape, stencil="backward")
+
+    dyHz = (H_pad[2] - jnp.roll(H_pad[2], 1, axis=1))[1:-1, 1:-1, 1:-1] * dy_scale
+    dzHy = (H_pad[1] - jnp.roll(H_pad[1], 1, axis=2))[1:-1, 1:-1, 1:-1] * dz_scale
+    dzHx = (H_pad[0] - jnp.roll(H_pad[0], 1, axis=2))[1:-1, 1:-1, 1:-1] * dz_scale
+    dxHz = (H_pad[2] - jnp.roll(H_pad[2], 1, axis=0))[1:-1, 1:-1, 1:-1] * dx_scale
+    dxHy = (H_pad[1] - jnp.roll(H_pad[1], 1, axis=0))[1:-1, 1:-1, 1:-1] * dx_scale
+    dyHx = (H_pad[0] - jnp.roll(H_pad[0], 1, axis=1))[1:-1, 1:-1, 1:-1] * dy_scale
 
     # Auxiliary fields
     psi_Exy, psi_Exz, psi_Eyz, psi_Eyx, psi_Ezx, psi_Ezy = psi_E
 
     if simulate_boundaries:
         # Get E-field PML coefficients
-        b = jnp.expm1(-config.courant_number * config.resolution / c0 / eps0 * (sigma / kappa + alpha)) + 1
+        b = jnp.expm1(-config.time_step_duration / eps0 * (sigma / kappa + alpha)) + 1
         a = jnp.nan_to_num((b - 1.0) * sigma / (sigma + alpha * kappa) / kappa, nan=0.0, posinf=0.0, neginf=0.0)
 
         # Update auxiliary fields

--- a/src/fdtdx/core/physics/metrics.py
+++ b/src/fdtdx/core/physics/metrics.py
@@ -117,11 +117,28 @@ def compute_poynting_flux(E: jax.Array, H: jax.Array, axis: int = 0) -> jax.Arra
     )
 
 
-def normalize_by_poynting_flux(E: jax.Array, H: jax.Array, axis: int) -> tuple[jax.Array, jax.Array]:
-    """Normalize fields so that Poynting flux along given axis = 1."""
+def normalize_by_poynting_flux(
+    E: jax.Array,
+    H: jax.Array,
+    axis: int,
+    area_weights: jax.Array | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    """Normalize fields so the integrated Poynting flux along ``axis`` is one.
+
+    Args:
+        E: Electric field array with component axis first.
+        H: Magnetic field array with component axis first.
+        axis: Physical propagation axis whose Poynting component is integrated.
+        area_weights: Optional detector-plane area weights broadcastable to
+            ``E[axis]``.  Uniform-grid callers may omit this for the historical
+            raw-sum normalization; non-uniform callers should provide weights so
+            refinement alone does not change the normalization.
+    """
     # Compute Poynting vector components
     S_complex = jnp.cross(jnp.conj(E), H, axisa=0, axisb=0, axisc=0)
     S_real = 0.5 * jnp.real(S_complex[axis])  # power flow in desired direction
+    if area_weights is not None:
+        S_real = S_real * area_weights
 
     # Integrate over transverse plane (axis orthogonal to `axis`)
     power = jnp.abs(jnp.sum(S_real))
@@ -131,3 +148,32 @@ def normalize_by_poynting_flux(E: jax.Array, H: jax.Array, axis: int) -> tuple[j
     E_norm = E / norm_factor
     H_norm = H / norm_factor
     return E_norm, H_norm
+
+
+def resample_to_uniform_2d(
+    field: jax.Array,
+    x_centers: jax.Array,
+    y_centers: jax.Array,
+) -> tuple[jax.Array, jax.Array | float, jax.Array | float]:
+    """Resample a ``(component, x, y)`` field onto a uniform transverse grid.
+
+    Interpolates each component from the given non-uniform physical center
+    coordinates onto a uniform grid with the same extent and number of points.
+    Returns the resampled field and the uniform grid spacings.
+    """
+    nx, ny = field.shape[1], field.shape[2]
+    target_x = jnp.linspace(x_centers[0], x_centers[-1], nx)
+    target_y = jnp.linspace(y_centers[0], y_centers[-1], ny)
+
+    def interp_x(component):
+        return jax.vmap(lambda column: jnp.interp(target_x, x_centers, column), in_axes=1, out_axes=1)(component)
+
+    def interp_y(component):
+        return jax.vmap(lambda row: jnp.interp(target_y, y_centers, row))(component)
+
+    field = jax.vmap(interp_x)(field)
+    field = jax.vmap(interp_y)(field)
+
+    dx = (target_x[1] - target_x[0]) if nx > 1 else 1.0
+    dy = (target_y[1] - target_y[0]) if ny > 1 else 1.0
+    return field, dx, dy

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from types import SimpleNamespace
-from typing import List, Literal
+from typing import List, Literal, Sequence
 
 import jax
 import jax.numpy as jnp
@@ -93,13 +93,14 @@ def compute_mode(
     frequency: float,
     inv_permittivities: jax.Array,  # shape (nx, ny, nz)
     inv_permeabilities: jax.Array | float,
-    resolution: float,
-    direction: Literal["+", "-"],
+    resolution: float | None = None,
+    direction: Literal["+", "-"] = "+",
     mode_index: int = 0,
     filter_pol: Literal["te", "tm"] | None = None,
     dtype: jnp.dtype = jnp.float32,
     bend_radius: float | None = None,
     bend_axis: int | None = None,
+    transverse_coords: Sequence[ArrayLike] | None = None,
 ) -> tuple[
     jax.Array,  # E
     jax.Array,  # H
@@ -118,8 +119,8 @@ def compute_mode(
         inv_permittivities (jax.Array): 3D array of inverse relative permittivity values
         inv_permeabilities (jax.Array | float): 3D array of inverse relative permittivity values or single float for
             uniform permeability distribution.
-        resolution (float): resolution of the simulation grid in meter. For example a grid spacing of 10nm should be
-            given as 10e-9.
+        resolution (float | None): Uniform-grid spacing in metres. Required when ``transverse_coords`` is not
+            provided (uniform-grid path). Ignored when ``transverse_coords`` is given. Defaults to None.
         direction (Literal["+", "-"]): Propagation direction, either "+" or "-".
         mode_index (int, optional): Index of the mode to compute. Defaults to 0.
         filter_pol (Literal["te", "tm"] | None, optional). If not None, modes are filtered by polarization.
@@ -130,6 +131,9 @@ def compute_mode(
             None (straight waveguide).
         bend_axis (int | None, optional): Physical axis index (0/1/2) pointing from the waveguide toward the center
             of curvature. Must differ from the propagation axis. Required when bend_radius is set. Defaults to None.
+        transverse_coords: Optional pair of physical edge-coordinate arrays, in metres, for the two axes transverse
+            to propagation. Each array must have one more entry than the corresponding transverse cell count. When
+            provided, the Tidy3D mode solver receives the non-uniform rectilinear grid directly.
 
     Returns:
         Tuple[jax.Array, jax.Array, jax.Array]:
@@ -214,7 +218,31 @@ def compute_mode(
         permittivities = 1 / inv_permittivities
     other_axes = [a for a in range(1, 4) if permittivities.shape[a] != 1]
     propagation_axis = permittivities.shape[1:].index(1)
-    coords = [np.arange(permittivities.shape[dim] + 1) * resolution / 1e-6 for dim in other_axes]
+    if transverse_coords is None:
+        if resolution is None:
+            raise ValueError("resolution is required when transverse_coords is not provided")
+        coords = [np.arange(permittivities.shape[dim] + 1) * resolution / 1e-6 for dim in other_axes]
+        normalization_area_weights = None
+    else:
+        if len(transverse_coords) != 2:
+            raise ValueError(
+                f"transverse_coords must contain exactly two coordinate arrays, got {len(transverse_coords)}"
+            )
+        coords_meter = [np.asarray(coord, dtype=np.float64) for coord in transverse_coords]
+        expected_lengths = [permittivities.shape[dim] + 1 for dim in other_axes]
+        for axis_idx, (coord, expected_length) in enumerate(zip(coords_meter, expected_lengths, strict=True)):
+            if coord.ndim != 1 or coord.shape[0] != expected_length:
+                raise ValueError(
+                    f"transverse_coords[{axis_idx}] must be 1D with length {expected_length}, got {coord.shape}"
+                )
+            if np.any(np.diff(coord) <= 0):
+                raise ValueError(f"transverse_coords[{axis_idx}] must be strictly increasing")
+        coords = [coord / 1e-6 for coord in coords_meter]
+        area_2d = jnp.asarray(np.diff(coords_meter[0])[:, None] * np.diff(coords_meter[1])[None, :], dtype=dtype)
+        weight_shape = [1, 1, 1]
+        weight_shape[other_axes[0] - 1] = area_2d.shape[0]
+        weight_shape[other_axes[1] - 1] = area_2d.shape[1]
+        normalization_area_weights = area_2d.reshape(weight_shape)
     permittivity_squeezed = jnp.take(
         permittivities,
         indices=0,
@@ -289,7 +317,12 @@ def compute_mode(
     # Tidy3D uses different scaling internally, so convert back
     mode_H = mode_H * tidy3d.constants.ETA_0
 
-    mode_E_norm, mode_H_norm = normalize_by_poynting_flux(mode_E, mode_H, axis=propagation_axis)
+    mode_E_norm, mode_H_norm = normalize_by_poynting_flux(
+        mode_E,
+        mode_H,
+        axis=propagation_axis,
+        area_weights=normalization_area_weights,
+    )
 
     return mode_E_norm, mode_H_norm, eff_idx
 

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -100,7 +100,7 @@ def compute_mode(
     dtype: jnp.dtype = jnp.float32,
     bend_radius: float | None = None,
     bend_axis: int | None = None,
-    transverse_coords: Sequence[ArrayLike] | None = None,
+    transverse_coords: Sequence[jax.Array] | None = None,
 ) -> tuple[
     jax.Array,  # E
     jax.Array,  # H
@@ -132,8 +132,10 @@ def compute_mode(
         bend_axis (int | None, optional): Physical axis index (0/1/2) pointing from the waveguide toward the center
             of curvature. Must differ from the propagation axis. Required when bend_radius is set. Defaults to None.
         transverse_coords: Optional pair of physical edge-coordinate arrays, in metres, for the two axes transverse
-            to propagation. Each array must have one more entry than the corresponding transverse cell count. When
-            provided, the Tidy3D mode solver receives the non-uniform rectilinear grid directly.
+            to propagation. Each array must have one more entry than the corresponding transverse cell count.
+            When provided, the Tidy3D mode solver receives the non-uniform rectilinear grid directly.
+            JAX arrays are accepted; the numpy conversion happens inside the tidy3d callback so the function
+            remains compatible with ``jax.jit``.
 
     Returns:
         Tuple[jax.Array, jax.Array, jax.Array]:
@@ -156,7 +158,9 @@ def compute_mode(
 
     np_complex_dtype = np.complex128 if dtype == jnp.float64 else np.complex64
 
-    def mode_helper(permittivity, permeability):
+    def mode_helper(permittivity, permeability, c0_um, c1_um):
+        # c0_um, c1_um are concrete numpy arrays here (materialised by pure_callback)
+        coords = [np.asarray(c0_um), np.asarray(c1_um)]
         if bend_radius is not None:
             assert bend_axis is not None
             transverse_axes = [ax for ax in range(3) if ax != propagation_axis]
@@ -221,24 +225,29 @@ def compute_mode(
     if transverse_coords is None:
         if resolution is None:
             raise ValueError("resolution is required when transverse_coords is not provided")
-        coords = [np.arange(permittivities.shape[dim] + 1) * resolution / 1e-6 for dim in other_axes]
+        # Uniform grid: build concrete coordinate arrays in µm and pass as callback args.
+        c0_um = jnp.asarray(np.arange(permittivities.shape[other_axes[0]] + 1) * resolution / 1e-6)
+        c1_um = jnp.asarray(np.arange(permittivities.shape[other_axes[1]] + 1) * resolution / 1e-6)
         normalization_area_weights = None
     else:
         if len(transverse_coords) != 2:
             raise ValueError(
                 f"transverse_coords must contain exactly two coordinate arrays, got {len(transverse_coords)}"
             )
-        coords_meter = [np.asarray(coord, dtype=np.float64) for coord in transverse_coords]
+        # Shape validation uses .shape which is always concrete, even for JAX tracers.
         expected_lengths = [permittivities.shape[dim] + 1 for dim in other_axes]
-        for axis_idx, (coord, expected_length) in enumerate(zip(coords_meter, expected_lengths, strict=True)):
-            if coord.ndim != 1 or coord.shape[0] != expected_length:
+        for axis_idx, (coord, expected_length) in enumerate(zip(transverse_coords, expected_lengths, strict=True)):
+            if coord.shape[0] != expected_length:
                 raise ValueError(
                     f"transverse_coords[{axis_idx}] must be 1D with length {expected_length}, got {coord.shape}"
                 )
-            if np.any(np.diff(coord) <= 0):
-                raise ValueError(f"transverse_coords[{axis_idx}] must be strictly increasing")
-        coords = [coord / 1e-6 for coord in coords_meter]
-        area_2d = jnp.asarray(np.diff(coords_meter[0])[:, None] * np.diff(coords_meter[1])[None, :], dtype=dtype)
+        # Convert to µm for tidy3d; keep as JAX arrays so jax.jit can trace through.
+        c0_um = jnp.asarray(transverse_coords[0]) / 1e-6
+        c1_um = jnp.asarray(transverse_coords[1]) / 1e-6
+        # area_2d in m²: use jnp.diff so this works with traced JAX arrays.
+        area_2d = (
+            jnp.diff(jnp.asarray(transverse_coords[0]))[:, None] * jnp.diff(jnp.asarray(transverse_coords[1]))[None, :]
+        ).astype(dtype)
         weight_shape = [1, 1, 1]
         weight_shape[other_axes[0] - 1] = area_2d.shape[0]
         weight_shape[other_axes[1] - 1] = area_2d.shape[1]
@@ -304,12 +313,17 @@ def compute_mode(
     else:  # float
         permeability_squeezed = permeabilities
 
-    # pure callback to tidy3d is necessary to work in jitted environment
+    # pure callback to tidy3d is necessary to work in jitted environment.
+    # c0_um and c1_um are passed as explicit args so JAX materialises them to
+    # concrete numpy arrays before calling mode_helper, allowing np.asarray()
+    # inside the callback without raising TracerArrayConversionError.
     mode_E_raw, mode_H_raw, eff_idx = jax.pure_callback(
         mode_helper,
         result_shape_dtype,
         jax.lax.stop_gradient(permittivity_squeezed),
         jax.lax.stop_gradient(permeability_squeezed),
+        jax.lax.stop_gradient(c0_um),
+        jax.lax.stop_gradient(c1_um),
     )
     mode_E = jnp.expand_dims(mode_E_raw, axis=propagation_axis + 1)
     mode_H = jnp.expand_dims(mode_H_raw, axis=propagation_axis + 1)

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -237,7 +237,7 @@ def compute_mode(
         # Shape validation uses .shape which is always concrete, even for JAX tracers.
         expected_lengths = [permittivities.shape[dim] + 1 for dim in other_axes]
         for axis_idx, (coord, expected_length) in enumerate(zip(transverse_coords, expected_lengths, strict=True)):
-            if coord.shape[0] != expected_length:
+            if coord.ndim != 1 or coord.shape[0] != expected_length:
                 raise ValueError(
                     f"transverse_coords[{axis_idx}] must be 1D with length {expected_length}, got {coord.shape}"
                 )

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -7,6 +7,7 @@ import jax.numpy as jnp
 
 from fdtdx import constants
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.core.jax.guards import check_not_tracing
 from fdtdx.core.jax.sharding import create_named_sharded_matrix
 from fdtdx.core.jax.ste import straight_through_estimator
@@ -103,6 +104,12 @@ def place_objects(
     object_map = {obj.name: obj for obj in object_list}
     volume_name = _resolve_volume_name(object_map)
     volume_obj = object_map[volume_name]
+    volume_shape = tuple(s1 - s0 for s0, s1 in resolved_slices[volume_obj.name])
+    grid = config.resolve_grid(volume_shape)  # Resolve user grid policy before objects see the config.
+    if grid.shape != volume_shape:
+        raise ValueError(f"Configured grid shape {grid.shape} does not match simulation volume shape {volume_shape}.")
+    if not isinstance(config.grid, RectilinearGrid):
+        config = config.aset("grid", grid)
 
     # Step 4: Place objects on grid based on resolved slice tuples
     placed_objects = []
@@ -342,6 +349,9 @@ def _init_arrays(
     # create E/H fields
     volume_shape = objects.volume.grid_shape
     _warn_if_simulation_volume_too_large(volume_shape)
+    grid = config.resolve_grid(volume_shape)
+    if grid.shape != volume_shape:
+        raise ValueError(f"Configured grid shape {grid.shape} does not match simulation volume shape {volume_shape}.")
     ext_shape = (3, *volume_shape)
 
     # Determine whether to use complex-valued fields
@@ -499,6 +509,9 @@ def _init_arrays(
             sharding_axis=1,
             backend=config.backend,
         )
+    conductivity_spacing = None
+    if electric_conductivity is not None or magnetic_conductivity is not None:
+        conductivity_spacing = constants.c * config.time_step_duration / config.courant_number
 
     # dispersive ADE auxiliary arrays - all None unless any material is dispersive.
     # Per-cell coefficients are broadcast over component via a size-1 axis.
@@ -613,8 +626,11 @@ def _init_arrays(
                     # Fully anisotropic
                     cond_tuple = o.material.electric_conductivity
 
-                # scale by grid size
-                obj_electric_conductivity = (jnp.array(cond_tuple, dtype=config.dtype) * config.resolution)[
+                # Scale physical conductivity into the dimensionless update coefficient.
+                # On uniform grids this equals the scalar grid spacing.  On stretched
+                # grids it is the reference spacing implied by ``c0 * dt / courant``.
+                assert conductivity_spacing is not None
+                obj_electric_conductivity = (jnp.array(cond_tuple, dtype=config.dtype) * conductivity_spacing)[
                     :, None, None, None
                 ]
                 electric_conductivity = electric_conductivity.at[:, *o.grid_slice].set(obj_electric_conductivity)
@@ -634,8 +650,9 @@ def _init_arrays(
                     # Fully anisotropic
                     cond_tuple = o.material.magnetic_conductivity
 
-                # scale by grid size
-                obj_magnetic_conductivity = (jnp.array(cond_tuple, dtype=config.dtype) * config.resolution)[
+                # Scale physical conductivity into the dimensionless update coefficient.
+                assert conductivity_spacing is not None
+                obj_magnetic_conductivity = (jnp.array(cond_tuple, dtype=config.dtype) * conductivity_spacing)[
                     :, None, None, None
                 ]
                 magnetic_conductivity = magnetic_conductivity.at[:, *o.grid_slice].set(obj_magnetic_conductivity)
@@ -720,7 +737,8 @@ def _init_arrays(
                     )
                 )
 
-                component_values = jnp.moveaxis(allowed_conds[indices], -1, 0) * config.resolution
+                assert conductivity_spacing is not None
+                component_values = jnp.moveaxis(allowed_conds[indices], -1, 0) * conductivity_spacing
                 diff = component_values - electric_conductivity[:, *o.grid_slice]
                 electric_conductivity = electric_conductivity.at[:, *o.grid_slice].add(mask * diff)
 
@@ -733,7 +751,8 @@ def _init_arrays(
                     )
                 )
 
-                component_values = jnp.moveaxis(allowed_conds[indices], -1, 0) * config.resolution
+                assert conductivity_spacing is not None
+                component_values = jnp.moveaxis(allowed_conds[indices], -1, 0) * conductivity_spacing
                 diff = component_values - magnetic_conductivity[:, *o.grid_slice]
                 magnetic_conductivity = magnetic_conductivity.at[:, *o.grid_slice].add(mask * diff)
 
@@ -971,6 +990,40 @@ def _center_to_bounds(
     upper = lower + size
 
     return lower, upper
+
+
+def _real_length_to_grid_size(config: SimulationConfig, axis: int, length: float) -> int:
+    """Convert a physical length to a grid-cell count.
+
+    Non-uniform grids snap upward so objects always cover at least the
+    requested metric length.  Uniform grids use the historical round-to-nearest
+    rule for exact backwards compatibility.
+    """
+    snap = "upper" if config.has_nonuniform_grid else "nearest"
+    return config.grid.length_to_cell_count(axis, length, snap=snap)
+
+
+def _real_coord_to_edge_index(config: SimulationConfig, axis: int, coord: float) -> int:
+    """Snap a physical coordinate to a grid edge index."""
+    return config.grid.coord_to_index(axis, coord, snap="nearest")
+
+
+def _center_to_bounds_for_grid(config: SimulationConfig, axis: int, real_pos: float, size: int) -> tuple[int, int]:
+    """Convert a physical center and resolved grid size to edge bounds."""
+    return config.grid.bounds_for_center(axis, real_pos, size)
+
+
+def _raise_for_nonuniform_grid_offsets(config: SimulationConfig, values: Sequence[int | None], name: str):
+    """Reject index-space distance offsets when a grid is non-uniform.
+
+    Zero and ``None`` are accepted as no-ops for backwards-compatible helper
+    defaults.  Non-zero grid distances do not have a metric meaning on stretched
+    grids and must be expressed in metres instead.
+    """
+    if not config.has_nonuniform_grid:
+        return
+    if any(v not in (None, 0) for v in values):
+        raise ValueError(f"{name} are index-space distances and are not supported on non-uniform grids.")
 
 
 def _resolve_static_positions_initial(
@@ -1223,6 +1276,7 @@ def _apply_constraints_iteratively(
                         constraint=c,
                         object_map=object_map,
                         slice_dict=slice_dict,
+                        config=config,
                     )
                 elif isinstance(c, RealCoordinateConstraint):
                     resolved, slice_dict = _apply_real_coordinate_constraint(
@@ -1245,6 +1299,7 @@ def _apply_constraints_iteratively(
                         object_map=object_map,
                         config=config,
                         shape_dict=shape_dict,
+                        slice_dict=slice_dict,
                     )
                 elif isinstance(c, SizeExtensionConstraint):
                     resolved, slice_dict = _apply_size_extension_constraint(
@@ -1307,9 +1362,8 @@ def _resolve_static_shapes(
             if obj.partial_grid_shape[axis] is not None:
                 shape_dict[obj_name][axis] = obj.partial_grid_shape[axis]
             if obj.partial_real_shape[axis] is not None:
-                shape_dict[obj_name][axis] = round(
-                    obj.partial_real_shape[axis] / config.resolution  # type: ignore
-                )
+                cur_grid_shape = _real_length_to_grid_size(config, axis, obj.partial_real_shape[axis])  # type: ignore
+                shape_dict[obj_name][axis] = cur_grid_shape
     return shape_dict
 
 
@@ -1385,7 +1439,12 @@ def _apply_grid_coordinate_constraint(
     constraint: GridCoordinateConstraint,
     object_map: dict[str, SimulationObject],
     slice_dict: dict[str, list[list[int | None]]],
+    config: SimulationConfig | None = None,
 ):
+    if config is not None and config.has_nonuniform_grid:
+        raise ValueError(
+            "GridCoordinateConstraint is an index-space placement API and is not supported on non-uniform grids."
+        )
     obj_name = constraint.object
     obj = object_map[obj_name]
     resolved_something = False
@@ -1413,7 +1472,7 @@ def _apply_real_coordinate_constraint(
     obj = object_map[obj_name]
     resolved_something = False
     for axis_idx, axis in enumerate(constraint.axes):
-        cur_size = round(constraint.coordinates[axis_idx] / config.resolution)
+        cur_size = _real_coord_to_edge_index(config, axis, constraint.coordinates[axis_idx])
         b_idx = 0 if constraint.sides[axis_idx] == "-" else 1
         if slice_dict[obj_name][axis][b_idx] is None:
             slice_dict[obj_name][axis][b_idx] = cur_size
@@ -1441,6 +1500,7 @@ def _apply_position_constraint(
     for axis_idx, axis in enumerate(constraint.axes):
         grid_margin = constraint.grid_margins[axis_idx]
         real_margin = constraint.margins[axis_idx]
+        _raise_for_nonuniform_grid_offsets(config, (grid_margin,), "grid_margins")
         # check if other knows their position
         other_b0, other_b1 = slice_dict[other_name][axis]
         if other_b0 is None or other_b1 is None:
@@ -1449,23 +1509,22 @@ def _apply_position_constraint(
         object_size = shape_dict[obj_name][axis]
         if object_size is None:
             continue
-        # calculate anchor of other
-        other_pos = constraint.other_object_positions[axis_idx]
-        other_midpoint = (other_b1 + other_b0) / 2
-        factor = (other_b1 - other_b0) / 2
-        other_offset = 0
-        if grid_margin is not None:
-            other_offset += grid_margin
+        other_anchor = config.grid.anchor_coordinate(
+            axis,
+            (other_b0, other_b1),
+            constraint.other_object_positions[axis_idx],
+        )
         if real_margin is not None:
-            other_offset += real_margin / config.resolution
-        other_anchor = other_midpoint + factor * other_pos + other_offset
-        # calculate position of object
-        obj_pos = constraint.object_positions[axis_idx]
-        obj_factor = object_size / 2
-        object_midpoint = other_anchor - obj_pos * obj_factor
-        b0 = round(object_midpoint - obj_factor)
-        # Important: do not round twice to exactly preserve object size
-        b1 = b0 + object_size
+            other_anchor += real_margin
+        if grid_margin is not None:
+            # grid_margin is in cell units; rejected for non-uniform grids above
+            other_anchor += grid_margin * config.uniform_spacing()
+        b0, b1 = config.grid.bounds_for_anchor(
+            axis,
+            object_size,
+            other_anchor,
+            constraint.object_positions[axis_idx],
+        )
         # update position or check consistency
         old_b0, old_b1 = slice_dict[obj_name][axis]
         if old_b0 is None:
@@ -1500,6 +1559,7 @@ def _apply_size_constraint(
     object_map: dict[str, SimulationObject],
     config: SimulationConfig,
     shape_dict: dict[str, list[int | None]],
+    slice_dict: dict[str, list[list[int | None]]] | None = None,
 ):
     """Resolve a size relationship between objects."""
     obj_name, other_name = constraint.object, constraint.other_object
@@ -1507,6 +1567,7 @@ def _apply_size_constraint(
     resolved_something = False
     # iterate through axes of the constraint
     for axis_idx, axis in enumerate(constraint.axes):
+        _raise_for_nonuniform_grid_offsets(config, (constraint.grid_offsets[axis_idx],), "grid_offsets")
         other_axes = constraint.other_axes[axis_idx]
         # check if other object knows their shape
         other_shape = shape_dict[other_name][other_axes]
@@ -1514,12 +1575,18 @@ def _apply_size_constraint(
             continue
         # calculate objects shape
         proportion = constraint.proportions[axis_idx]
-        grid_offset = 0
-        if constraint.grid_offsets[axis_idx] is not None:
-            grid_offset += constraint.grid_offsets[axis_idx]
+        assert slice_dict is not None, "_apply_size_constraint requires slice_dict"
+        other_b0, other_b1 = slice_dict[other_name][other_axes]
+        if other_b0 is None or other_b1 is None:
+            continue
+        other_length = config.grid.axis_extent(other_axes, (other_b0, other_b1))
+        target_length = other_length * proportion
         if constraint.offsets[axis_idx] is not None:
-            grid_offset += constraint.offsets[axis_idx] / config.resolution
-        object_shape = round(other_shape * proportion + grid_offset)
+            target_length += constraint.offsets[axis_idx]
+        if constraint.grid_offsets[axis_idx] is not None:
+            # grid_offsets are in cell units; rejected for non-uniform grids above
+            target_length += constraint.grid_offsets[axis_idx] * config.uniform_spacing()
+        object_shape = _real_length_to_grid_size(config, axis, target_length)
         # update or check consistency
         if shape_dict[obj_name][axis] is None:
             shape_dict[obj_name][axis] = object_shape
@@ -1546,21 +1613,24 @@ def _apply_size_extension_constraint(
     obj = object_map[obj_name]
     dir_idx = 0 if constraint.direction == "-" else 1
     resolved_something = False
+    _raise_for_nonuniform_grid_offsets(config, (constraint.grid_offset,), "grid_offset")
     # calculate anchor point
     if other_name is not None:
         # check if other knows their position
         other_b0, other_b1 = slice_dict[other_name][constraint.axis]
         if other_b0 is None or other_b1 is None:
             return False, slice_dict
-        # calculate anchor of other position
-        other_midpoint = (other_b1 + other_b0) / 2
-        factor = (other_b1 - other_b0) / 2
-        other_offset = 0
-        if constraint.grid_offset is not None:
-            other_offset += constraint.grid_offset
+        other_anchor_coord = config.grid.anchor_coordinate(
+            constraint.axis,
+            (other_b0, other_b1),
+            constraint.other_position,
+        )
         if constraint.offset is not None:
-            other_offset += constraint.offset / config.resolution
-        other_anchor = round(other_midpoint + factor * constraint.other_position + other_offset)
+            other_anchor_coord += constraint.offset
+        if constraint.grid_offset is not None:
+            # grid_offset is in cell units; rejected for non-uniform grids above
+            other_anchor_coord += constraint.grid_offset * config.uniform_spacing()
+        other_anchor = config.grid.coord_to_index(constraint.axis, other_anchor_coord, snap="nearest")
     else:
         # if other is not specified, extend to boundary of simulation volume
         other_anchor = slice_dict[volume_name][constraint.axis][dir_idx]

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -998,6 +998,15 @@ def _real_length_to_grid_size(config: SimulationConfig, axis: int, length: float
     Non-uniform grids snap upward so objects always cover at least the
     requested metric length.  Uniform grids use the historical round-to-nearest
     rule for exact backwards compatibility.
+
+    Limitation: on a non-uniform (stretched) grid this helper measures from
+    the lower domain edge, so the returned count reflects the local cell density
+    at the origin rather than at the object's actual placement position.  Objects
+    placed in coarser regions may therefore span more physical length than
+    requested.  A fully location-aware conversion requires knowing the object's
+    anchor position before sizing it, which is not available at this call site.
+    Use ``partial_grid_shape`` to specify sizes in cell counts when exact metric
+    sizing is required on non-uniform grids.
     """
     snap = "upper" if config.has_nonuniform_grid else "nearest"
     return config.grid.length_to_cell_count(axis, length, snap=snap)

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -1017,9 +1017,21 @@ def _real_coord_to_edge_index(config: SimulationConfig, axis: int, coord: float)
     return config.grid.coord_to_index(axis, coord, snap="nearest")
 
 
-def _center_to_bounds_for_grid(config: SimulationConfig, axis: int, real_pos: float, size: int) -> tuple[int, int]:
-    """Convert a physical center and resolved grid size to edge bounds."""
-    return config.grid.bounds_for_center(axis, real_pos, size)
+def _center_to_bounds_for_grid(
+    config: SimulationConfig, axis: int, real_pos: float, size: int, volume_size: int
+) -> tuple[int, int]:
+    """Convert a center-relative position to edge bounds, accounting for grid geometry.
+
+    real_pos is interpreted relative to the simulation volume center (0 = center of domain).
+    Works for both uniform and non-uniform grids.
+    """
+    grid = config.grid
+    if isinstance(grid, RectilinearGrid):
+        edges = grid.edges(axis)
+        volume_center_coord = float(edges[0] + edges[-1]) / 2
+    else:
+        volume_center_coord = grid.origin[axis] + volume_size * grid.spacing / 2
+    return grid.bounds_for_center(axis, real_pos + volume_center_coord, size)
 
 
 def _raise_for_nonuniform_grid_offsets(config: SimulationConfig, values: Sequence[int | None], name: str):
@@ -1075,9 +1087,10 @@ def _resolve_static_positions_initial(
                 if volume_size is None:
                     raise ValueError(f"Simulation volume size for axis {axis} is unresolved.")
 
-                lower, upper = _center_to_bounds(
+                lower, upper = _center_to_bounds_for_grid(
+                    config=config,
+                    axis=axis,
                     real_pos=real_position,
-                    resolution=config.resolution,
                     size=size,
                     volume_size=volume_size,
                 )
@@ -1143,9 +1156,10 @@ def _resolve_static_positions_iterative(
                 if volume_size is None:
                     raise ValueError(f"Simulation volume size for axis {axis} is unresolved.")
 
-                lower, upper = _center_to_bounds(
+                lower, upper = _center_to_bounds_for_grid(
+                    config=config,
+                    axis=axis,
                     real_pos=real_position,
-                    resolution=config.resolution,
                     size=size,
                     volume_size=volume_size,
                 )

--- a/src/fdtdx/fdtd/update.py
+++ b/src/fdtdx/fdtd/update.py
@@ -93,7 +93,9 @@ def pad_fields_for_boundaries(
     Args:
         fields: Field array of shape (3, Nx, Ny, Nz)
         objects: Container with simulation objects including boundaries
-        config: Simulation configuration (provides resolution)
+        config: Simulation configuration. The scalar spacing argument is kept
+            for boundary API compatibility; grid-aware boundaries should read
+            physical metrics from ``config.grid`` when it is available.
 
     Returns:
         Padded fields of shape (3, Nx+2, Ny+2, Nz+2) with all corrections applied
@@ -103,8 +105,13 @@ def pad_fields_for_boundaries(
     boundaries = objects.boundary_objects
     if boundaries:
         volume_shape = objects.volume.grid_shape
+        if config.has_nonuniform_grid:
+            assert config.resolved_grid is not None
+            spacing = float(config.resolved_grid.min_spacing)
+        else:
+            spacing = config.uniform_spacing()
         for boundary in boundaries:
-            padded = boundary.apply_pad_correction(padded, volume_shape, config.resolution)
+            padded = boundary.apply_pad_correction(padded, volume_shape, spacing)
     return padded
 
 
@@ -689,6 +696,7 @@ def update_detector_states(
     interpolated_E, interpolated_H = interpolate_fields(
         E_pad=E_pad,
         H_pad=H_avg_pad,
+        config=config,
     )
 
     def helper_fn(E_input, H_input, detector: Detector):

--- a/src/fdtdx/materials.py
+++ b/src/fdtdx/materials.py
@@ -1,5 +1,4 @@
 import math
-from typing import cast
 
 import numpy as np
 
@@ -49,20 +48,7 @@ def _normalize_material_property(
             else:
                 raise ValueError(f"Invalid material property tuple: {value}. Expected a tuple of 3 tuples or 3 floats.")
         elif len(value) == 9:
-            return cast(
-                tuple[
-                    float,
-                    float,
-                    float,
-                    float,
-                    float,
-                    float,
-                    float,
-                    float,
-                    float,
-                ],
-                value,
-            )
+            return value
         else:
             raise ValueError(f"Material property tuple must have exactly 3 or 9 elements, got {len(value)}")
     else:

--- a/src/fdtdx/objects/boundaries/bloch.py
+++ b/src/fdtdx/objects/boundaries/bloch.py
@@ -146,5 +146,10 @@ class BlochBoundary(BaseBoundary):
             Complex scalar exp(i * k_axis * L) where L = volume_shape[axis] * resolution
         """
         k = self.bloch_vector[self.axis]
-        L = volume_shape[self.axis] * resolution
+        grid = getattr(self._config, "resolved_grid", None)
+        if grid is not None:
+            edges = grid.edges(self.axis)
+            L = edges[volume_shape[self.axis]] - edges[0]
+        else:
+            L = volume_shape[self.axis] * resolution
         return jnp.exp(1j * k * L)

--- a/src/fdtdx/objects/boundaries/initialization.py
+++ b/src/fdtdx/objects/boundaries/initialization.py
@@ -169,37 +169,37 @@ class BoundaryConfig(TreeClass):
     #: Initial sigma value at min x boundary. Default 0.0.
     sigma_start_minx: float | None = frozen_field(default=None)
 
-    #: Final sigma value at min x boundary. Default -(3.0 + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * (self.thickness * self._config.resolution)).
+    #: Final sigma value at min x boundary. Default -(3.0 + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * (self.thickness * self._config.uniform_spacing())).
     sigma_end_minx: float | None = frozen_field(default=None)
 
     #: Initial sigma value at max x boundary. Default 0.0.
     sigma_start_maxx: float | None = frozen_field(default=None)
 
-    #: Final sigma value at max x boundary. Default -(3.0 + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * (self.thickness * self._config.resolution)).
+    #: Final sigma value at max x boundary. Default -(3.0 + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * (self.thickness * self._config.uniform_spacing())).
     sigma_end_maxx: float | None = frozen_field(default=None)
 
     #: Initial sigma value at min y boundary. Default 0.0.
     sigma_start_miny: float | None = frozen_field(default=None)
 
-    #: Final sigma value at min y boundary. Default -(3.0 + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * (self.thickness * self._config.resolution)).
+    #: Final sigma value at min y boundary. Default -(3.0 + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * (self.thickness * self._config.uniform_spacing())).
     sigma_end_miny: float | None = frozen_field(default=None)
 
     #: Initial sigma value at max y boundary. Default 0.0.
     sigma_start_maxy: float | None = frozen_field(default=None)
 
-    #: Final sigma value at max y boundary. Default -(3.0 + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * (self.thickness * self._config.resolution)).
+    #: Final sigma value at max y boundary. Default -(3.0 + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * (self.thickness * self._config.uniform_spacing())).
     sigma_end_maxy: float | None = frozen_field(default=None)
 
     #: Initial sigma value at min z boundary. Default 0.0.
     sigma_start_minz: float | None = frozen_field(default=None)
 
-    #: Final sigma value at min z boundary. Default -(3.0 + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * (self.thickness * self._config.resolution)).
+    #: Final sigma value at min z boundary. Default -(3.0 + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * (self.thickness * self._config.uniform_spacing())).
     sigma_end_minz: float | None = frozen_field(default=None)
 
     #: Initial sigma value at max z boundary. Default 0.0.
     sigma_start_maxz: float | None = frozen_field(default=None)
 
-    #: Final sigma value at max z boundary. Default -(3.0 + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * (self.thickness * self._config.resolution)).
+    #: Final sigma value at max z boundary. Default -(3.0 + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * (self.thickness * self._config.uniform_spacing())).
     sigma_end_maxz: float | None = frozen_field(default=None)
 
     #: Polynomial order for sigma grading at min x boundary. Default 3.0.

--- a/src/fdtdx/objects/boundaries/perfectly_matched_layer.py
+++ b/src/fdtdx/objects/boundaries/perfectly_matched_layer.py
@@ -87,11 +87,23 @@ class PerfectlyMatchedLayer(BaseBoundary):
         # Now calculate sigma_end if it wasn't provided by the user
         if self.sigma_end is None:
             assert self.sigma_order is not None, "sigma_order should be set by __post_init__"
-            pml_thickness = self.thickness * self._config.resolution
+            pml_thickness = self._physical_thickness()
             sigma_end_calculated = -(self.sigma_order + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * pml_thickness)
             self = self.aset("sigma_end", sigma_end_calculated.astype(float))
 
         return self
+
+    def _physical_thickness(self) -> float:
+        """Return PML thickness in metres.
+
+        Uniform-grid simulations keep the historical ``cell_count * spacing``
+        behavior.  Non-uniform grids derive thickness from physical grid edges so
+        the same PML cell count can represent stretched physical layers.
+        """
+        grid = self._config.resolved_grid
+        if grid is not None:
+            return grid.axis_extent(self.axis, self.grid_slice_tuple[self.axis])
+        return self.thickness * self._config.uniform_spacing()
 
     @property
     @override
@@ -142,18 +154,22 @@ class PerfectlyMatchedLayer(BaseBoundary):
 
         # Create distance array along the PML axis
         # d varies from 0 (at interface) to L (at outer edge)
-        if self.direction == "-":
+        if self._config.has_nonuniform_grid:
+            dE, dH, norm = self._compute_nonuniform_pml_depths(dtype)
+        elif self.direction == "-":
             # For min boundary, distance increases as we go towards lower indices
             dE = jnp.arange(L - 1, -1, -1, dtype=dtype)
             dH = jnp.append(jnp.arange(L - 1.5, -0.5, -1, dtype=dtype), 0)
+            norm = L
         else:
             # For max boundary, distance increases as we go towards higher indices
             dE = jnp.insert(jnp.arange(0.5, L - 0.5, 1, dtype=dtype), 0, 0)
             dH = jnp.arange(0, L, 1, dtype=dtype)
+            norm = L
 
         # Compute polynomial grading: value_start + (value_end - value_start) * (d/L)^order
-        profileE_1d = value_start + (value_end - value_start) * jnp.power(dE / L, order)
-        profileH_1d = value_start + (value_end - value_start) * jnp.power(dH / L, order)
+        profileE_1d = value_start + (value_end - value_start) * jnp.power(dE / norm, order)
+        profileH_1d = value_start + (value_end - value_start) * jnp.power(dH / norm, order)
 
         # Create shape matching PML region with grading only along self.axis
         shape = [1, 1, 1]
@@ -165,6 +181,35 @@ class PerfectlyMatchedLayer(BaseBoundary):
         profileH = jnp.broadcast_to(profileH_reshaped, self.grid_shape)
 
         return profileE, profileH
+
+    def _compute_nonuniform_pml_depths(self, dtype) -> tuple[jax.Array, jax.Array, float]:
+        """Return E/H physical depths into a non-uniform PML.
+
+        Depth is measured from the interior PML interface toward the outer
+        boundary.  The E profile uses cell-edge depth so the interface cell has
+        zero depth, matching the existing uniform-grid endpoint convention.  The
+        H profile uses cell-center depth except at the interface cell, where it is
+        pinned to zero for continuity with the historical CPML staggering.
+        """
+        grid = self._config.resolved_grid
+        assert grid is not None
+        lower, upper = self.grid_slice_tuple[self.axis]
+        edges = grid.edges(self.axis)[lower : upper + 1].astype(dtype)
+        norm = float(edges[-1] - edges[0])
+        centers = 0.5 * (edges[:-1] + edges[1:])
+
+        if self.direction == "-":
+            interface = edges[-1]
+            dE = interface - edges[1:]
+            dH = interface - centers
+            dH = dH.at[-1].set(0)
+        else:
+            interface = edges[0]
+            dE = edges[:-1] - interface
+            dH = centers - interface
+            dH = dH.at[0].set(0)
+
+        return dE, dH, norm
 
     def modify_arrays(
         self,

--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -65,6 +65,7 @@ class Detector(SimulationObject, ABC):
     _num_time_steps_on: int = frozen_private_field()
     _is_on_at_time_step_arr: jax.Array = private_field()
     _time_step_to_arr_idx: jax.Array = private_field()
+    _cached_cell_volume_weights: jax.Array = private_field()
 
     @property
     def num_time_steps_recorded(self) -> int:
@@ -79,6 +80,78 @@ class Detector(SimulationObject, ABC):
         if self._num_time_steps_on is None:
             raise Exception("Detector is not yet initialized")
         return self._num_time_steps_on
+
+    def _cell_volume_weights(self) -> jax.Array:
+        """Return physical cell-volume weights for this detector's grid slice."""
+        return self._cached_cell_volume_weights
+
+    def _volume_weighted_spatial_mean(self, values: jax.Array, leading_dims: int) -> jax.Array:
+        """Average spatial detector samples using physical cell volumes.
+
+        Args:
+            values: Array whose final three dimensions match ``grid_shape``.
+            leading_dims: Number of leading non-spatial dimensions to preserve,
+                such as component or frequency axes.
+
+        Returns:
+            ``values`` averaged over the three spatial dimensions.
+        """
+        weights = self._cell_volume_weights()
+        weight_shape = (1,) * leading_dims + weights.shape
+        spatial_axes = tuple(range(leading_dims, values.ndim))
+        return jnp.sum(values * weights.reshape(weight_shape), axis=spatial_axes) / jnp.sum(weights)
+
+    def _plot_axis_centers_um(self, axis: int) -> np.ndarray:
+        """Return detector-local cell centers in micrometres for plotting.
+
+        Rectilinear grids use the physical cell centers from ``RectilinearGrid``.  The
+        coordinates are shifted so plots start at the detector slice origin,
+        matching the historical uniform-grid display convention.
+        """
+        grid = self._config.resolved_grid
+        if grid is not None:
+            start, stop = self.grid_slice_tuple[axis]
+            edges = np.asarray(grid.edges(axis)[start : stop + 1])
+            centers = 0.5 * (edges[:-1] + edges[1:])
+            return (centers - edges[0]) / 1.0e-6
+
+        spacing = self._config.uniform_spacing()
+        return (np.arange(self.grid_shape[axis]) + 0.5) * spacing / 1.0e-6
+
+    def _plot_axis_edges_um(self, axis: int) -> np.ndarray:
+        """Return detector-local cell edges in micrometres for slice plots."""
+        grid = self._config.resolved_grid
+        if grid is not None:
+            start, stop = self.grid_slice_tuple[axis]
+            edges = np.asarray(grid.edges(axis)[start : stop + 1])
+            return (edges - edges[0]) / 1.0e-6
+
+        spacing = self._config.uniform_spacing()
+        return np.arange(self.grid_shape[axis] + 1) * spacing / 1.0e-6
+
+    def _plot_resolutions(self) -> tuple[float, float, float]:
+        """Return a scalar-resolution tuple for legacy plotting APIs.
+
+        When a non-uniform ``RectilinearGrid`` is present this value is only a fallback
+        for call signatures; rectilinear plots receive explicit edge arrays and
+        do not use the scalar spacing to position cells.
+        """
+        if self._config.has_nonuniform_grid:
+            assert self._config.resolved_grid is not None
+            spacing = self._config.resolved_grid.min_spacing
+            return (spacing, spacing, spacing)
+        spacing = self._config.uniform_spacing()
+        return (spacing, spacing, spacing)
+
+    def _plot_coordinate_edges_um(self) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+        """Return rectilinear detector edge coordinates when needed for plots."""
+        if not self._config.has_nonuniform_grid:
+            return None
+        return (
+            self._plot_axis_edges_um(0),
+            self._plot_axis_edges_um(1),
+            self._plot_axis_edges_um(2),
+        )
 
     def _calculate_on_list(
         self,
@@ -138,6 +211,14 @@ class Detector(SimulationObject, ABC):
                 counter += 1
         time_to_arr_idx_arr = jnp.asarray(time_to_arr_idx_list, dtype=jnp.int32)
         self = self.aset("_time_step_to_arr_idx", time_to_arr_idx_arr, create_new_ok=True)
+        # compute cell volume weights now that config and grid_slice are available
+        grid = self._config.resolved_grid
+        if grid is not None:
+            weights = grid.cell_volume(self.grid_slice_tuple)
+        else:
+            spacing = self._config.uniform_spacing()
+            weights = jnp.ones(self.grid_shape, dtype=self.dtype) * spacing**3
+        self = self.aset("_cached_cell_volume_weights", weights, create_new_ok=True)
         return self
 
     def init_state(
@@ -232,17 +313,20 @@ class Detector(SimulationObject, ABC):
                 fig = plot_line_over_time(arr=v, time_steps=time_steps.tolist(), metric_name=f"{self.name}: {k}")
                 figs[k] = fig
         elif squeezed_ndim == 1 and self.num_time_steps_recorded == 1:
-            SCALE = 10
             xlabel = None
+            spatial_axis = None
             if self.grid_shape[0] > 1 and self.grid_shape[1] <= 1 and self.grid_shape[2] <= 1:
                 xlabel = "X axis (μm)"
+                spatial_axis = self._plot_axis_centers_um(0)
             elif self.grid_shape[0] <= 1 and self.grid_shape[1] > 1 and self.grid_shape[2] <= 1:
                 xlabel = "Y axis (μm)"
+                spatial_axis = self._plot_axis_centers_um(1)
             elif self.grid_shape[0] <= 1 and self.grid_shape[1] <= 1 and self.grid_shape[2] > 1:
                 xlabel = "Z axis (μm)"
+                spatial_axis = self._plot_axis_centers_um(2)
             assert xlabel is not None, "This should never happen"
+            assert spatial_axis is not None, "This should never happen"
             for k, v in squeezed_arrs.items():
-                spatial_axis = np.arange(len(v)) / SCALE
                 fig = plot_line_over_time(
                     arr=v, time_steps=spatial_axis, metric_name=f"{self.name}: {k}", xlabel=xlabel
                 )
@@ -252,9 +336,6 @@ class Detector(SimulationObject, ABC):
             time_steps = np.where(np.asarray(self._is_on_at_time_step_arr))[0]
             time_steps = time_steps * self._config.time_step_duration
 
-            # Determine spatial axis based on which dimension has size > 1
-            SCALE = 10  # μm per grid point
-
             for k, v in squeezed_arrs.items():
                 # Determine which dimension is spatial (not time)
                 spatial_dim = 1 if v.shape[1] > 1 else 0
@@ -262,8 +343,10 @@ class Detector(SimulationObject, ABC):
                     # Transpose if needed so time is always first dimension
                     v = v.T
 
-                # Create spatial axis in μm
-                spatial_points = np.arange(v.shape[1]) / SCALE
+                active_axes = [axis for axis, size in enumerate(self.grid_shape) if size > 1]
+                if len(active_axes) != 1:
+                    raise Exception(f"Cannot infer one spatial plotting axis for grid shape {self.grid_shape}")
+                spatial_points = self._plot_axis_centers_um(active_axes[0])
 
                 fig = plot_waterfall_over_time(
                     arr=v,
@@ -280,11 +363,8 @@ class Detector(SimulationObject, ABC):
                     xy_slice=squeezed_arrs["XY Plane"],
                     xz_slice=squeezed_arrs["XZ Plane"],
                     yz_slice=squeezed_arrs["YZ Plane"],
-                    resolutions=(
-                        self._config.resolution,
-                        self._config.resolution,
-                        self._config.resolution,
-                    ),
+                    resolutions=self._plot_resolutions(),
+                    coordinate_edges_um=self._plot_coordinate_edges_um(),
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
                 )
@@ -301,11 +381,8 @@ class Detector(SimulationObject, ABC):
                     yz_slice=squeezed_arrs["YZ Plane"],
                     progress=progress,
                     num_worker=self.num_video_workers,
-                    resolutions=(
-                        self._config.resolution,
-                        self._config.resolution,
-                        self._config.resolution,
-                    ),
+                    resolutions=self._plot_resolutions(),
+                    coordinate_edges_um=self._plot_coordinate_edges_um(),
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
                 )
@@ -325,11 +402,8 @@ class Detector(SimulationObject, ABC):
                     xy_slice=xy_slice,
                     xz_slice=xz_slice,
                     yz_slice=yz_slice,
-                    resolutions=(
-                        self._config.resolution,
-                        self._config.resolution,
-                        self._config.resolution,
-                    ),
+                    resolutions=self._plot_resolutions(),
+                    coordinate_edges_um=self._plot_coordinate_edges_um(),
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
                 )
@@ -347,11 +421,8 @@ class Detector(SimulationObject, ABC):
                     yz_slice=yz_slice,
                     progress=progress,
                     num_worker=self.num_video_workers,
-                    resolutions=(
-                        self._config.resolution,
-                        self._config.resolution,
-                        self._config.resolution,
-                    ),
+                    resolutions=self._plot_resolutions(),
+                    coordinate_edges_um=self._plot_coordinate_edges_um(),
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
                 )

--- a/src/fdtdx/objects/detectors/diffractive.py
+++ b/src/fdtdx/objects/detectors/diffractive.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 
 from fdtdx import constants
 from fdtdx.core.jax.pytrees import autoinit, frozen_field
+from fdtdx.core.physics.metrics import resample_to_uniform_2d
 from fdtdx.objects.detectors.detector import Detector, DetectorState
 
 
@@ -100,6 +101,24 @@ class DiffractiveDetector(Detector):
     def _num_latent_time_steps(self) -> int:
         return 1
 
+    def _transverse_centers(self, plane_dims: list[int]) -> tuple[jax.Array, jax.Array] | None:
+        """Return physical transverse cell centers for the detector plane.
+
+        FFT order decomposition requires equally spaced samples.  On rectilinear
+        non-uniform grids, fields are first resampled onto a uniform grid spanning
+        the same detector-center extent.  Uniform grids keep the legacy direct
+        FFT path.
+        """
+        if not self._config.has_nonuniform_grid:
+            return None
+        grid = self._config.resolved_grid
+        assert grid is not None
+        centers = []
+        for axis in plane_dims:
+            lower, upper = self.grid_slice_tuple[axis]
+            centers.append(grid.centers(axis)[lower:upper])
+        return tuple(centers)  # type: ignore[return-value]
+
     def update(
         self,
         time_step: jax.Array,
@@ -124,6 +143,13 @@ class DiffractiveDetector(Detector):
         cur_E = jnp.squeeze(cur_E, axis=prop_axis + 1)  # Shape: (3, nx, ny)
         cur_H = jnp.squeeze(cur_H, axis=prop_axis + 1)  # Shape: (3, nx, ny)
 
+        transverse_centers = self._transverse_centers(plane_dims)
+        if transverse_centers is None:
+            dx = dy = self._config.uniform_spacing()
+        else:
+            cur_E, dx, dy = resample_to_uniform_2d(cur_E, transverse_centers[0], transverse_centers[1])
+            cur_H, _, _ = resample_to_uniform_2d(cur_H, transverse_centers[0], transverse_centers[1])
+
         # Compute FFT of each field component.
         # After the squeeze, cur_E/cur_H always have shape (3, dim1, dim2), so the
         # two spatial axes are always 1 and 2 regardless of which axis was squeezed.
@@ -138,7 +164,6 @@ class DiffractiveDetector(Detector):
         ky_indices = jnp.where(orders[:, 1] >= 0, orders[:, 1], Ny + orders[:, 1])
 
         # Compute wavevectors
-        dx = dy = self._config.resolution
         kx = 2 * jnp.pi * jnp.fft.fftfreq(Nx, dx)
         ky = 2 * jnp.pi * jnp.fft.fftfreq(Ny, dy)
         k0 = 2 * jnp.pi * self.frequencies[0] / constants.c  # Use first frequency for now

--- a/src/fdtdx/objects/detectors/diffractive.py
+++ b/src/fdtdx/objects/detectors/diffractive.py
@@ -117,7 +117,8 @@ class DiffractiveDetector(Detector):
         for axis in plane_dims:
             lower, upper = self.grid_slice_tuple[axis]
             centers.append(grid.centers(axis)[lower:upper])
-        return tuple(centers)  # type: ignore[return-value]
+        c0, c1 = centers
+        return c0, c1
 
     def update(
         self,

--- a/src/fdtdx/objects/detectors/energy.py
+++ b/src/fdtdx/objects/detectors/energy.py
@@ -1,4 +1,5 @@
 import jax
+import numpy as np
 
 from fdtdx.core.jax.pytrees import autoinit, frozen_field
 from fdtdx.core.physics.metrics import compute_energy
@@ -37,6 +38,29 @@ class EnergyDetector(Detector):
     #: If "mean", aggregates slices by averaging instead of using position.
     #: If None, mean is used. Defaults to None.
     aggregate: str | None = frozen_field(default=None)  # e.g., "mean"
+
+    def _slice_position_to_index(self, axis: int, real_pos: float | None, axis_len: int) -> int:
+        """Map a requested physical slice position to a local energy index.
+
+        Uniform grids keep the historical origin-plus-spacing conversion.  On a
+        rectilinear grid, slice positions are compared against cell centers in
+        the placed detector interval.  This avoids interpreting physical metres
+        through a single global resolution and makes the selected slice stable
+        under local grid stretching.
+        """
+        if real_pos is None:
+            return axis_len // 2
+        grid = self._config.resolved_grid
+        if grid is not None:
+            start, stop = self.grid_slice_tuple[axis]
+            centers = np.asarray(grid.centers(axis)[start:stop])
+            idx = int(np.argmin(np.abs(centers - real_pos)))
+            return max(0, min(idx, axis_len - 1))
+
+        spacing = self._config.uniform_spacing()
+        origin = self.grid_slice[axis].start * spacing
+        idx = int((real_pos - origin) / spacing)
+        return max(0, min(idx, axis_len - 1))
 
     def _shape_dtype_single_time_step(
         self,
@@ -90,20 +114,9 @@ class EnergyDetector(Detector):
                 energy_xz = energy.mean(axis=1)
                 energy_yz = energy.mean(axis=0)
             else:
-                # Convert real-world positions to indices
-                origin_x = self.grid_slice[0].start * self._config.resolution
-                origin_y = self.grid_slice[1].start * self._config.resolution
-                origin_z = self.grid_slice[2].start * self._config.resolution
-
-                def to_index(real_pos, origin, axis_len):
-                    if real_pos is not None:
-                        idx = int((real_pos - origin) / self._config.resolution)
-                        return max(0, min(idx, axis_len - 1))
-                    return axis_len // 2
-
-                x_idx = to_index(self.x_slice, origin_x, energy.shape[0])
-                y_idx = to_index(self.y_slice, origin_y, energy.shape[1])
-                z_idx = to_index(self.z_slice, origin_z, energy.shape[2])
+                x_idx = self._slice_position_to_index(0, self.x_slice, energy.shape[0])
+                y_idx = self._slice_position_to_index(1, self.y_slice, energy.shape[1])
+                z_idx = self._slice_position_to_index(2, self.z_slice, energy.shape[2])
 
                 energy_xy = energy[:, :, z_idx]
                 energy_xz = energy[:, y_idx, :]
@@ -120,6 +133,7 @@ class EnergyDetector(Detector):
             }
 
         if self.reduce_volume:
+            energy = energy * self._cell_volume_weights()
             total_energy = energy.sum()
             new_arr = state["energy"].at[arr_idx].set(total_energy)
             return {"energy": new_arr}

--- a/src/fdtdx/objects/detectors/energy.py
+++ b/src/fdtdx/objects/detectors/energy.py
@@ -1,5 +1,5 @@
 import jax
-import numpy as np
+import jax.numpy as jnp
 
 from fdtdx.core.jax.pytrees import autoinit, frozen_field
 from fdtdx.core.physics.metrics import compute_energy
@@ -39,7 +39,7 @@ class EnergyDetector(Detector):
     #: If None, mean is used. Defaults to None.
     aggregate: str | None = frozen_field(default=None)  # e.g., "mean"
 
-    def _slice_position_to_index(self, axis: int, real_pos: float | None, axis_len: int) -> int:
+    def _slice_position_to_index(self, axis: int, real_pos: float | None, axis_len: int) -> int | jax.Array:
         """Map a requested physical slice position to a local energy index.
 
         Uniform grids keep the historical origin-plus-spacing conversion.  On a
@@ -47,15 +47,19 @@ class EnergyDetector(Detector):
         the placed detector interval.  This avoids interpreting physical metres
         through a single global resolution and makes the selected slice stable
         under local grid stretching.
+
+        Returns a plain Python int for uniform grids (safe as a static index
+        under jit) and a 0-d JAX array for non-uniform grids (safe as a
+        dynamic index under jit via JAX's dynamic indexing semantics).
         """
         if real_pos is None:
             return axis_len // 2
         grid = self._config.resolved_grid
         if grid is not None:
             start, stop = self.grid_slice_tuple[axis]
-            centers = np.asarray(grid.centers(axis)[start:stop])
-            idx = int(np.argmin(np.abs(centers - real_pos)))
-            return max(0, min(idx, axis_len - 1))
+            centers = grid.centers(axis)[start:stop]
+            idx = jnp.clip(jnp.argmin(jnp.abs(centers - real_pos)), 0, axis_len - 1)
+            return idx
 
         spacing = self._config.uniform_spacing()
         origin = self.grid_slice[axis].start * spacing

--- a/src/fdtdx/objects/detectors/field.py
+++ b/src/fdtdx/objects/detectors/field.py
@@ -57,7 +57,7 @@ class FieldDetector(Detector):
         EH = jnp.stack(fields, axis=0)
 
         if self.reduce_volume:
-            EH = EH.mean(axis=(1, 2, 3))
+            EH = self._volume_weighted_spatial_mean(EH, leading_dims=1)
         arr_idx = self._time_step_to_arr_idx[time_step]
         new_full_arr = state["fields"].at[arr_idx].set(EH)
         new_state = {"fields": new_full_arr}

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -119,7 +119,8 @@ class ModeOverlapDetector(PhasorDetector):
                 continue
             lower, upper = self.grid_slice_tuple[axis]
             transverse_edges.append(grid.edges(axis)[lower : upper + 1])
-        return tuple(transverse_edges)
+        e0, e1 = transverse_edges
+        return e0, e1
 
     def _mode_solver_resolution(self) -> float:
         """Return scalar resolution only for legacy uniform mode-solver setup.

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -58,9 +58,11 @@ class ModeOverlapDetector(PhasorDetector):
 
     #: Cannot be specified here since plotting a single scalar is useless.
     plot: bool = frozen_field(default=False, init=False)  # single scalar is useless for plotting
+
     _mode_E: jax.Array = private_field()
     _mode_H: jax.Array = private_field()
     _mode_neff: jax.Array = private_field()  # not required for detection, used for inspection
+    _cached_face_area_weights: jax.Array = private_field()
 
     @property
     def propagation_axis(self) -> int:
@@ -87,7 +89,49 @@ class ModeOverlapDetector(PhasorDetector):
             raise ValueError(
                 f"bend_axis ({self.bend_axis}) must differ from the propagation axis ({self.propagation_axis})"
             )
+        grid = self._config.resolved_grid
+        if grid is not None:
+            weights = grid.face_area(axis=self.propagation_axis, slice_tuple=self.grid_slice_tuple)
+        else:
+            spacing = self._config.uniform_spacing()
+            weights = jnp.ones(self.grid_shape, dtype=jnp.float32) * spacing * spacing
+        self = self.aset("_cached_face_area_weights", weights, create_new_ok=True)
         return self
+
+    def _face_area_weights(self) -> jax.Array:
+        """Return detector-plane face areas for mode-overlap integration."""
+        return self._cached_face_area_weights
+
+    def _transverse_edge_coordinates(self) -> tuple[jax.Array, jax.Array] | None:
+        """Return physical transverse edge coordinates for the mode solver.
+
+        Tidy3D can solve modes on rectilinear non-uniform grids when supplied
+        with edge-coordinate arrays.  Returning ``None`` keeps the uniform scalar
+        spacing path for legacy configurations and older tests.
+        """
+        grid = self._config.resolved_grid
+        if grid is None:
+            return None
+
+        transverse_edges = []
+        for axis in range(3):
+            if axis == self.propagation_axis:
+                continue
+            lower, upper = self.grid_slice_tuple[axis]
+            transverse_edges.append(grid.edges(axis)[lower : upper + 1])
+        return tuple(transverse_edges)
+
+    def _mode_solver_resolution(self) -> float:
+        """Return scalar resolution only for legacy uniform mode-solver setup.
+
+        ``compute_mode`` ignores this value when explicit transverse coordinates
+        are supplied.  For non-uniform grids we pass a harmless finite value so
+        the compatibility argument does not force a uniform-grid check.
+        """
+        if self._config.has_nonuniform_grid:
+            assert self._config.resolved_grid is not None
+            return self._config.resolved_grid.min_spacing
+        return self._config.uniform_spacing()
 
     def apply(
         self,
@@ -127,13 +171,14 @@ class ModeOverlapDetector(PhasorDetector):
             frequency=self.wave_characters[0].get_frequency(),
             inv_permittivities=inv_permittivity_slice,
             inv_permeabilities=inv_permeability_slice,
-            resolution=self._config.resolution,
+            resolution=self._mode_solver_resolution(),
             direction=self.direction,
             mode_index=self.mode_index,
             filter_pol=self.filter_pol,
             dtype=self._config.dtype,
             bend_radius=self.bend_radius,
             bend_axis=self.bend_axis,
+            transverse_coords=self._transverse_edge_coordinates(),
         )
 
         self = self.aset("_mode_E", mode_E, create_new_ok=True)
@@ -164,7 +209,9 @@ class ModeOverlapDetector(PhasorDetector):
             axis=0,
         )[self.propagation_axis]
 
-        alpha_coeff = jnp.sum(E_cross_H_star_sim + E_star_cross_H_sim)
+        integrand = E_cross_H_star_sim + E_star_cross_H_sim
+        integrand = integrand * self._face_area_weights()
+        alpha_coeff = jnp.sum(integrand)
 
         # in pulsed mode return unscaled coefficient
         if self.scaling_mode != "pulse":

--- a/src/fdtdx/objects/detectors/phasor.py
+++ b/src/fdtdx/objects/detectors/phasor.py
@@ -108,9 +108,8 @@ class PhasorDetector(Detector):
         new_phasors = EH * phasors * static_scale  # Shape: (num_freqs, num_components, *grid_shape)
 
         if self.reduce_volume:
-            # Average over all spatial dimensions
-            spatial_axes = tuple(range(2, new_phasors.ndim))  # Skip freq and component axes
-            new_phasors = new_phasors.mean(axis=spatial_axes) if spatial_axes else new_phasors
+            # Average over spatial dimensions using physical cell volumes.
+            new_phasors = self._volume_weighted_spatial_mean(new_phasors, leading_dims=2)
 
         if self.inverse:
             result = state["phasor"] - new_phasors[None, ...]

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -9,11 +9,31 @@ def plot_2d_from_slices(
     xz_slice: np.ndarray,
     yz_slice: np.ndarray,
     resolutions: tuple[float, float, float],
+    coordinate_edges_um: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
     minvals: tuple[float | None, float | None, float | None] = (None, None, None),
     maxvals: tuple[float | None, float | None, float | None] = (None, None, None),
     plot_interpolation: str = "gaussian",
     plot_dpi: int | None = None,
 ) -> Figure:
+    """Plot orthogonal slices using either uniform spacing or rectilinear edges.
+
+    Args:
+        xy_slice: Values on an ``(x, y)`` slice.
+        xz_slice: Values on an ``(x, z)`` slice.
+        yz_slice: Values on a ``(y, z)`` slice.
+        resolutions: Legacy uniform ``(dx, dy, dz)`` spacing in metres.
+        coordinate_edges_um: Optional rectilinear edge coordinates in micrometres
+            for the plotted detector slice. When supplied, plots use
+            ``pcolormesh`` so non-uniform cell widths are represented by their
+            physical edge positions instead of one scalar spacing.
+        minvals: Per-slice color minima.
+        maxvals: Per-slice color maxima.
+        plot_interpolation: Interpolation used by the legacy uniform imshow path.
+        plot_dpi: Figure DPI.
+
+    Returns:
+        Matplotlib figure with XY, XZ, and YZ panels.
+    """
     slices = [xy_slice, xz_slice, yz_slice]
     for a in range(3):
         if minvals[a] is None:
@@ -34,22 +54,34 @@ def plot_2d_from_slices(
 
     # Create XY plane plot
     ax1 = fig.add_subplot(131)
-    extent1 = (
-        0,
-        xy_slice.shape[0] * res_x,
-        0,
-        xy_slice.shape[1] * res_y,
-    )
-    cax1 = ax1.imshow(
-        xy_slice.T,
-        cmap=cmap,
-        vmin=minvals[0],
-        vmax=maxvals[0],
-        extent=extent1,
-        interpolation=plot_interpolation,
-        aspect="equal",
-        origin="lower",
-    )
+    if coordinate_edges_um is None:
+        extent1 = (
+            0,
+            xy_slice.shape[0] * res_x,
+            0,
+            xy_slice.shape[1] * res_y,
+        )
+        cax1 = ax1.imshow(
+            xy_slice.T,
+            cmap=cmap,
+            vmin=minvals[0],
+            vmax=maxvals[0],
+            extent=extent1,
+            interpolation=plot_interpolation,
+            aspect="equal",
+            origin="lower",
+        )
+    else:
+        cax1 = ax1.pcolormesh(
+            coordinate_edges_um[0],
+            coordinate_edges_um[1],
+            xy_slice.T,
+            cmap=cmap,
+            vmin=minvals[0],
+            vmax=maxvals[0],
+            shading="auto",
+        )
+        ax1.set_aspect("equal")
     ax1.set_xlabel("X axis (µm)")
     ax1.set_ylabel("Y axis (µm)")
 
@@ -58,22 +90,34 @@ def plot_2d_from_slices(
     # Create XZ plane plot
 
     ax2 = fig.add_subplot(132)
-    extent2 = (
-        0,
-        xz_slice.shape[0] * res_x,
-        0,
-        xz_slice.shape[1] * res_z,
-    )
-    cax2 = ax2.imshow(
-        xz_slice.T,
-        cmap=cmap,
-        vmin=minvals[1],
-        vmax=maxvals[1],
-        extent=extent2,
-        interpolation=plot_interpolation,
-        aspect="equal",
-        origin="lower",
-    )
+    if coordinate_edges_um is None:
+        extent2 = (
+            0,
+            xz_slice.shape[0] * res_x,
+            0,
+            xz_slice.shape[1] * res_z,
+        )
+        cax2 = ax2.imshow(
+            xz_slice.T,
+            cmap=cmap,
+            vmin=minvals[1],
+            vmax=maxvals[1],
+            extent=extent2,
+            interpolation=plot_interpolation,
+            aspect="equal",
+            origin="lower",
+        )
+    else:
+        cax2 = ax2.pcolormesh(
+            coordinate_edges_um[0],
+            coordinate_edges_um[2],
+            xz_slice.T,
+            cmap=cmap,
+            vmin=minvals[1],
+            vmax=maxvals[1],
+            shading="auto",
+        )
+        ax2.set_aspect("equal")
     ax2.set_xlabel("X axis (µm)")
     ax2.set_ylabel("Z axis (µm)")
 
@@ -81,22 +125,34 @@ def plot_2d_from_slices(
 
     # # Create YZ plane plot
     ax3 = fig.add_subplot(133)
-    extent3 = (
-        0,
-        yz_slice.shape[0] * res_y,
-        0,
-        yz_slice.shape[1] * res_z,
-    )
-    cax3 = ax3.imshow(
-        yz_slice.T,
-        cmap=cmap,
-        vmin=minvals[2],
-        vmax=maxvals[2],
-        extent=extent3,
-        interpolation=plot_interpolation,
-        aspect="equal",
-        origin="lower",
-    )
+    if coordinate_edges_um is None:
+        extent3 = (
+            0,
+            yz_slice.shape[0] * res_y,
+            0,
+            yz_slice.shape[1] * res_z,
+        )
+        cax3 = ax3.imshow(
+            yz_slice.T,
+            cmap=cmap,
+            vmin=minvals[2],
+            vmax=maxvals[2],
+            extent=extent3,
+            interpolation=plot_interpolation,
+            aspect="equal",
+            origin="lower",
+        )
+    else:
+        cax3 = ax3.pcolormesh(
+            coordinate_edges_um[1],
+            coordinate_edges_um[2],
+            yz_slice.T,
+            cmap=cmap,
+            vmin=minvals[2],
+            vmax=maxvals[2],
+            shading="auto",
+        )
+        ax3.set_aspect("equal")
     ax3.set_xlabel("Y axis (µm)")
     ax3.set_ylabel("Z axis (µm)")
 

--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -23,6 +23,7 @@ def plot_from_slices(
     maxvals: tuple[float, float, float],
     plot_dpi: int | None,
     plot_interpolation: str,
+    coordinate_edges_um: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
 ):
     xy_slice, xz_slice, yz_slice = slice_tuple
 
@@ -31,6 +32,7 @@ def plot_from_slices(
         xz_slice=xz_slice,
         yz_slice=yz_slice,
         resolutions=resolutions,
+        coordinate_edges_um=coordinate_edges_um,
         minvals=minvals,
         maxvals=maxvals,
         plot_dpi=plot_dpi,
@@ -77,6 +79,7 @@ def generate_video_from_slices(
     progress: Progress | None = None,
     minvals: tuple[float | None, float | None, float | None] = (None, None, None),
     maxvals: tuple[float | None, float | None, float | None] = (None, None, None),
+    coordinate_edges_um: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
 ) -> str:
     """Generates an MP4 video from time-series slice data using parallel processing.
 
@@ -89,6 +92,8 @@ def generate_video_from_slices(
         yz_slice (np.ndarray): 3D array containing YZ plane slice data over time
         plt_fn (Callable): Plotting function to generate each frame
         resolutions (tuple[float, float, float]): Tuple of (dx, dy, dz) spatial resolutions in meters
+        coordinate_edges_um: Optional rectilinear edge coordinates in micrometres
+            for plotting non-uniform grids without resampling.
         num_worker (int | None): Number of parallel worker processes. If None, frames are processes sequentially.
         plot_interpolation (str): Interpolation method for imshow ('gaussian', 'nearest', etc)
         plot_dpi (int | None): DPI resolution for the figures. None uses default.
@@ -127,6 +132,7 @@ def generate_video_from_slices(
         maxvals=maxvals,
         plot_dpi=plot_dpi,
         plot_interpolation=plot_interpolation,
+        coordinate_edges_um=coordinate_edges_um,
     )
     slice_arr_list = [(xy_slice[t], xz_slice[t], yz_slice[t]) for t in range(time_steps)]
     if num_worker is None:

--- a/src/fdtdx/objects/detectors/poynting_flux.py
+++ b/src/fdtdx/objects/detectors/poynting_flux.py
@@ -1,10 +1,13 @@
-from typing import Literal
+from typing import Literal, Self
 
 import jax
+import jax.numpy as jnp
 
-from fdtdx.core.jax.pytrees import autoinit, frozen_field
+from fdtdx.config import SimulationConfig
+from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.core.physics.metrics import compute_poynting_flux
 from fdtdx.objects.detectors.detector import Detector, DetectorState
+from fdtdx.typing import SliceTuple3D
 
 
 @autoinit
@@ -33,6 +36,8 @@ class PoyntingFluxDetector(Detector):
     #: is returned (scalar). If true, all three vector components are returned. Defaults to False.
     keep_all_components: bool = frozen_field(default=False)
 
+    _cached_face_area_weights: jax.Array = private_field()
+
     @property
     def propagation_axis(self) -> int:
         """Determines the axis along which Poynting flux is measured.
@@ -55,6 +60,32 @@ class PoyntingFluxDetector(Detector):
             raise Exception(f"Invalid poynting flux detector shape: {self.grid_shape}")
         return self.grid_shape.index(1)
 
+    def place_on_grid(
+        self: Self,
+        grid_slice_tuple: SliceTuple3D,
+        config: SimulationConfig,
+        key: jax.Array,
+    ) -> Self:
+        self = super().place_on_grid(grid_slice_tuple=grid_slice_tuple, config=config, key=key)
+        can_determine_axis = self.keep_all_components or (
+            self.fixed_propagation_axis is not None or sum(a == 1 for a in self.grid_shape) == 1
+        )
+        if can_determine_axis:
+            grid = self._config.resolved_grid
+            if grid is not None:
+                if self.keep_all_components:
+                    weights = jnp.stack(
+                        [grid.face_area(axis=axis, slice_tuple=self.grid_slice_tuple) for axis in range(3)]
+                    )
+                else:
+                    weights = grid.face_area(axis=self.propagation_axis, slice_tuple=self.grid_slice_tuple)
+            else:
+                spacing = self._config.uniform_spacing()
+                area = jnp.ones(self.grid_shape, dtype=self.dtype) * spacing * spacing
+                weights = jnp.stack([area, area, area]) if self.keep_all_components else area
+            self = self.aset("_cached_face_area_weights", weights, create_new_ok=True)
+        return self
+
     def _shape_dtype_single_time_step(
         self,
     ) -> dict[str, jax.ShapeDtypeStruct]:
@@ -63,6 +94,10 @@ class PoyntingFluxDetector(Detector):
         else:
             shape = (1,) if self.reduce_volume else self.grid_shape
         return {"poynting_flux": jax.ShapeDtypeStruct(shape, self.dtype)}
+
+    def _face_area_weights(self) -> jax.Array:
+        """Return face-area weights matching this detector's grid slice."""
+        return self._cached_face_area_weights
 
     def update(
         self,
@@ -83,6 +118,7 @@ class PoyntingFluxDetector(Detector):
         if self.direction == "-":
             pf = -pf
         if self.reduce_volume:
+            pf = pf * self._face_area_weights()
             if self.keep_all_components:
                 pf = pf.sum(axis=(1, 2, 3))
             else:

--- a/src/fdtdx/objects/device/device.py
+++ b/src/fdtdx/objects/device/device.py
@@ -1,3 +1,4 @@
+import math
 from abc import ABC
 from typing import Self, Sequence, cast
 
@@ -49,7 +50,13 @@ class Device(OrderableObject, ABC):
     partial_voxel_real_shape: PartialRealShape3D = frozen_field(default=UNDEFINED_SHAPE_3D)
 
     _single_voxel_grid_shape: tuple[int, int, int] = frozen_private_field(default=INVALID_SHAPE_3D)
+    _matrix_voxel_grid_shape_override: tuple[int, int, int] = frozen_private_field(default=INVALID_SHAPE_3D)
+    _physical_design_voxel_shape: tuple[float, float, float] | None = frozen_private_field(default=None)
+    _physical_design_domain_shape: tuple[float, float, float] | None = frozen_private_field(default=None)
 
+    # TODO(teevee112): support physical-unit design voxels on non-uniform grids — requires a resampling layer
+    # or snapping to RectilinearGrid cell boundaries; currently only grid-cell-count voxels are
+    # reliable on non-uniform grids (see PR #312)
     @property
     def matrix_voxel_grid_shape(self) -> tuple[int, int, int]:
         """Calculate the shape of the voxel matrix in grid coordinates.
@@ -59,9 +66,13 @@ class Device(OrderableObject, ABC):
                 of the grid shape when divided by the single voxel shape.
         """
         return (
-            round(self.grid_shape[0] / self.single_voxel_grid_shape[0]),
-            round(self.grid_shape[1] / self.single_voxel_grid_shape[1]),
-            round(self.grid_shape[2] / self.single_voxel_grid_shape[2]),
+            self._matrix_voxel_grid_shape_override
+            if self._matrix_voxel_grid_shape_override != INVALID_SHAPE_3D
+            else (
+                round(self.grid_shape[0] / self.single_voxel_grid_shape[0]),
+                round(self.grid_shape[1] / self.single_voxel_grid_shape[1]),
+                round(self.grid_shape[2] / self.single_voxel_grid_shape[2]),
+            )
         )
 
     @property
@@ -77,17 +88,36 @@ class Device(OrderableObject, ABC):
 
     @property
     def single_voxel_real_shape(self) -> tuple[float, float, float]:
-        """Calculate the shape of a single voxel in real (physical) coordinates.
+        """Calculate the representative physical size of one design voxel.
 
         Returns:
-            tuple[float, float, float]: Tuple of (x,y,z) dimensions in real units, computed by multiplying
-                the grid shape by the simulation resolution.
+            Tuple of ``(x, y, z)`` dimensions in metres.
+
+        Notes:
+            On uniform simulation grids this is the exact size of each design
+            voxel.  On non-uniform grids, devices are currently supported only
+            when design voxels are specified by simulation-cell counts.  The
+            returned physical size is then the average design-voxel extent over
+            the placed device, suitable for transforms that need a representative
+            scale.  True physical-size design voxels still require a resampling
+            layer and are rejected during placement.
         """
-        grid_shape = self.single_voxel_grid_shape
+        if self._physical_design_voxel_shape is not None:
+            return self._physical_design_voxel_shape
+        grid = self._config.resolved_grid
+        if grid is not None and not grid.is_uniform:
+            return (
+                self.real_shape[0] / self.matrix_voxel_grid_shape[0],
+                self.real_shape[1] / self.matrix_voxel_grid_shape[1],
+                self.real_shape[2] / self.matrix_voxel_grid_shape[2],
+            )
+
+        single_voxel_shape = self.single_voxel_grid_shape
+        spacing = self._config.uniform_spacing()
         return (
-            grid_shape[0] * self._config.resolution,
-            grid_shape[1] * self._config.resolution,
-            grid_shape[2] * self._config.resolution,
+            single_voxel_shape[0] * spacing,
+            single_voxel_shape[1] * spacing,
+            single_voxel_shape[2] * spacing,
         )
 
     @property
@@ -113,6 +143,25 @@ class Device(OrderableObject, ABC):
         self = super().place_on_grid(grid_slice_tuple=grid_slice_tuple, config=config, key=key)
         # determine voxel shape
         voxel_grid_shape = []
+        spacing = None
+        if not config.has_nonuniform_grid:
+            spacing = config.uniform_spacing()
+        uses_physical_design_grid = config.has_nonuniform_grid and any(
+            shape is not None for shape in self.partial_voxel_real_shape
+        )
+        if uses_physical_design_grid and any(shape is not None for shape in self.partial_voxel_grid_shape):
+            raise ValueError(
+                "Non-uniform physical device voxel sizes cannot be mixed with partial_voxel_grid_shape. "
+                "Use either a physical design grid or grid-cell-count design voxels."
+            )
+        if uses_physical_design_grid:
+            raise NotImplementedError(
+                "Physical-unit design voxels (partial_voxel_real_shape) are not yet supported on "
+                "non-uniform grids. Use partial_voxel_grid_shape to specify voxel sizes in "
+                "simulation grid-cell counts instead."
+            )
+        physical_design_shape = []
+        matrix_shape_override = []
         for axis in range(3):
             partial_grid = self.partial_voxel_grid_shape[axis]
             partial_real = self.partial_voxel_real_shape[axis]
@@ -121,21 +170,35 @@ class Device(OrderableObject, ABC):
             if partial_grid is not None:
                 voxel_grid_shape.append(partial_grid)
             elif partial_real is not None:
-                voxel_grid_shape.append(round(partial_real / config.resolution))
+                if uses_physical_design_grid:
+                    if partial_real <= 0:
+                        raise ValueError(f"Physical design voxel size must be positive for {axis=}.")
+                    physical_design_shape.append(float(partial_real))
+                    matrix_shape_override.append(max(1, math.ceil(self.real_shape[axis] / partial_real)))
+                    voxel_grid_shape.append(1)
+                else:
+                    assert spacing is not None
+                    voxel_grid_shape.append(round(partial_real / spacing))
             else:
                 raise Exception(f"Multi-Material voxels not specified in axis: {axis=}")
 
         self = self.aset("_single_voxel_grid_shape", tuple(voxel_grid_shape))
+        if uses_physical_design_grid:
+            self = self.aset("_physical_design_voxel_shape", tuple(physical_design_shape))
+            self = self.aset("_physical_design_domain_shape", self.real_shape)
+            self = self.aset("_matrix_voxel_grid_shape_override", tuple(matrix_shape_override))
 
         # sanity checks on the voxel shape
         for axis in range(3):
-            float_div = is_float_divisible(
-                self.single_voxel_real_shape[axis],
-                self._config.resolution,
-            )
-            if not float_div:
-                raise Exception(f"Not divisible: {self.single_voxel_real_shape[axis]=}, {self._config.resolution=}")
-            if self.grid_shape[axis] % self.matrix_voxel_grid_shape[axis] != 0:
+            if spacing is not None:
+                float_div = is_float_divisible(
+                    self.single_voxel_real_shape[axis],
+                    spacing,
+                    tolerance=max(1e-15, abs(spacing) * 1e-4),
+                )
+                if not float_div:
+                    raise Exception(f"Not divisible: {self.single_voxel_real_shape[axis]=}, {spacing=}")
+            if not uses_physical_design_grid and self.grid_shape[axis] % self.matrix_voxel_grid_shape[axis] != 0:
                 raise Exception(
                     f"Due to discretization, matrix got skewered for {axis=}. "
                     f"{self.grid_shape=}, {self.matrix_voxel_grid_shape=}"
@@ -176,6 +239,56 @@ class Device(OrderableObject, ABC):
                 f"but got {self.materials}"
             )
         return self
+
+    @staticmethod
+    def _overlap_weights_1d(sim_edges: jax.Array, design_edges: jax.Array) -> jax.Array:
+        """Return design-voxel overlap fractions for each simulation cell.
+
+        Rows correspond to simulation cells and columns correspond to design
+        voxels.  Each row sums to one for cells contained inside the local
+        design domain.  Using overlap fractions instead of center sampling keeps
+        physical-size design grids conservative on stretched meshes: a large
+        simulation cell that straddles multiple design voxels receives the
+        volume-weighted average of those parameters.
+        """
+        sim_lower = sim_edges[:-1, None]
+        sim_upper = sim_edges[1:, None]
+        design_lower = design_edges[None, :-1]
+        design_upper = design_edges[None, 1:]
+        overlap = jnp.maximum(0.0, jnp.minimum(sim_upper, design_upper) - jnp.maximum(sim_lower, design_lower))
+        widths = sim_upper - sim_lower
+        return overlap / widths
+
+    def _resample_design_params_to_sim_grid(self, params: jax.Array) -> jax.Array:
+        """Map design-grid parameters to simulation cells.
+
+        Grid-count design voxels use the legacy repeat expansion.  Physical
+        design voxels on non-uniform grids use separable volume-overlap weights
+        so the expanded simulation grid represents the average design parameter
+        over each rectilinear simulation cell.
+        """
+        grid = self._config.resolved_grid
+        if self._physical_design_voxel_shape is None or grid is None:
+            return expand_matrix(
+                matrix=params,
+                grid_points_per_voxel=self.single_voxel_grid_shape,
+            )
+        if self._physical_design_domain_shape is None:
+            raise RuntimeError("Physical design-grid devices must be placed before expansion.")
+
+        overlap_weights = []
+        for axis in range(3):
+            lower, upper = self.grid_slice_tuple[axis]
+            sim_edges = grid.edges(axis)[lower : upper + 1]
+            design_edges = jnp.linspace(
+                0.0,
+                self._physical_design_domain_shape[axis],
+                self.matrix_voxel_grid_shape[axis] + 1,
+                dtype=sim_edges.dtype,
+            )
+            local_sim_edges = sim_edges - sim_edges[0]
+            overlap_weights.append(self._overlap_weights_1d(local_sim_edges, design_edges))
+        return jnp.einsum("ia,jb,kc,abc->ijk", overlap_weights[0], overlap_weights[1], overlap_weights[2], params)
 
     def init_params(
         self,
@@ -226,8 +339,5 @@ class Device(OrderableObject, ABC):
                 " make sure that the latent transformations abide to this rule."
             )
         if expand_to_sim_grid:
-            params = expand_matrix(
-                matrix=params,
-                grid_points_per_voxel=self.single_voxel_grid_shape,
-            )
+            params = self._resample_design_params_to_sim_grid(params)
         return params

--- a/src/fdtdx/objects/device/device.py
+++ b/src/fdtdx/objects/device/device.py
@@ -178,7 +178,13 @@ class Device(OrderableObject, ABC):
                     voxel_grid_shape.append(1)
                 else:
                     assert spacing is not None
-                    voxel_grid_shape.append(round(partial_real / spacing))
+                    cell_count = round(partial_real / spacing)
+                    if cell_count < 1:
+                        raise ValueError(
+                            f"Device voxel size {partial_real:.3e} m on axis {axis} rounds to 0 cells "
+                            f"at spacing {spacing:.3e} m. Increase the voxel size or reduce the grid spacing."
+                        )
+                    voxel_grid_shape.append(cell_count)
             else:
                 raise Exception(f"Multi-Material voxels not specified in axis: {axis=}")
 

--- a/src/fdtdx/objects/object.py
+++ b/src/fdtdx/objects/object.py
@@ -256,13 +256,24 @@ class SimulationObject(TreeClass, ABC):
 
     @property
     def real_shape(self) -> RealShape3D:
+        """Physical side lengths covered by this object's placed grid slice.
+
+        The value is derived from ``SimulationConfig.grid`` when available.  That
+        keeps object geometry tied to physical edge coordinates instead of a
+        global scalar resolution.  During early placement, before a concrete grid
+        has been attached to the config, the legacy uniform-resolution fallback is
+        still used for compatibility.
+        """
+        grid = self._config.resolved_grid
+        if grid is not None:
+            return grid.slice_extent(self.grid_slice_tuple)
         grid_shape = self.grid_shape
-        real_shape = (
-            grid_shape[0] * self._config.resolution,
-            grid_shape[1] * self._config.resolution,
-            grid_shape[2] * self._config.resolution,
+        spacing = self._config.uniform_spacing()
+        return (
+            grid_shape[0] * spacing,
+            grid_shape[1] * spacing,
+            grid_shape[2] * spacing,
         )
-        return real_shape
 
     @property
     def grid_shape(self) -> GridShape3D:

--- a/src/fdtdx/objects/sources/linear_polarization.py
+++ b/src/fdtdx/objects/sources/linear_polarization.py
@@ -14,6 +14,45 @@ from fdtdx.dispersion import effective_inv_permittivity
 from fdtdx.objects.sources.tfsf import TFSFPlaneSource, _build_dispersive_H_filter
 
 
+def _linear_interpolate_rectilinear_2d(
+    point: jax.Array,
+    x_coords: jax.Array,
+    y_coords: jax.Array,
+    values: jax.Array,
+) -> jax.Array:
+    """Bilinearly interpolate ``values`` sampled on rectilinear cell centers.
+
+    The tilted-source projection for non-uniform grids works in physical
+    transverse coordinates rather than legacy index coordinates.  This helper is
+    intentionally small and JAX-friendly: it finds the local bracketing centers
+    on each axis, clamps outside samples to the nearest center, and forms the
+    separable bilinear blend.  Clamping matches the practical behavior of the
+    legacy index-space interpolation near finite source boundaries.
+    """
+
+    def axis_weights(coords: jax.Array, val: jax.Array) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+        if coords.shape[0] == 1:
+            zero = jnp.asarray(0, dtype=jnp.int32)
+            return zero, zero, jnp.asarray(1.0, dtype=val.dtype), jnp.asarray(0.0, dtype=val.dtype)
+        upper = jnp.searchsorted(coords, val, side="right")
+        upper = jnp.clip(upper, 1, coords.shape[0] - 1)
+        lower = upper - 1
+        lower_coord = coords[lower]
+        upper_coord = coords[upper]
+        fraction = jnp.where(upper_coord == lower_coord, 0.0, (val - lower_coord) / (upper_coord - lower_coord))
+        fraction = jnp.clip(fraction, 0.0, 1.0)
+        return lower, upper, 1.0 - fraction, fraction
+
+    x0, x1, wx0, wx1 = axis_weights(x_coords, point[0])
+    y0, y1, wy0, wy1 = axis_weights(y_coords, point[1])
+    return (
+        wx0 * wy0 * values[x0, y0]
+        + wx0 * wy1 * values[x0, y1]
+        + wx1 * wy0 * values[x1, y0]
+        + wx1 * wy1 * values[x1, y1]
+    )
+
+
 @autoinit
 class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
     #: the electric polarization vector
@@ -24,6 +63,58 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
 
     #: whether to normalize the polarization vector
     normalize_by_energy: bool = frozen_field(default=True)
+
+    def _local_edge_coordinates(self) -> tuple[jax.Array, jax.Array, jax.Array] | None:
+        """Return source-local physical edge coordinates for Yee metrics.
+
+        Coordinates are shifted so the lower corner of this source slice is the
+        local origin.  Uniform grids can use the legacy scalar path, but
+        non-uniform grids need these explicit edge arrays for time-of-flight
+        corrections and physical profile sampling.
+        """
+        grid = self._config.resolved_grid
+        if grid is None:
+            return None
+        local_edges = []
+        for axis in range(3):
+            lower, upper = self.grid_slice_tuple[axis]
+            edges = grid.edges(axis)[lower : upper + 1]
+            local_edges.append(edges - edges[0])
+        return tuple(local_edges)
+
+    def _source_center_physical(self, source_center: jax.Array) -> jax.Array | None:
+        """Return the physical center used for grid-aware Yee time offsets."""
+        local_edges = self._local_edge_coordinates()
+        if local_edges is None:
+            return None
+        physical_center = []
+        for axis, edges in enumerate(local_edges):
+            if axis == self.propagation_axis:
+                physical_center.append(jnp.asarray(0.0, dtype=self._config.dtype))
+            elif self._config.has_nonuniform_grid:
+                center_axis = 0 if axis == self.horizontal_axis else 1
+                physical_center.append(jnp.asarray(source_center[center_axis], dtype=self._config.dtype))
+            else:
+                transverse_center = source_center[0] if axis == self.horizontal_axis else source_center[1]
+                physical_center.append(transverse_center * self._source_resolution())
+        return jnp.asarray(physical_center, dtype=self._config.dtype)
+
+    def _source_resolution(self) -> float:
+        """Return scalar spacing only for legacy source APIs.
+
+        ``calculate_time_offset_yee`` ignores this value when explicit
+        ``coordinate_edges`` are provided.  The min-spacing fallback keeps the
+        call signature usable for rectilinear grids without pretending the mesh
+        is uniform.
+        """
+        if self._config.has_nonuniform_grid:
+            assert self._config.resolved_grid is not None
+            return self._config.resolved_grid.min_spacing
+        return self._config.uniform_spacing()
+
+    def _uses_physical_source_coordinates(self) -> bool:
+        """Whether transverse source coordinates are represented in metres."""
+        return self._config.has_nonuniform_grid
 
     def apply(
         self: Self,
@@ -89,14 +180,25 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
         # update is amplitude multiplied by polarization
         amplitude_raw = self._get_amplitude_raw(center)[None, ...]
 
-        # map amplitude to propagation plane
-        w, h = jnp.meshgrid(
-            jnp.arange(self.grid_shape[self.horizontal_axis]),
-            jnp.arange(self.grid_shape[self.vertical_axis]),
-            indexing="ij",
-        )
-        wh_indices = jnp.stack((w, h), axis=-1)
-        wh_indices -= center
+        # map amplitude to propagation plane.  Uniform grids keep the legacy
+        # index-space projection; non-uniform grids project physical transverse
+        # coordinates and interpolate against physical cell centers.
+        if self._uses_physical_source_coordinates():
+            local_edges = self._local_edge_coordinates()
+            assert local_edges is not None
+            horizontal_edges = local_edges[self.horizontal_axis]
+            vertical_edges = local_edges[self.vertical_axis]
+            horizontal_centers = 0.5 * (horizontal_edges[:-1] + horizontal_edges[1:])
+            vertical_centers = 0.5 * (vertical_edges[:-1] + vertical_edges[1:])
+            w, h = jnp.meshgrid(horizontal_centers, vertical_centers, indexing="ij")
+        else:
+            w, h = jnp.meshgrid(
+                jnp.arange(self.grid_shape[self.horizontal_axis]),
+                jnp.arange(self.grid_shape[self.vertical_axis]),
+                indexing="ij",
+            )
+        wh_coords = jnp.stack((w, h), axis=-1)
+        wh_coords -= center
         # basis in plane
         h_list = [0, 0, 0]
         h_list[self.horizontal_axis] = 1
@@ -116,11 +218,20 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
             v = jnp.dot(projection, v_basis)
             return jnp.asarray((u, v), dtype=self._config.dtype)
 
-        float_projected = jax.vmap(project)(wh_indices.reshape(-1, 2))
+        float_projected = jax.vmap(project)(wh_coords.reshape(-1, 2))
         float_projected += center
-        # interpolate floating indices in original array
-        index_fn = jax.vmap(linear_interpolated_indexing, in_axes=(0, None))
-        interp = index_fn(float_projected, amplitude_raw.squeeze())
+        if self._uses_physical_source_coordinates():
+            index_fn = jax.vmap(
+                _linear_interpolate_rectilinear_2d,
+                in_axes=(0, None, None, None),
+            )
+            profile_2d = jnp.take(amplitude_raw[0], 0, axis=self.propagation_axis)
+            interp = index_fn(float_projected, horizontal_centers, vertical_centers, profile_2d)
+        else:
+            # interpolate floating indices in original array
+            index_fn = jax.vmap(linear_interpolated_indexing, in_axes=(0, None))
+            profile_2d = jnp.take(amplitude_raw[0], 0, axis=self.propagation_axis)
+            interp = index_fn(float_projected, profile_2d)
         amplitude = interp.reshape(*amplitude_raw.shape)
 
         E = amplitude * e_pol[:, None, None, None]
@@ -172,10 +283,12 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
             wave_vector=wave_vector,
             inv_permittivities=inv_permittivities,
             inv_permeabilities=inv_permeabilities,
-            resolution=self._config.resolution,
+            resolution=self._source_resolution(),
             time_step_duration=self._config.time_step_duration,
             e_polarization=e_pol,
             h_polarization=h_pol,
+            coordinate_edges=self._local_edge_coordinates(),
+            center_physical=self._source_center_physical(center),
         )
 
         self = self.aset("_E", E, create_new_ok=True)
@@ -258,7 +371,29 @@ class GaussianPlaneSource(LinearlyPolarizedPlaneSource):
         self,
         center: jax.Array,
     ) -> jax.Array:
-        grid_radius = self.radius / self._config.resolution
+        if self._config.has_nonuniform_grid:
+            local_edges = self._local_edge_coordinates()
+            assert local_edges is not None
+            horizontal_edges = local_edges[self.horizontal_axis]
+            vertical_edges = local_edges[self.vertical_axis]
+            horizontal_centers = 0.5 * (horizontal_edges[:-1] + horizontal_edges[1:])
+            vertical_centers = 0.5 * (vertical_edges[:-1] + vertical_edges[1:])
+            h_grid, v_grid = jnp.meshgrid(horizontal_centers, vertical_centers, indexing="ij")
+            h_center = center[0]
+            v_center = center[1]
+            normalized_radius_squared = ((h_grid - h_center) / self.radius) ** 2 + (
+                (v_grid - v_center) / self.radius
+            ) ** 2
+            mask = normalized_radius_squared < 1
+            exp_part = jnp.exp(-0.5 * normalized_radius_squared / self.std**2)
+            profile_2d = jnp.where(mask, exp_part, 0)
+            h_widths = horizontal_edges[1:] - horizontal_edges[:-1]
+            v_widths = vertical_edges[1:] - vertical_edges[:-1]
+            cell_areas = h_widths[:, None] * v_widths[None, :]
+            profile_2d = profile_2d / (profile_2d * cell_areas).sum()
+            return jnp.expand_dims(profile_2d, axis=self.propagation_axis)
+
+        grid_radius = self.radius / self._config.uniform_spacing()
         profile = self._gauss_profile(
             width=self.grid_shape[self.horizontal_axis],
             height=self.grid_shape[self.vertical_axis],

--- a/src/fdtdx/objects/sources/linear_polarization.py
+++ b/src/fdtdx/objects/sources/linear_polarization.py
@@ -80,7 +80,8 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
             lower, upper = self.grid_slice_tuple[axis]
             edges = grid.edges(axis)[lower : upper + 1]
             local_edges.append(edges - edges[0])
-        return tuple(local_edges)
+        e0, e1, e2 = local_edges
+        return e0, e1, e2
 
     def _source_center_physical(self, source_center: jax.Array) -> jax.Array | None:
         """Return the physical center used for grid-aware Yee time offsets."""

--- a/src/fdtdx/objects/sources/mode.py
+++ b/src/fdtdx/objects/sources/mode.py
@@ -44,7 +44,8 @@ class ModePlaneSource(TFSFPlaneSource):
             lower, upper = self.grid_slice_tuple[axis]
             edges = grid.edges(axis)[lower : upper + 1]
             local_edges.append(edges - edges[0])
-        return tuple(local_edges)
+        e0, e1, e2 = local_edges
+        return e0, e1, e2
 
     def _transverse_edge_coordinates(self) -> tuple[jax.Array, jax.Array] | None:
         """Return local transverse edge coordinates for Tidy3D mode solving."""

--- a/src/fdtdx/objects/sources/mode.py
+++ b/src/fdtdx/objects/sources/mode.py
@@ -28,6 +28,56 @@ class ModePlaneSource(TFSFPlaneSource):
 
     _neff: jax.Array = private_field()  # not required for sim, used for inspection
 
+    def _local_edge_coordinates(self) -> tuple[jax.Array, jax.Array, jax.Array] | None:
+        """Return local physical edge coordinates for this source slice.
+
+        Non-uniform mode sources need edge coordinates for both Tidy3D mode
+        solving and Yee time offsets.  Coordinates are shifted so the source
+        slice lower corner is at zero on each axis.
+        """
+        grid = self._config.resolved_grid
+        if grid is None:
+            return None
+
+        local_edges = []
+        for axis in range(3):
+            lower, upper = self.grid_slice_tuple[axis]
+            edges = grid.edges(axis)[lower : upper + 1]
+            local_edges.append(edges - edges[0])
+        return tuple(local_edges)
+
+    def _transverse_edge_coordinates(self) -> tuple[jax.Array, jax.Array] | None:
+        """Return local transverse edge coordinates for Tidy3D mode solving."""
+        local_edges = self._local_edge_coordinates()
+        if local_edges is None:
+            return None
+        axes = [axis for axis in range(3) if axis != self.propagation_axis]
+        return local_edges[axes[0]], local_edges[axes[1]]
+
+    def _mode_solver_resolution(self) -> float:
+        """Return scalar resolution only for legacy uniform mode-solver setup.
+
+        ``compute_mode`` ignores this value when explicit transverse coordinates
+        are provided, but the argument remains part of the compatibility API.
+        """
+        if self._config.has_nonuniform_grid:
+            assert self._config.resolved_grid is not None
+            return self._config.resolved_grid.min_spacing
+        return self._config.uniform_spacing()
+
+    def _source_center_physical(self) -> jax.Array | None:
+        """Return the physical source center for grid-aware Yee time offsets."""
+        local_edges = self._local_edge_coordinates()
+        if local_edges is None:
+            return None
+        center = []
+        for axis, edges in enumerate(local_edges):
+            if axis == self.propagation_axis:
+                center.append(jnp.asarray(0.0, dtype=self._config.dtype))
+            else:
+                center.append(0.5 * edges[-1])
+        return jnp.asarray(center, dtype=self._config.dtype)
+
     def apply(
         self: Self,
         key: jax.Array,
@@ -84,11 +134,12 @@ class ModePlaneSource(TFSFPlaneSource):
             frequency=self.wave_character.get_frequency(),
             inv_permittivities=inv_permittivity_slice,
             inv_permeabilities=inv_permeability_slice,
-            resolution=self._config.resolution,
+            resolution=self._mode_solver_resolution(),
             direction=self.direction,
             mode_index=self.mode_index,
             filter_pol=self.filter_pol,
             dtype=self._config.dtype,
+            transverse_coords=self._transverse_edge_coordinates(),
         )
         mode_E, mode_H = jnp.real(mode_E), jnp.real(mode_H)
 
@@ -109,9 +160,11 @@ class ModePlaneSource(TFSFPlaneSource):
             wave_vector=raw_wave_vector,
             inv_permittivities=inv_permittivity_slice,
             inv_permeabilities=jnp.ones_like(inv_permeability_slice),
-            resolution=self._config.resolution,
+            resolution=self._mode_solver_resolution(),
             time_step_duration=self._config.time_step_duration,
             effective_index=jnp.real(eff_index),
+            coordinate_edges=self._local_edge_coordinates(),
+            center_physical=self._source_center_physical(),
         )
 
         self = self.aset("_time_offset_E", time_offset_E, create_new_ok=True)

--- a/src/fdtdx/objects/sources/tfsf.py
+++ b/src/fdtdx/objects/sources/tfsf.py
@@ -178,21 +178,35 @@ class TFSFPlaneSource(DirectionalPlaneSourceBase, ABC):
 
     @property
     def max_vertical_offset_grid(self) -> float:
-        """Convert maximum vertical offset from physical units to grid points.
+        """Return the maximum vertical random offset in source-center units.
 
         Returns:
-            float: Maximum vertical offset in grid points.
+            On uniform grids this is the legacy grid-index offset.  On
+            non-uniform grids source centers are represented in physical
+            transverse coordinates, so the returned value is the requested
+            physical offset in metres.
         """
-        return self.max_vertical_offset / self._config.resolution
+        if self.max_vertical_offset == 0:
+            return 0.0
+        if self._config.has_nonuniform_grid:
+            return self.max_vertical_offset
+        return self.max_vertical_offset / self._config.uniform_spacing()
 
     @property
     def max_horizontal_offset_grid(self) -> float:
-        """Convert maximum horizontal offset from physical units to grid points.
+        """Return the maximum horizontal random offset in source-center units.
 
         Returns:
-            float: Maximum horizontal offset in grid points.
+            On uniform grids this is the legacy grid-index offset.  On
+            non-uniform grids source centers are represented in physical
+            transverse coordinates, so the returned value is the requested
+            physical offset in metres.
         """
-        return self.max_horizontal_offset / self._config.resolution
+        if self.max_horizontal_offset == 0:
+            return 0.0
+        if self._config.has_nonuniform_grid:
+            return self.max_horizontal_offset
+        return self.max_horizontal_offset / self._config.uniform_spacing()
 
     def _get_azimuth_elevation(
         self,
@@ -218,13 +232,28 @@ class TFSFPlaneSource(DirectionalPlaneSourceBase, ABC):
         return azimuth_radians, elevation_radians
 
     def _get_center(self, key: jax.Array) -> jax.Array:  # shape(2,)
-        # Calculate center position with random offset
-        horizontal_size = self.grid_shape[self.horizontal_axis]
-        vertical_size = self.grid_shape[self.vertical_axis]
+        """Calculate the randomized source center.
 
-        # account for zero-indexing in center calculation
-        center_horizontal = (horizontal_size - 1) / 2
-        center_vertical = (vertical_size - 1) / 2
+        Uniform-grid sources use the legacy index-space center.  On a
+        non-uniform grid, tilted projections and Gaussian profiles are sampled in
+        physical coordinates, so the returned center is measured in metres from
+        the source-slice lower edge along the transverse axes.
+        """
+        if self._config.has_nonuniform_grid:
+            grid = self._config.resolved_grid
+            assert grid is not None
+            local_edges = []
+            for axis in (self.horizontal_axis, self.vertical_axis):
+                lower, upper = self.grid_slice_tuple[axis]
+                edges = grid.edges(axis)[lower : upper + 1]
+                local_edges.append(edges - edges[0])
+            center_horizontal = 0.5 * local_edges[0][-1]
+            center_vertical = 0.5 * local_edges[1][-1]
+        else:
+            horizontal_size = self.grid_shape[self.horizontal_axis]
+            vertical_size = self.grid_shape[self.vertical_axis]
+            center_horizontal = (horizontal_size - 1) / 2
+            center_vertical = (vertical_size - 1) / 2
 
         key, subkey = jax.random.split(key)
         horizontal_offset = jax.random.uniform(

--- a/src/fdtdx/objects/static_material/cylinder.py
+++ b/src/fdtdx/objects/static_material/cylinder.py
@@ -69,15 +69,22 @@ class Cylinder(StaticMultiMaterialObject):
         return 2
 
     def get_voxel_mask_for_shape(self) -> jax.Array:
-        width = self.grid_shape[self.vertical_axis]
-        height = self.grid_shape[self.horizontal_axis]
-        center = (height / 2, width / 2)
-        grid_radius_exact = self.radius / self._config.resolution
-        grid = (
-            jnp.stack(jnp.meshgrid(*map(jnp.arange, (width, height)), indexing="xy"), axis=-1)
-            - jnp.asarray(center)
-            + 0.5
-        ) / jnp.asarray(grid_radius_exact)
+        def local_centers(axis: int) -> jax.Array:
+            """Return physical cell centers relative to this object's lower edge."""
+            lower, upper = self.grid_slice_tuple[axis]
+            grid = self._config.resolved_grid
+            if grid is None:
+                spacing = self._config.uniform_spacing()
+                return (jnp.arange(self.grid_shape[axis]) + 0.5) * spacing
+            edges = grid.edges(axis)
+            return 0.5 * (edges[lower:upper] + edges[lower + 1 : upper + 1]) - edges[lower]
+
+        horizontal = local_centers(self.horizontal_axis)
+        vertical = local_centers(self.vertical_axis)
+        horizontal_grid, vertical_grid = jnp.meshgrid(horizontal, vertical, indexing="ij")
+        center_h = 0.5 * self.real_shape[self.horizontal_axis]
+        center_v = 0.5 * self.real_shape[self.vertical_axis]
+        grid = jnp.stack((horizontal_grid - center_h, vertical_grid - center_v), axis=-1) / self.radius
 
         mask = (grid**2).sum(axis=-1) < 1
         mask = jnp.expand_dims(mask, axis=self.axis)

--- a/src/fdtdx/objects/static_material/polygon.py
+++ b/src/fdtdx/objects/static_material/polygon.py
@@ -5,7 +5,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from fdtdx.core.grid import polygon_to_mask
+from fdtdx.core.grid import polygon_to_mask, polygon_to_mask_at_points
 from fdtdx.core.jax.pytrees import autoinit, frozen_field
 from fdtdx.materials import compute_ordered_names
 from fdtdx.objects.static_material.static import StaticMultiMaterialObject
@@ -75,20 +75,35 @@ class ExtrudedPolygon(StaticMultiMaterialObject):
         n_horizontal = self.grid_shape[self.horizontal_axis]
         n_vertical = self.grid_shape[self.vertical_axis]
 
-        half_res = 0.5 * self._config.resolution
-        max_horizontal = (n_horizontal - 0.5) * self._config.resolution
-        max_vertical = (n_vertical - 0.5) * self._config.resolution
-
         # Shift vertices from object-center coords to local grid coords.
         center_h = 0.5 * self.real_shape[self.horizontal_axis]
         center_v = 0.5 * self.real_shape[self.vertical_axis]
         grid_vertices = self.vertices + np.array([center_h, center_v])
 
-        mask_2d = polygon_to_mask(
-            boundary=(half_res, half_res, max_horizontal, max_vertical),
-            resolution=self._config.resolution,
-            polygon_vertices=grid_vertices,
-        )
+        grid = self._config.resolved_grid
+        if grid is None:
+            spacing = self._config.uniform_spacing()
+            half_res = 0.5 * spacing
+            max_horizontal = (n_horizontal - 0.5) * spacing
+            max_vertical = (n_vertical - 0.5) * spacing
+
+            mask_2d = polygon_to_mask(
+                boundary=(half_res, half_res, max_horizontal, max_vertical),
+                resolution=spacing,
+                polygon_vertices=grid_vertices,
+            )
+        else:
+            h_lower, h_upper = self.grid_slice_tuple[self.horizontal_axis]
+            v_lower, v_upper = self.grid_slice_tuple[self.vertical_axis]
+            h_edges = np.asarray(grid.edges(self.horizontal_axis))
+            v_edges = np.asarray(grid.edges(self.vertical_axis))
+            h_centers = 0.5 * (h_edges[h_lower:h_upper] + h_edges[h_lower + 1 : h_upper + 1]) - h_edges[h_lower]
+            v_centers = 0.5 * (v_edges[v_lower:v_upper] + v_edges[v_lower + 1 : v_upper + 1]) - v_edges[v_lower]
+            mask_2d = polygon_to_mask_at_points(
+                x_coords=h_centers,
+                y_coords=v_centers,
+                polygon_vertices=grid_vertices,
+            )
         extrusion_height = self.grid_shape[self.axis]
         mask = jnp.repeat(
             jnp.expand_dims(jnp.asarray(mask_2d, dtype=jnp.bool), axis=self.axis),

--- a/src/fdtdx/objects/static_material/sphere.py
+++ b/src/fdtdx/objects/static_material/sphere.py
@@ -52,29 +52,29 @@ class Sphere(StaticMultiMaterialObject):
         Returns:
             jax.Array: Boolean mask where True indicates voxels inside the sphere/ellipsoid.
         """
-        # Get dimensions
-        x_dim, y_dim, z_dim = self.grid_shape
-
-        # Define center of the ellipsoid
-        center = (x_dim / 2, y_dim / 2, z_dim / 2)
-
         # Determine the radii for each axis
         radius_x = self.radius_x if self.radius_x is not None else self.radius
         radius_y = self.radius_y if self.radius_y is not None else self.radius
         radius_z = self.radius_z if self.radius_z is not None else self.radius
 
-        # Convert radii to grid units
-        grid_radius_x = radius_x / self._config.resolution
-        grid_radius_y = radius_y / self._config.resolution
-        grid_radius_z = radius_z / self._config.resolution
+        def local_centers(axis: int) -> jax.Array:
+            """Return physical cell centers relative to this object's lower edge."""
+            lower, upper = self.grid_slice_tuple[axis]
+            grid = self._config.resolved_grid
+            if grid is None:
+                spacing = self._config.uniform_spacing()
+                return (jnp.arange(self.grid_shape[axis]) + 0.5) * spacing
+            edges = grid.edges(axis)
+            return 0.5 * (edges[lower:upper] + edges[lower + 1 : upper + 1]) - edges[lower]
 
         # Create 3D grid
-        x, y, z = jnp.meshgrid(jnp.arange(x_dim), jnp.arange(y_dim), jnp.arange(z_dim), indexing="ij")
+        x, y, z = jnp.meshgrid(local_centers(0), local_centers(1), local_centers(2), indexing="ij")
+        center_x, center_y, center_z = (0.5 * axis_size for axis_size in self.real_shape)
 
         # Calculate normalized squared distances for each dimension using the ellipsoid equation
-        x_term = ((x - center[0] + 0.5) / grid_radius_x) ** 2
-        y_term = ((y - center[1] + 0.5) / grid_radius_y) ** 2
-        z_term = ((z - center[2] + 0.5) / grid_radius_z) ** 2
+        x_term = ((x - center_x) / radius_x) ** 2
+        y_term = ((y - center_y) / radius_y) ** 2
+        z_term = ((z - center_z) / radius_z) ** 2
 
         # Create mask based on ellipsoid equation: points inside if x^2/a^2 + y^2/b^2 + z^2/c^2 < 1
         mask = (x_term + y_term + z_term) < 1

--- a/src/fdtdx/utils/plot_material.py
+++ b/src/fdtdx/utils/plot_material.py
@@ -7,9 +7,36 @@ import numpy as np
 from matplotlib.figure import Figure
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.fdtd.container import ArrayContainer
 
 MaterialType = Literal["permittivity", "permeability"]
+
+
+def _axis_edges_um(config: SimulationConfig, axis: int, length: int) -> np.ndarray:
+    """Return local plotting edges in micrometres for an axis."""
+    grid = getattr(config, "grid", None)
+    if isinstance(grid, RectilinearGrid):
+        edges = np.asarray(grid.edges(axis)[: length + 1])
+        return (edges - edges[0]) / 1.0e-6
+
+    spacing = config.uniform_spacing()
+    return np.arange(length + 1) * spacing / 1.0e-6
+
+
+def _slice_index_from_position(config: SimulationConfig, axis: int, length: int, position: float) -> int:
+    """Select a material slice by physical offset from the domain center."""
+    grid = getattr(config, "grid", None)
+    if isinstance(grid, RectilinearGrid):
+        edges = np.asarray(grid.edges(axis)[: length + 1])
+        centers = 0.5 * (edges[:-1] + edges[1:])
+        target = 0.5 * (edges[0] + edges[-1]) + position
+        return int(np.clip(np.argmin(np.abs(centers - target)), 0, length - 1))
+
+    spacing = config.uniform_spacing()
+    center_idx = length // 2
+    slice_offset = round(position / spacing)
+    return max(0, min(center_idx + slice_offset, length - 1))
 
 
 def plot_material_from_side(
@@ -63,56 +90,58 @@ def plot_material_from_side(
         else:
             material_array = 1.0 / arrays.inv_permeabilities
 
-    resolution = config.resolution / 1.0e-6  # Convert to µm
-
-    # Calculate slice index from position
-    slice_offset = round(position / config.resolution)
-
     # material_array has shape (num_components, Nx, Ny, Nz)
     material_array = jnp.asarray(material_array)
     spatial_shape = material_array.shape[1:]  # (Nx, Ny, Nz)
-    half_real_shape_um = [N * resolution / 2 for N in spatial_shape]
 
     # Determine slice parameters based on viewing side
     if viewing_side == "z":
         # XY plane - slice through Z axis
-        center_idx = spatial_shape[2] // 2
-        slice_idx = center_idx + slice_offset
-        slice_idx = max(0, min(slice_idx, spatial_shape[2] - 1))
+        slice_idx = _slice_index_from_position(config, 2, spatial_shape[2], position)
         material_slice = material_array[material_axis, :, :, slice_idx]
         axis_labels = ("x (µm)", "y (µm)")
         title = f"XY plane - {type} at z={position * 1e6:.2f} µm"
-        extent = [-half_real_shape_um[0], half_real_shape_um[0], -half_real_shape_um[1], half_real_shape_um[1]]
+        edge_x = _axis_edges_um(config, 0, spatial_shape[0])
+        edge_y = _axis_edges_um(config, 1, spatial_shape[1])
 
     elif viewing_side == "y":
         # XZ plane - slice through Y axis
-        center_idx = spatial_shape[1] // 2
-        slice_idx = center_idx + slice_offset
-        slice_idx = max(0, min(slice_idx, spatial_shape[1] - 1))
+        slice_idx = _slice_index_from_position(config, 1, spatial_shape[1], position)
         material_slice = material_array[material_axis, :, slice_idx, :]
         axis_labels = ("x (µm)", "z (µm)")
         title = f"XZ plane - {type} at y={position * 1e6:.2f} µm"
-        extent = [-half_real_shape_um[0], half_real_shape_um[0], -half_real_shape_um[2], half_real_shape_um[2]]
+        edge_x = _axis_edges_um(config, 0, spatial_shape[0])
+        edge_y = _axis_edges_um(config, 2, spatial_shape[2])
 
     else:  # viewing_side == "x"
         # YZ plane - slice through X axis
-        center_idx = spatial_shape[0] // 2
-        slice_idx = center_idx + slice_offset
-        slice_idx = max(0, min(slice_idx, spatial_shape[0] - 1))
+        slice_idx = _slice_index_from_position(config, 0, spatial_shape[0], position)
         material_slice = material_array[material_axis, slice_idx, :, :]
         axis_labels = ("y (µm)", "z (µm)")
         title = f"YZ plane - {type} at x={position * 1e6:.2f} µm"
-        extent = [-half_real_shape_um[1], half_real_shape_um[1], -half_real_shape_um[2], half_real_shape_um[2]]
+        edge_x = _axis_edges_um(config, 1, spatial_shape[1])
+        edge_y = _axis_edges_um(config, 2, spatial_shape[2])
 
     # Plot the material slice
-    im = ax.imshow(
-        material_slice.T,  # Transpose for correct orientation
-        origin="lower",
-        extent=cast(tuple[int | float, int | float, int | float, int | float], tuple(extent)),
-        aspect="equal",
-        cmap="viridis",
-        interpolation="nearest",
-    )
+    if isinstance(getattr(config, "grid", None), RectilinearGrid):
+        im = ax.pcolormesh(
+            edge_x,
+            edge_y,
+            material_slice.T,
+            cmap="viridis",
+            shading="auto",
+        )
+        ax.set_aspect("equal")
+    else:
+        extent = [edge_x[0], edge_x[-1], edge_y[0], edge_y[-1]]
+        im = ax.imshow(
+            material_slice.T,  # Transpose for correct orientation
+            origin="lower",
+            extent=cast(tuple[int | float, int | float, int | float, int | float], tuple(extent)),
+            aspect="equal",
+            cmap="viridis",
+            interpolation="nearest",
+        )
 
     # Set labels and titles
     ax.set_xlabel(axis_labels[0])

--- a/src/fdtdx/utils/plot_setup.py
+++ b/src/fdtdx/utils/plot_setup.py
@@ -165,7 +165,6 @@ def plot_setup_from_side(
         full_coverage_objects = _get_full_coverage_objects(object_list, axis_indices, plane_size, volume)
         plane_exclude_list.extend(full_coverage_objects)
 
-
     # Filter objects for this plane
     colored_objects: list[SimulationObject] = [
         o for o in object_list if o.color is not None and (plane_exclude_list is None or o not in plane_exclude_list)

--- a/src/fdtdx/utils/plot_setup.py
+++ b/src/fdtdx/utils/plot_setup.py
@@ -6,6 +6,7 @@ from matplotlib.figure import Figure
 from matplotlib.patches import Patch, Rectangle
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.fdtd.container import ObjectContainer
 from fdtdx.objects.boundaries.bloch import BlochBoundary
 from fdtdx.objects.boundaries.pec import PerfectElectricConductor
@@ -51,6 +52,18 @@ def _get_full_coverage_objects(
             full_coverage_objects.append(obj)
 
     return full_coverage_objects
+
+
+def _axis_edges_um(config: SimulationConfig, axis: int, bounds: tuple[int, int]) -> tuple[float, float]:
+    """Return local physical edge coordinates in micrometres for an index interval."""
+    grid = getattr(config, "grid", None)
+    if isinstance(grid, RectilinearGrid):
+        edges = grid.edges(axis)
+        domain_origin = float(edges[0])
+        return (float(edges[bounds[0]] - domain_origin) / 1.0e-6, float(edges[bounds[1]] - domain_origin) / 1.0e-6)
+
+    spacing = config.uniform_spacing()
+    return (bounds[0] * spacing / 1.0e-6, bounds[1] * spacing / 1.0e-6)
 
 
 def plot_setup_from_side(
@@ -125,8 +138,6 @@ def plot_setup_from_side(
     else:
         fig = None
 
-    resolution = config.resolution / 1.0e-6  # Convert to µm
-
     # Determine which exclude list to use based on viewing side
     if viewing_side == "z":
         plane_exclude_list = list(exclude_xy_plane_object_list)  # Create a copy
@@ -154,7 +165,6 @@ def plot_setup_from_side(
         full_coverage_objects = _get_full_coverage_objects(object_list, axis_indices, plane_size, volume)
         plane_exclude_list.extend(full_coverage_objects)
 
-    half_real_size_um = [N * resolution / 2 for N in plane_size]
 
     # Filter objects for this plane
     colored_objects: list[SimulationObject] = [
@@ -211,11 +221,13 @@ def plot_setup_from_side(
         ax.add_patch(
             Rectangle(
                 (
-                    slices[axis_indices[0]][0] * resolution - half_real_size_um[0],
-                    slices[axis_indices[1]][0] * resolution - half_real_size_um[1],
+                    _axis_edges_um(config, axis_indices[0], slices[axis_indices[0]])[0],
+                    _axis_edges_um(config, axis_indices[1], slices[axis_indices[1]])[0],
                 ),
-                (slices[axis_indices[0]][1] - slices[axis_indices[0]][0]) * resolution,
-                (slices[axis_indices[1]][1] - slices[axis_indices[1]][0]) * resolution,
+                _axis_edges_um(config, axis_indices[0], slices[axis_indices[0]])[1]
+                - _axis_edges_um(config, axis_indices[0], slices[axis_indices[0]])[0],
+                _axis_edges_um(config, axis_indices[1], slices[axis_indices[1]])[1]
+                - _axis_edges_um(config, axis_indices[1], slices[axis_indices[1]])[0],
                 color=color.to_mpl() if color is not None else "gray",
                 alpha=0.5,
                 linestyle="--"
@@ -228,8 +240,8 @@ def plot_setup_from_side(
     ax.set_xlabel(axis_labels[0])
     ax.set_ylabel(axis_labels[1])
     ax.set_title(title)
-    ax.set_xlim((-half_real_size_um[0], half_real_size_um[0]))
-    ax.set_ylim((-half_real_size_um[1], half_real_size_um[1]))
+    ax.set_xlim(_axis_edges_um(config, axis_indices[0], (0, plane_size[0])))
+    ax.set_ylim(_axis_edges_um(config, axis_indices[1], (0, plane_size[1])))
     ax.set_aspect("equal")
     ax.grid(True)
 

--- a/src/fdtdx/utils/sparams.py
+++ b/src/fdtdx/utils/sparams.py
@@ -8,6 +8,7 @@ import jax
 
 from fdtdx import DetectorState, GaussianPulseProfile, extend_material_to_pml
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.fdtd.container import ArrayContainer, ObjectContainer
 from fdtdx.fdtd.initialization import apply_params, place_objects
@@ -126,7 +127,7 @@ def setup_sparams_simulation(
         domain_size[2] + 2.0 * pml_thickness,
     )
 
-    config = SimulationConfig(time=max_time, resolution=resolution)
+    config = SimulationConfig(time=max_time, grid=UniformGrid(spacing=resolution))
 
     object_list = []
     constraints = []

--- a/tests/integration/conversion/test_json.py
+++ b/tests/integration/conversion/test_json.py
@@ -7,6 +7,7 @@ import pytest
 from fdtdx.colors import PINK
 from fdtdx.config import SimulationConfig
 from fdtdx.conversion.json import JsonSetup, export_json, export_json_str, import_from_json
+from fdtdx.core.grid import UniformGrid
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.fdtd.container import ArrayContainer, ObjectContainer, ParameterContainer
@@ -29,7 +30,7 @@ def setup_simulation_inputs():
     constraints = []
 
     # Simulation config — small domain to keep test runtime short
-    config = SimulationConfig(time=20e-15, resolution=100e-9, dtype=jnp.float32, courant_factor=0.99)
+    config = SimulationConfig(time=20e-15, grid=UniformGrid(spacing=100e-9), dtype=jnp.float32, courant_factor=0.99)
 
     # Volume: 3µm³ → 30x30x30 cells
     volume = SimulationVolume(
@@ -122,7 +123,7 @@ def test_config_json(setup_simulation_inputs):
     s = export_json_str(conf)
     rec = import_from_json(s)
     assert rec.time == 20e-15
-    assert rec.resolution == 100e-9
+    assert rec.uniform_spacing() == 100e-9
 
 
 def test_volume_json(setup_simulation_inputs):

--- a/tests/integration/conversion/test_vti.py
+++ b/tests/integration/conversion/test_vti.py
@@ -1,9 +1,11 @@
 """Integration tests for fdtdx.conversion.vti module."""
 
 import jax
+import jax.numpy as jnp
 
 import fdtdx
-from fdtdx import export_arrays_snapshot_to_vti
+from fdtdx import export_arrays_snapshot_to_vti, export_vtr
+from fdtdx.core.grid import RectilinearGrid
 
 
 def test_export_arrays_snapshot_to_vti(tmp_path):
@@ -11,7 +13,7 @@ def test_export_arrays_snapshot_to_vti(tmp_path):
 
     config = fdtdx.SimulationConfig(
         time=100e-15,
-        resolution=100e-9,
+        grid=fdtdx.UniformGrid(spacing=100e-9),
     )
     volume = fdtdx.SimulationVolume(
         partial_real_shape=(2.0e-6, 2.0e-6, 2.0e-6),
@@ -32,7 +34,7 @@ def test_export_arrays_snapshot_to_vti(tmp_path):
     output_path = tmp_path / "snapshot.vti"
 
     # Run the snapshot export
-    export_arrays_snapshot_to_vti(arrays, output_path, config.resolution)
+    export_arrays_snapshot_to_vti(arrays, output_path, config.uniform_spacing())
 
     assert output_path.exists()
     assert output_path.stat().st_size > 0
@@ -47,5 +49,38 @@ def test_export_arrays_snapshot_to_vti(tmp_path):
     assert 'Name="H"' in content
 
     # Check spacing/resolution was passed correctly
-    res_str = f"{config.resolution} {config.resolution} {config.resolution}"
+    res_str = f"{config.uniform_spacing()} {config.uniform_spacing()} {config.uniform_spacing()}"
     assert res_str in content
+
+
+def test_export_vtr_uniform_grid(tmp_path):
+    grid = RectilinearGrid.uniform(shape=(4, 5, 6), spacing=50e-9)
+    cell_data = {"field": jnp.ones((4, 5, 6), dtype=jnp.float32)}
+    output_path = tmp_path / "uniform.vtr"
+
+    export_vtr(cell_data, output_path, grid)
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
+    with open(output_path, "r", encoding="utf-8", errors="ignore") as f:
+        content = f.read()
+    assert 'Name="field"' in content
+    assert "RectilinearGrid" in content
+
+
+def test_export_vtr_nonuniform_grid(tmp_path):
+    x_edges = jnp.array([0.0, 50e-9, 150e-9, 350e-9, 750e-9])
+    y_edges = jnp.linspace(0.0, 500e-9, 6)
+    z_edges = jnp.linspace(0.0, 300e-9, 4)
+    grid = RectilinearGrid(x_edges=x_edges, y_edges=y_edges, z_edges=z_edges)
+    cell_data = {"E": jnp.zeros((3, 4, 5, 3), dtype=jnp.float32)}
+    output_path = tmp_path / "nonuniform.vtr"
+
+    export_vtr(cell_data, output_path, grid)
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
+    with open(output_path, "r", encoding="utf-8", errors="ignore") as f:
+        content = f.read()
+    assert 'Name="E"' in content
+    assert "X_COORDINATES" in content

--- a/tests/integration/fdtd/test_custom_time_signal_profile.py
+++ b/tests/integration/fdtd/test_custom_time_signal_profile.py
@@ -22,7 +22,7 @@ def _gaussian_windowed_carrier(config: fdtdx.SimulationConfig, wave: fdtdx.WaveC
 def test_custom_time_signal_profile_source_workflow():
     """CustomTimeSignalProfile works through placement and source wrappers."""
     config = fdtdx.SimulationConfig(
-        resolution=50e-9,
+        grid=fdtdx.UniformGrid(spacing=50e-9),
         time=500e-15,
         dtype=jnp.float32,
     )

--- a/tests/integration/fdtd/test_dispersive_init.py
+++ b/tests/integration/fdtd/test_dispersive_init.py
@@ -30,7 +30,9 @@ def _placed(container, name):
 
 @pytest.fixture
 def simple_config():
-    return SimulationConfig(resolution=1e-7, time=1e-14, backend="cpu")
+    from fdtdx.core.grid import UniformGrid
+
+    return SimulationConfig(grid=UniformGrid(spacing=1e-7), time=1e-14, backend="cpu")
 
 
 @pytest.fixture
@@ -265,7 +267,7 @@ def test_static_multi_material_dispersive(simple_config, simple_volume):
         name="sphere",
         materials=materials,
         material_name="drude",
-        radius=5.0 * simple_config.resolution,
+        radius=5.0 * simple_config.uniform_spacing(),
     )
     constraint = GridCoordinateConstraint(object="sphere", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[8, 8, 8])
     key = jax.random.PRNGKey(0)

--- a/tests/integration/fdtd/test_initialization.py
+++ b/tests/integration/fdtd/test_initialization.py
@@ -4,7 +4,9 @@ import jax
 import jax.numpy as jnp
 import pytest
 
+from fdtdx import constants
 from fdtdx.config import GradientConfig, SimulationConfig
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.fdtd.container import ArrayContainer, ObjectContainer
 from fdtdx.fdtd.initialization import place_objects
 from fdtdx.interfaces.recorder import Recorder
@@ -22,7 +24,7 @@ from fdtdx.objects.static_material.static import SimulationVolume, UniformMateri
 
 @pytest.fixture
 def simple_config():
-    return SimulationConfig(resolution=1.0, time=100e-15, backend="cpu")
+    return SimulationConfig(grid=UniformGrid(spacing=1.0), time=100e-15, backend="cpu")
 
 
 @pytest.fixture
@@ -85,7 +87,7 @@ def test_place_objects_updates_config(simple_config, simple_volume, simple_mater
         [simple_volume, obj], simple_config, [constraint], key
     )
     assert config is not None
-    assert config.resolution == simple_config.resolution
+    assert config.uniform_spacing() == simple_config.uniform_spacing()
 
 
 def test_place_objects_initializes_arrays(simple_config, simple_volume, simple_material):
@@ -150,6 +152,72 @@ def test_diagonally_anisotropic_material(simple_config, simple_volume):
     # electric and magnetic conductivity arrays created
     assert arrays.electric_conductivity is not None
     assert arrays.magnetic_conductivity is not None
+
+
+def test_nonuniform_grid_initializes_conductive_volume():
+    """Conductivity scaling uses the update reference spacing, not a uniform grid size."""
+    grid = RectilinearGrid(
+        x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+        y_edges=jnp.asarray([0.0, 1.5, 4.0]),
+        z_edges=jnp.asarray([0.0, 2.0, 5.0]),
+    )
+    mat = Material(
+        permittivity=1.0,
+        permeability=1.0,
+        electric_conductivity=0.2,
+        magnetic_conductivity=0.4,
+    )
+    volume = SimulationVolume(name="volume", partial_grid_shape=(2, 2, 2), material=mat)
+    config = SimulationConfig(grid=grid, time=1e-8, backend="cpu")
+
+    _obj_container, arrays, _params, updated_config, _info = place_objects([volume], config, [], jax.random.PRNGKey(0))
+
+    conductivity_spacing = constants.c * updated_config.time_step_duration / updated_config.courant_number
+    assert arrays.electric_conductivity is not None
+    assert arrays.magnetic_conductivity is not None
+    assert jnp.allclose(arrays.electric_conductivity, 0.2 * conductivity_spacing)
+    assert jnp.allclose(arrays.magnetic_conductivity, 0.4 * conductivity_spacing)
+
+
+def test_uniform_rectilinear_grid_initialization_matches_scalar_resolution(simple_material):
+    """Explicit uniform RectilinearGrid initialization is equivalent to scalar resolution."""
+    resolution = 1.0
+    volume = SimulationVolume(name="volume", partial_grid_shape=(4, 4, 4))
+    obj = UniformMaterialObject(name="obj1", partial_grid_shape=(2, 2, 2), material=simple_material)
+    constraint = GridCoordinateConstraint(
+        object="obj1",
+        axes=[0, 1, 2],
+        sides=["-", "-", "-"],
+        coordinates=[1, 1, 1],
+    )
+
+    scalar_config = SimulationConfig(grid=UniformGrid(spacing=resolution), time=100e-15, backend="cpu")
+    grid_config = SimulationConfig(
+        grid=RectilinearGrid.uniform(shape=(4, 4, 4), spacing=resolution),
+        time=100e-15,
+        backend="cpu",
+    )
+
+    _, scalar_arrays, _, scalar_updated_config, _ = place_objects(
+        [volume, obj],
+        scalar_config,
+        [constraint],
+        jax.random.PRNGKey(0),
+    )
+    _, grid_arrays, _, grid_updated_config, _ = place_objects(
+        [volume, obj],
+        grid_config,
+        [constraint],
+        jax.random.PRNGKey(0),
+    )
+
+    assert jnp.array_equal(grid_arrays.inv_permittivities, scalar_arrays.inv_permittivities)
+    assert jnp.array_equal(grid_arrays.inv_permeabilities, scalar_arrays.inv_permeabilities)
+    assert grid_updated_config.grid is not None
+    assert scalar_updated_config.grid is not None
+    assert jnp.allclose(grid_updated_config.grid.x_edges, scalar_updated_config.grid.x_edges)
+    assert jnp.allclose(grid_updated_config.grid.y_edges, scalar_updated_config.grid.y_edges)
+    assert jnp.allclose(grid_updated_config.grid.z_edges, scalar_updated_config.grid.z_edges)
 
 
 def test_fully_anisotropic_material(simple_config, simple_volume):
@@ -260,7 +328,7 @@ def test_recording_state_with_gradient_config(simple_volume, simple_material):
     recorder = Recorder(modules=[])
     gradient_config = GradientConfig(recorder=recorder)
     config = SimulationConfig(
-        resolution=1.0,
+        grid=UniformGrid(spacing=1.0),
         time=100e-15,
         backend="cpu",
         gradient_config=gradient_config,

--- a/tests/integration/fdtd/test_placement.py
+++ b/tests/integration/fdtd/test_placement.py
@@ -6,7 +6,7 @@ import fdtdx
 
 def test_placement():
     config = fdtdx.SimulationConfig(
-        resolution=100e-9,
+        grid=fdtdx.UniformGrid(spacing=100e-9),
         time=10e-15,
     )
 

--- a/tests/integration/fdtd/test_stop_conditions.py
+++ b/tests/integration/fdtd/test_stop_conditions.py
@@ -3,6 +3,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.fdtd.container import ArrayContainer, FieldState
 from fdtdx.fdtd.initialization import place_objects
@@ -52,7 +53,7 @@ class TestCondition:
 
         config = SimulationConfig(
             time=100e-11,
-            resolution=1e-4,
+            grid=UniformGrid(spacing=1e-4),
             courant_factor=0.99,
         )
         detector_name = "test_detector"
@@ -213,7 +214,7 @@ class TestCondition:
         config = setup_simulation_state["config"]
         objects = setup_simulation_state["objects"]
         arrays = state[1]
-        # If courant_factor=0.99 and resolution=1e-4, then time_step_duration ≈ 1.906e-13 s
+        # If courant_factor=0.99 and grid=UniformGrid(spacing=1e-4), then time_step_duration ≈ 1.906e-13 s
         # Therefore we have time / time_step_duration ≈ 524.5, which is rounded up to 525.
         # This is the number of time steps. Remember that min_steps cannot be larger than this
         detector_name = setup_simulation_state["dn"]

--- a/tests/integration/objects/test_device.py
+++ b/tests/integration/objects/test_device.py
@@ -12,7 +12,7 @@ def test_ssp_intricate_grad_nan_bug():
 
     config = fdtdx.SimulationConfig(
         time=200e-15,
-        resolution=20e-9,
+        grid=fdtdx.UniformGrid(spacing=20e-9),
         dtype=jnp.float32,
         courant_factor=0.99,
     )
@@ -33,7 +33,7 @@ def test_ssp_intricate_grad_nan_bug():
             fdtdx.GaussianSmoothing2D(std_discrete=3),
             fdtdx.SubpixelSmoothedProjection(),
         ],
-        partial_voxel_real_shape=(config.resolution, config.resolution, height),
+        partial_voxel_real_shape=(config.uniform_spacing(), config.uniform_spacing(), height),
     )
     key = jax.random.PRNGKey(42)
     objects, arrays, params, config, _ = fdtdx.place_objects(

--- a/tests/integration/placement/test_constraint_placement.py
+++ b/tests/integration/placement/test_constraint_placement.py
@@ -23,7 +23,7 @@ N = 20  # grid cells per axis
 
 
 def _cfg():
-    return fdtdx.SimulationConfig(resolution=RESOLUTION, time=10e-15)
+    return fdtdx.SimulationConfig(grid=fdtdx.UniformGrid(spacing=RESOLUTION), time=10e-15)
 
 
 def _volume():

--- a/tests/integration/placement/test_infinity_extension_constraint.py
+++ b/tests/integration/placement/test_infinity_extension_constraint.py
@@ -17,7 +17,7 @@ def test_place_at_center_of_infinite_object():
     pending PositionConstraint on the axis being extended. It eagerly locks position=0
     even when a constraint will later demand a different position.
     """
-    config = fdtdx.SimulationConfig(resolution=100e-9, time=10e-15)
+    config = fdtdx.SimulationConfig(grid=fdtdx.UniformGrid(spacing=100e-9), time=10e-15)
     constraints, objects = [], []
 
     volume = fdtdx.SimulationVolume(partial_real_shape=(2e-6, 2e-6, 2e-6))

--- a/tests/integration/utils/test_plot_material.py
+++ b/tests/integration/utils/test_plot_material.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 import fdtdx
 from fdtdx import Cylinder, SimulationVolume, Sphere
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.objects.object import GridCoordinateConstraint
 from fdtdx.objects.static_material.static import Material, UniformMaterialObject
 from fdtdx.utils.plot_material import plot_material, plot_material_from_side
@@ -21,11 +22,35 @@ TEST_OUTPUT_DIR = Path("tests/generated")
 TEST_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 
+def _plotted_material_artists(ax):
+    """Return image or rectilinear mesh artists created by material plotting."""
+    return list(ax.get_images()) + list(ax.collections)
+
+
+def _plotted_material_array(ax):
+    """Return plotted material values for either imshow or pcolormesh output."""
+    images = ax.get_images()
+    if images:
+        return images[0].get_array()
+    assert ax.collections, "Expected an image or mesh collection on the material plot."
+    return ax.collections[0].get_array()
+
+
+def _axis_extent(ax) -> tuple[float, float, float, float]:
+    """Return data extents for image or mesh based material plots."""
+    images = ax.get_images()
+    if images:
+        return images[0].get_extent()
+    xlim = ax.get_xlim()
+    ylim = ax.get_ylim()
+    return (xlim[0], xlim[1], ylim[0], ylim[1])
+
+
 @pytest.fixture
 def simple_material_setup():
     """A simple setup with basic material objects for testing."""
     config = SimulationConfig(
-        resolution=50e-9,
+        grid=UniformGrid(spacing=50e-9),
         time=100e-15,
     )
 
@@ -73,7 +98,7 @@ def simple_material_setup():
 def cylinder_setup():
     """Setup with a cylinder object."""
     config = SimulationConfig(
-        resolution=30e-9,
+        grid=UniformGrid(spacing=30e-9),
         time=100e-15,
     )
 
@@ -122,7 +147,7 @@ def cylinder_setup():
 def sphere_setup():
     """Setup with a sphere object."""
     config = SimulationConfig(
-        resolution=30e-9,
+        grid=UniformGrid(spacing=30e-9),
         time=100e-15,
     )
 
@@ -323,8 +348,7 @@ def test_plot_material_verify_values(simple_material_setup):
         type="permittivity",
     )
 
-    im = ax.get_images()[0]
-    data = im.get_array()
+    data = _plotted_material_array(ax)
 
     assert data is not None
     assert data.size > 0
@@ -333,7 +357,7 @@ def test_plot_material_verify_values(simple_material_setup):
     # Setup uses 40 grid cells at 50nm resolution = 2.0 µm in each direction.
     # If the component axis bug is present, array_shape[0] == num_components (~3)
     # instead of Nx (40), collapsing the x-extent to ~0.15 µm instead of 2.0 µm.
-    extent = im.get_extent()  # [xmin, xmax, ymin, ymax] in µm
+    extent = _axis_extent(ax)  # [xmin, xmax, ymin, ymax] in µm
     expected_size_um = 2.0  # 40 cells * 50nm = 2µm
     assert abs((extent[1] - extent[0]) - expected_size_um) < 0.1, (
         f"X-extent should be ~{expected_size_um} µm but got {extent[1]:.4f} µm. "
@@ -406,7 +430,7 @@ def test_plot_material_custom_axes(simple_material_setup):
     assert len(axs) == 3
 
     for ax in axs:
-        assert len(ax.get_images()) > 0
+        assert len(_plotted_material_artists(ax)) > 0
         assert ax.get_xlabel() != ""
         assert ax.get_ylabel() != ""
         assert ax.get_title() != ""
@@ -482,7 +506,7 @@ def test_plot_material_with_external_figure(simple_material_setup):
 def test_plot_material_all_types_objects():
     """Test plot_material with UniformMaterialObject, Cylinder, and Sphere."""
     config = SimulationConfig(
-        resolution=40e-9,
+        grid=UniformGrid(spacing=40e-9),
         time=100e-15,
     )
 
@@ -590,17 +614,16 @@ def test_plot_material_material_axis(simple_material_setup):
         )
         assert result_fig is not None, f"plot_material returned None for material_axis={axis}"
 
-        # Verify all three subplots have image data
+        # Verify all three subplots have image or rectilinear mesh data
         axs = result_fig.get_axes()
-        # Filter out colorbar axes (they have no images)
-        plot_axs = [a for a in axs if len(a.get_images()) > 0]
+        # Filter out colorbar axes (they have no plotted material artists)
+        plot_axs = [a for a in axs if len(_plotted_material_artists(a)) > 0]
         assert len(plot_axs) == 3, f"Expected 3 subplots with image data for material_axis={axis}, got {len(plot_axs)}"
 
         # Verify each subplot spans the full 2µm domain on both axes
         expected_size_um = 2.0  # 40 cells * 50nm
         for ax in plot_axs:
-            im = ax.get_images()[0]
-            extent = im.get_extent()  # [xmin, xmax, ymin, ymax]
+            extent = _axis_extent(ax)  # [xmin, xmax, ymin, ymax]
             assert abs((extent[1] - extent[0]) - expected_size_um) < 0.1, (
                 f"material_axis={axis}: x-extent should be ~{expected_size_um} µm "
                 f"but got {(extent[1] - extent[0]):.4f} µm in subplot '{ax.get_title()}'"

--- a/tests/integration/utils/test_plot_setup.py
+++ b/tests/integration/utils/test_plot_setup.py
@@ -11,6 +11,7 @@ import fdtdx
 from fdtdx import SimulationVolume
 from fdtdx.colors import Color
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.objects.object import GridCoordinateConstraint, OrderableObject
 from fdtdx.utils.plot_setup import plot_setup, plot_setup_from_side
 
@@ -23,7 +24,7 @@ TEST_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 def simulation_setup():
     """Fixture that creates a simple simulation setup with various objects."""
     config = SimulationConfig(
-        resolution=20e-9,
+        grid=UniformGrid(spacing=20e-9),
         time=100e-15,
     )
 

--- a/tests/integration/utils/test_sparams.py
+++ b/tests/integration/utils/test_sparams.py
@@ -143,7 +143,7 @@ class TestSetupSparamsReturnTypes:
 
     def test_config_resolution_preserved(self, minimal_setup):
         _objs, _arrays, config = minimal_setup
-        assert config.resolution == _RESOLUTION
+        assert config.uniform_spacing() == _RESOLUTION
 
 
 # ---------------------------------------------------------------------------

--- a/tests/simulation/fdtd/test_fdtd.py
+++ b/tests/simulation/fdtd/test_fdtd.py
@@ -17,6 +17,7 @@ import pytest
 
 import fdtdx
 from fdtdx.config import GradientConfig, SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.fdtd.container import ArrayContainer, FieldState
 from fdtdx.fdtd.fdtd import checkpointed_fdtd, reversible_fdtd
 from fdtdx.interfaces.recorder import Recorder
@@ -50,7 +51,7 @@ def _build_scene():
     """
     config = SimulationConfig(
         time=_SIM_TIME,
-        resolution=_RESOLUTION,
+        grid=UniformGrid(spacing=_RESOLUTION),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,
@@ -200,7 +201,7 @@ def _build_lossy_dispersive_scene(dtype):
     """
     config = SimulationConfig(
         time=_SIM_TIME,
-        resolution=_RESOLUTION,
+        grid=UniformGrid(spacing=_RESOLUTION),
         backend="cpu",
         dtype=dtype,
         courant_factor=0.99,
@@ -278,7 +279,7 @@ def _build_magnetic_lossy_scene(dtype):
     dispersive-lossy scene but on the magnetic branch."""
     config = SimulationConfig(
         time=_SIM_TIME,
-        resolution=_RESOLUTION,
+        grid=UniformGrid(spacing=_RESOLUTION),
         backend="cpu",
         dtype=dtype,
         courant_factor=0.99,

--- a/tests/simulation/fdtd/test_pulsed_vs_cw.py
+++ b/tests/simulation/fdtd/test_pulsed_vs_cw.py
@@ -75,7 +75,7 @@ _TOLERANCE = 0.05
 def _build_base(temporal_profile, wave_character):
     """Build base geometry: volume, PML+periodic boundaries, source."""
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/fdtd/test_time_reversal.py
+++ b/tests/simulation/fdtd/test_time_reversal.py
@@ -16,6 +16,7 @@ import jax.numpy as jnp
 
 import fdtdx
 from fdtdx.config import GradientConfig, SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.fdtd.backward import backward
 from fdtdx.fdtd.container import ArrayContainer, FieldState
 from fdtdx.fdtd.fdtd import checkpointed_fdtd, reversible_fdtd
@@ -62,7 +63,7 @@ def _build_simulation(boundary_types, bloch_vector=(0.0, 0.0, 0.0)):
     """
     config = SimulationConfig(
         time=_SIM_TIME,
-        resolution=_RESOLUTION,
+        grid=UniformGrid(spacing=_RESOLUTION),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,

--- a/tests/simulation/fdtd/test_time_reversal.py
+++ b/tests/simulation/fdtd/test_time_reversal.py
@@ -360,7 +360,7 @@ class TestTimeReversalDispersiveLorentz:
     def _build():
         config = SimulationConfig(
             time=_SIM_TIME,
-            resolution=_RESOLUTION,
+            grid=UniformGrid(spacing=_RESOLUTION),
             backend="cpu",
             dtype=jnp.float32,
             courant_factor=0.99,
@@ -508,7 +508,7 @@ class TestTimeReversalDispersiveLossy:
     def _build():
         config = SimulationConfig(
             time=_SIM_TIME,
-            resolution=_RESOLUTION,
+            grid=UniformGrid(spacing=_RESOLUTION),
             backend="cpu",
             dtype=jnp.float32,
             courant_factor=0.99,
@@ -649,7 +649,7 @@ class TestStrictReversibilityLossy:
     def _build():
         config = SimulationConfig(
             time=_SIM_TIME,
-            resolution=_RESOLUTION,
+            grid=UniformGrid(spacing=_RESOLUTION),
             backend="cpu",
             dtype=jnp.float64,
             courant_factor=0.99,
@@ -721,7 +721,7 @@ class TestTimeReversalMagneticConductivity:
     def _build():
         config = SimulationConfig(
             time=_SIM_TIME,
-            resolution=_RESOLUTION,
+            grid=UniformGrid(spacing=_RESOLUTION),
             backend="cpu",
             dtype=jnp.float64,
             courant_factor=0.99,
@@ -794,7 +794,7 @@ class TestTimeReversalDispersiveDrude:
     def _build():
         config = SimulationConfig(
             time=_SIM_TIME,
-            resolution=_RESOLUTION,
+            grid=UniformGrid(spacing=_RESOLUTION),
             backend="cpu",
             dtype=jnp.float64,
             courant_factor=0.99,
@@ -1027,7 +1027,7 @@ class TestGradientDispersiveLossy:
     def _build():
         config = SimulationConfig(
             time=_SIM_TIME,
-            resolution=_RESOLUTION,
+            grid=UniformGrid(spacing=_RESOLUTION),
             backend="cpu",
             dtype=jnp.float32,
             courant_factor=0.99,
@@ -1198,7 +1198,7 @@ class TestGradientDispersiveLossy:
         ~1e-12 and the tolerance can tighten by three orders of magnitude."""
         config = SimulationConfig(
             time=_SIM_TIME,
-            resolution=_RESOLUTION,
+            grid=UniformGrid(spacing=_RESOLUTION),
             backend="cpu",
             dtype=jnp.float64,
             courant_factor=0.99,
@@ -1325,7 +1325,7 @@ class TestGradientMagneticConductivity:
     def _build():
         config = SimulationConfig(
             time=_SIM_TIME,
-            resolution=_RESOLUTION,
+            grid=UniformGrid(spacing=_RESOLUTION),
             backend="cpu",
             dtype=jnp.float64,
             courant_factor=0.99,
@@ -1466,7 +1466,7 @@ class TestGradientPMLBlochComplex:
         """
         config = SimulationConfig(
             time=_SIM_TIME,
-            resolution=_RESOLUTION,
+            grid=UniformGrid(spacing=_RESOLUTION),
             backend="cpu",
             dtype=jnp.float32,
             courant_factor=0.99,

--- a/tests/simulation/physics/boundaries/test_bloch_oblique.py
+++ b/tests/simulation/physics/boundaries/test_bloch_oblique.py
@@ -72,7 +72,7 @@ _T_ANALYTIC = (_N2 * _COS_T) / (_N1 * _COS_I) * (2 * _N1 * _COS_I / (_N1 * _COS_
 def _build_base():
     """Domain with Bloch x, periodic y, PML z, oblique TE source."""
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/boundaries/test_bloch_zero_vector.py
+++ b/tests/simulation/physics/boundaries/test_bloch_zero_vector.py
@@ -38,7 +38,7 @@ _REL_TOL = 1e-4
 
 def _build(bc_type, bloch_vector=(0.0, 0.0, 0.0)):
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/boundaries/test_mixed_boundaries.py
+++ b/tests/simulation/physics/boundaries/test_mixed_boundaries.py
@@ -95,7 +95,7 @@ def _build_domain(
 ):
     """Build a simulation domain with specified transverse sizes and boundary overrides."""
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
         use_complex_fields=use_complex_fields,

--- a/tests/simulation/physics/boundaries/test_pec_pmc_symmetry.py
+++ b/tests/simulation/physics/boundaries/test_pec_pmc_symmetry.py
@@ -62,7 +62,7 @@ _SIM_TIME = 150e-15  # 150 fs — extra time for standing wave to develop
 
 def _build(z_max_type):
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/boundaries/test_pec_reflection.py
+++ b/tests/simulation/physics/boundaries/test_pec_reflection.py
@@ -53,7 +53,7 @@ _N_AVG_STEPS = 10 * _STEPS_PER_PERIOD
 def _build_base(z_max_type="pml"):
     """Build domain with periodic xy, PML z-min, and configurable z-max."""
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/boundaries/test_pmc_reflection.py
+++ b/tests/simulation/physics/boundaries/test_pmc_reflection.py
@@ -45,7 +45,7 @@ _N_AVG_STEPS = 10 * _STEPS_PER_PERIOD
 
 def _build_base(z_max_type="pml"):
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/boundaries/test_quarter_domain_symmetry.py
+++ b/tests/simulation/physics/boundaries/test_quarter_domain_symmetry.py
@@ -64,7 +64,7 @@ _STEPS_PER_PERIOD = round(_WAVELENGTH / (3e8 * _DT_APPROX))
 def _build_quarter_domain():
     """Build quarter-domain sim with PEC at min_y and PMC at min_z."""
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )
@@ -118,7 +118,7 @@ def _build_full_domain():
     the true full domain that the quarter domain (with PEC/PMC mirrors) models.
     """
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/sources/test_dipole_green_function.py
+++ b/tests/simulation/physics/sources/test_dipole_green_function.py
@@ -41,7 +41,7 @@ _N = np.sqrt(_EPS_R)
 def _build_dipole_in_medium(eps_r=1.0):
     """Build domain with dipole in a uniform medium."""
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/sources/test_dipole_magnetic.py
+++ b/tests/simulation/physics/sources/test_dipole_magnetic.py
@@ -33,7 +33,7 @@ _N_AVG_STEPS = 10 * _STEPS_PER_PERIOD
 
 def _build_dipole(source_type="electric", polarization=2):
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/sources/test_dipole_radiation.py
+++ b/tests/simulation/physics/sources/test_dipole_radiation.py
@@ -46,7 +46,7 @@ _N_AVG_STEPS = 10 * _STEPS_PER_PERIOD
 def _build_dipole_domain(polarization=2, azimuth_angle=0.0, elevation_angle=0.0):
     """Build domain with a point dipole at center and PML on all faces."""
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/sources/test_gaussian_source.py
+++ b/tests/simulation/physics/sources/test_gaussian_source.py
@@ -46,7 +46,7 @@ _N_AVG_STEPS = 10 * _STEPS_PER_PERIOD
 
 def _build_gaussian(beam_radius: float, domain_xy: float):
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )
@@ -85,7 +85,7 @@ def _build_gaussian(beam_radius: float, domain_xy: float):
 
 def _build_uniform(domain_xy: float = _POWER_DOMAIN_XY):
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/sources/test_mode_source.py
+++ b/tests/simulation/physics/sources/test_mode_source.py
@@ -71,7 +71,7 @@ def _slab_neff_te(n_core: float, n_clad: float, wavelength: float, thickness: fl
 
 def _build_waveguide_domain():
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/sources/test_plane_source.py
+++ b/tests/simulation/physics/sources/test_plane_source.py
@@ -32,7 +32,7 @@ _SIM_TIME = 120e-15
 
 def _build_and_run(amplitude_factor=1.0, reduce_volume=True):
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/sources/test_temporal_profiles.py
+++ b/tests/simulation/physics/sources/test_temporal_profiles.py
@@ -34,7 +34,7 @@ _SIM_TIME = 120e-15
 
 def _build_base():
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )
@@ -272,7 +272,7 @@ def test_gaussian_pulse_broadband():
     sim_time = 12 * sigma_t  # t0=6σ_t peak + 6σ_t tail ≈ 19 fs
 
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=sim_time,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/test_birefringence.py
+++ b/tests/simulation/physics/test_birefringence.py
@@ -87,7 +87,7 @@ def _build_base(polarization_vector):
     and extends through the right PML, so the source is in vacuum.
     """
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/test_dispersion.py
+++ b/tests/simulation/physics/test_dispersion.py
@@ -88,7 +88,7 @@ def _fresnel_transmission_semi_infinite(eps_complex: complex) -> float:
 
 def _build_base():
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )
@@ -262,7 +262,7 @@ def _build_embedded_source(source_z: int):
     """Same as ``_build_base`` but with the plane source placed at an arbitrary
     z-coordinate so it can be embedded inside a uniform medium."""
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/test_dispersive_source.py
+++ b/tests/simulation/physics/test_dispersive_source.py
@@ -62,7 +62,7 @@ def _build_scene():
     """Uniform Lorentz medium, pulsed plane source in the middle, two
     Poynting flux detectors straddling the source."""
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/test_fresnel.py
+++ b/tests/simulation/physics/test_fresnel.py
@@ -68,7 +68,7 @@ _N_AVG_STEPS = 10 * _STEPS_PER_PERIOD  # average over last ~10 optical periods
 def _build_base():
     """Domain with periodic xy BCs, PML in z, and a +z UniformPlaneSource."""
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/test_nonuniform_grid.py
+++ b/tests/simulation/physics/test_nonuniform_grid.py
@@ -1,0 +1,146 @@
+"""End-to-end physics checks for mildly stretched rectilinear grids."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import fdtdx
+
+_WAVELENGTH = 1.0e-6
+_RESOLUTION = 50.0e-9
+_PML_CELLS = 8
+_NX = 3
+_NY = 3
+_NZ = 60
+_DOMAIN_XY = _NX * _RESOLUTION
+_DOMAIN_Z = _NZ * _RESOLUTION
+_SOURCE_Z = _PML_CELLS + 2
+_DET1_Z = _SOURCE_Z + 5
+_DET2_Z = _DET1_Z + 5
+_SIM_TIME = 90.0e-15
+
+
+def _stretched_z_edges() -> jnp.ndarray:
+    """Return a mildly stretched z grid with the same total physical length."""
+    cells = np.arange(_NZ, dtype=float)
+    widths = _RESOLUTION * (1.0 + 0.08 * np.sin(2.0 * np.pi * (cells + 0.5) / _NZ))
+    widths *= _DOMAIN_Z / widths.sum()
+    return jnp.asarray(np.concatenate([[0.0], np.cumsum(widths)]), dtype=jnp.float32)
+
+
+def _grid(kind: str) -> fdtdx.UniformGrid | fdtdx.RectilinearGrid:
+    if kind == "uniform":
+        return fdtdx.UniformGrid(spacing=_RESOLUTION)
+    if kind == "stretched":
+        return fdtdx.RectilinearGrid.custom(
+            x_edges=jnp.linspace(0.0, _DOMAIN_XY, _NX + 1),
+            y_edges=jnp.linspace(0.0, _DOMAIN_XY, _NY + 1),
+            z_edges=_stretched_z_edges(),
+        )
+    raise ValueError(f"Unknown grid kind: {kind}")
+
+
+def _add_real_z_plane(obj, volume, objects, constraints, z_coord: float):
+    constraints.extend(
+        [
+            obj.same_size(volume, axes=(0, 1)),
+            obj.place_at_center(volume, axes=(0, 1)),
+            fdtdx.RealCoordinateConstraint(
+                object=obj.name,
+                axes=(2,),
+                sides=("-",),
+                coordinates=(z_coord,),
+            ),
+        ]
+    )
+    objects.append(obj)
+
+
+def _build_and_run(kind: str):
+    config = fdtdx.SimulationConfig(
+        grid=_grid(kind),
+        time=_SIM_TIME,
+        dtype=jnp.float32,
+    )
+    objects, constraints = [], []
+    volume = fdtdx.SimulationVolume(partial_real_shape=(_DOMAIN_XY, _DOMAIN_XY, _DOMAIN_Z))
+    objects.append(volume)
+
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+        thickness=_PML_CELLS,
+        override_types={
+            "min_x": "periodic",
+            "max_x": "periodic",
+            "min_y": "periodic",
+            "max_y": "periodic",
+        },
+    )
+    bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    constraints.extend(c_list)
+    objects.extend(bound_dict.values())
+
+    wave = fdtdx.WaveCharacter(wavelength=_WAVELENGTH)
+    source = fdtdx.UniformPlaneSource(
+        partial_grid_shape=(None, None, 1),
+        wave_character=wave,
+        direction="+",
+        fixed_E_polarization_vector=(1, 0, 0),
+    )
+    _add_real_z_plane(source, volume, objects, constraints, _SOURCE_Z * _RESOLUTION)
+
+    for name, z_idx in (("d1", _DET1_Z), ("d2", _DET2_Z)):
+        detector = fdtdx.PhasorDetector(
+            name=name,
+            partial_grid_shape=(None, None, 1),
+            wave_characters=(wave,),
+            components=("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"),
+            reduce_volume=True,
+            plot=False,
+        )
+        _add_real_z_plane(detector, volume, objects, constraints, z_idx * _RESOLUTION)
+
+    key = jax.random.PRNGKey(0)
+    obj_container, arrays, params, config, _ = fdtdx.place_objects(objects, config, constraints, key)
+    arrays, obj_container, _ = fdtdx.apply_params(arrays, obj_container, params, key)
+    _, arrays = fdtdx.run_fdtd(arrays=arrays, objects=obj_container, config=config, key=key)
+    return arrays, obj_container, config
+
+
+def _phasor(arrays, detector_name: str, component: int) -> complex:
+    return complex(arrays.detector_states[detector_name]["phasor"][0, 0, component])
+
+
+def _detector_center_z(obj_container, config, detector_name: str) -> float:
+    detector = next(det for det in obj_container.detectors if det.name == detector_name)
+    lower, upper = detector.grid_slice_tuple[2]
+    grid = config.resolved_grid
+    assert grid is not None
+    return float(0.5 * (grid.z_edges[lower] + grid.z_edges[upper]))
+
+
+def _measured_k(arrays, obj_container, config) -> float:
+    d1 = _phasor(arrays, "d1", 0)
+    d2 = _phasor(arrays, "d2", 0)
+    separation = _detector_center_z(obj_container, config, "d2") - _detector_center_z(obj_container, config, "d1")
+    delta_phi = (np.angle(d2) - np.angle(d1)) % (2.0 * np.pi)
+    return float(delta_phi / separation)
+
+
+def _impedance(arrays, detector_name: str) -> float:
+    ex = _phasor(arrays, detector_name, 0)
+    hy = _phasor(arrays, detector_name, 4)
+    return float(abs(ex) / abs(hy))
+
+
+def test_mildly_stretched_grid_matches_uniform_vacuum_plane_wave():
+    """A full FDTD run on a mildly stretched grid matches uniform-grid observables."""
+    uniform_arrays, uniform_objects, uniform_config = _build_and_run("uniform")
+    stretched_arrays, stretched_objects, stretched_config = _build_and_run("stretched")
+
+    k_uniform = _measured_k(uniform_arrays, uniform_objects, uniform_config)
+    k_stretched = _measured_k(stretched_arrays, stretched_objects, stretched_config)
+    z_uniform = _impedance(uniform_arrays, "d1")
+    z_stretched = _impedance(stretched_arrays, "d1")
+
+    assert np.isclose(k_stretched, k_uniform, rtol=0.10), (k_uniform, k_stretched)
+    assert np.isclose(z_stretched, z_uniform, rtol=0.10), (z_uniform, z_stretched)

--- a/tests/simulation/physics/test_plane_wave.py
+++ b/tests/simulation/physics/test_plane_wave.py
@@ -58,7 +58,7 @@ def _build_1d_base():
         objects, constraints, config, volume, wave
     """
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/test_skin_depth.py
+++ b/tests/simulation/physics/test_skin_depth.py
@@ -103,7 +103,7 @@ def _analytic_alpha() -> float:
 def _build_base():
     """Vacuum domain with periodic xy BCs, PML in z, and an x-polarized +z source."""
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/simulation/physics/test_sparams.py
+++ b/tests/simulation/physics/test_sparams.py
@@ -59,7 +59,7 @@ def _build_waveguide_sparams():
     purely real TE mode that the ModePlaneSource can inject exactly.
     """
     config = fdtdx.SimulationConfig(
-        resolution=_RESOLUTION,
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
         time=_SIM_TIME,
         dtype=jnp.float32,
     )

--- a/tests/unit/conversion/test_vti.py
+++ b/tests/unit/conversion/test_vti.py
@@ -12,7 +12,9 @@ from fdtdx.conversion.vti import (
     encode_array,
     export_arrays_snapshot_to_vti,
     export_vti,
+    export_vtr,
 )
+from fdtdx.core.grid import RectilinearGrid
 
 # ---- NUMPY_TO_VTK_DTYPE mapping ----
 
@@ -161,6 +163,27 @@ class TestExportVti:
 
         content = path.read_text(encoding="utf-8", errors="ignore")
         assert 'Spacing="0.5 0.5 0.5"' in content
+
+    def test_nonuniform_grid_raises_with_vtr_hint(self, tmp_path):
+        data = jnp.zeros((2, 1, 1), dtype=jnp.float32)
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 1.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+
+        with pytest.raises(ValueError, match="Use export_vtr"):
+            export_vti({"field": data}, tmp_path / "fail.vti", resolution=1.0, grid=grid)
+
+    def test_uniform_grid_overrides_resolution(self, tmp_path):
+        data = jnp.zeros((2, 2, 2), dtype=jnp.float32)
+        grid = RectilinearGrid.uniform(shape=(2, 2, 2), spacing=0.25)
+        path = tmp_path / "test.vti"
+
+        export_vti({"field": data}, path, resolution=1.0, grid=grid)
+
+        content = path.read_text(encoding="utf-8", errors="ignore")
+        assert 'Spacing="0.25 0.25 0.25"' in content
 
     def test_scalar_field_components(self, tmp_path):
         data = jnp.zeros((3, 3, 3), dtype=jnp.float32)
@@ -343,3 +366,54 @@ class TestExportArraysSnapshotToVti:
         decompressed = zlib.decompress(compressed)
         values = jnp.frombuffer(decompressed, dtype=jnp.float32)
         assert jnp.allclose(values, 4.0)
+
+
+class TestExportVtr:
+    """Tests for rectilinear VTR export."""
+
+    def test_writes_rectilinear_grid_coordinates(self, tmp_path):
+        data = jnp.zeros((2, 2, 1), dtype=jnp.float32)
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 2.0, 5.0]),
+            z_edges=jnp.asarray([0.0, 4.0]),
+        )
+        path = tmp_path / "test.vtr"
+
+        export_vtr({"field": data}, path, grid)
+
+        content = path.read_text(encoding="utf-8", errors="ignore")
+        assert '<VTKFile type="RectilinearGrid"' in content
+        assert 'WholeExtent="0 2 0 2 0 1"' in content
+        assert 'Name="X_COORDINATES"' in content
+        assert "0.0 1.0 3.0" in content
+        assert "0.0 2.0 5.0" in content
+        assert "0.0 4.0" in content
+
+    def test_grid_slice_coordinates(self, tmp_path):
+        data = jnp.zeros((2, 1, 1), dtype=jnp.float32)
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+            y_edges=jnp.asarray([0.0, 2.0, 5.0]),
+            z_edges=jnp.asarray([0.0, 4.0]),
+        )
+        path = tmp_path / "slice.vtr"
+
+        export_vtr({"field": data}, path, grid, grid_slice=(slice(1, 3), slice(1, 2), slice(0, 1)))
+
+        content = path.read_text(encoding="utf-8", errors="ignore")
+        assert 'WholeExtent="1 3 1 2 0 1"' in content
+        assert "1.0 3.0 6.0" in content
+        assert "2.0 5.0" in content
+
+    def test_grid_slice_shape_mismatch_raises(self, tmp_path):
+        data = jnp.zeros((2, 1, 1), dtype=jnp.float32)
+        grid = RectilinearGrid.uniform(shape=(3, 3, 3), spacing=1.0)
+
+        with pytest.raises(AssertionError, match="shape must match"):
+            export_vtr(
+                {"field": data},
+                tmp_path / "fail.vtr",
+                grid,
+                grid_slice=(slice(0, 1), slice(0, 1), slice(0, 1)),
+            )

--- a/tests/unit/core/physics/test_curl.py
+++ b/tests/unit/core/physics/test_curl.py
@@ -1,6 +1,7 @@
 import jax.numpy as jnp
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.core.misc import pad_fields
 from fdtdx.core.physics.curl import curl_E, curl_H, interpolate_fields
 
@@ -8,7 +9,20 @@ from fdtdx.core.physics.curl import curl_E, curl_H, interpolate_fields
 def _make_config():
     return SimulationConfig(
         time=400e-15,
-        resolution=1.0,
+        grid=UniformGrid(spacing=1.0),
+        courant_factor=0.99,
+    )
+
+
+def _make_nonuniform_config():
+    grid = RectilinearGrid(
+        x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0, 10.0]),
+        y_edges=jnp.asarray([0.0, 1.0, 2.5, 5.0, 9.0]),
+        z_edges=jnp.asarray([0.0, 1.0, 4.0, 8.0, 13.0]),
+    )
+    return SimulationConfig(
+        time=400e-15,
+        grid=grid,
         courant_factor=0.99,
     )
 
@@ -83,6 +97,31 @@ def test_interpolate_fields_zero_fields():
     assert H_interp.shape == (3, 4, 4, 4)
     assert jnp.allclose(E_interp, 0.0)
     assert jnp.allclose(H_interp, 0.0)
+
+
+def test_interpolate_fields_nonuniform_center_to_edge_weights():
+    """Distance-weighted interpolation recovers linear fields on stretched cells."""
+    config = _make_nonuniform_config()
+    nx, ny, nz = config.grid.shape
+    x_centers = config.grid.centers(0)
+    z_edges = config.grid.z_edges[:-1]
+    Xc, _Y, Ze = jnp.meshgrid(x_centers, config.grid.y_edges[:-1], z_edges, indexing="ij")
+
+    E = jnp.zeros((3, nx, ny, nz), dtype=jnp.float32)
+    E = E.at[0].set(Xc + Ze)
+    H = jnp.zeros((3, nx, ny, nz), dtype=jnp.float32)
+
+    E_pad = pad_fields(E, (False, False, False))
+    H_pad = pad_fields(H, (False, False, False))
+    E_interp, _ = interpolate_fields(E_pad, H_pad, config=config)
+
+    target_x_edges = config.grid.x_edges[:-1]
+    target_z_centers = config.grid.centers(2)
+    X_edge, _Y_edge, Z_center = jnp.meshgrid(target_x_edges, config.grid.y_edges[:-1], target_z_centers, indexing="ij")
+    expected = X_edge + Z_center
+
+    assert E_interp.shape == (3, nx, ny, nz)
+    assert jnp.allclose(E_interp[0][1:, :, :-1], expected[1:, :, :-1], atol=1e-6)
 
 
 # ──────────────────────────────────────────────────────────────
@@ -218,6 +257,90 @@ def test_curl_E_mixed_periodic():
     assert jnp.allclose(curl_result[2][:-1, 1:-1, :-1], -2.0, atol=0.1)
 
 
+def test_curl_E_nonuniform_metric_no_boundaries():
+    """Local metric factors recover the physical curl of linear fields."""
+    config = _make_nonuniform_config()
+    nx, ny, nz = config.grid.shape
+    x = config.grid.x_edges[:-1]
+    y = config.grid.y_edges[:-1]
+    X, Y, _Z = jnp.meshgrid(x, y, config.grid.z_edges[:-1], indexing="ij")
+
+    E = jnp.stack([Y, -X, jnp.zeros((nx, ny, nz), dtype=jnp.float32)], axis=0)
+    E_pad = pad_fields(E, (False, False, False))
+    psi_H = jnp.zeros((6, nx, ny, nz))
+
+    curl_result, _ = curl_E(
+        config,
+        E_pad,
+        psi_H,
+        alpha=jnp.zeros((6, nx, ny, nz)),
+        kappa=jnp.ones((6, nx, ny, nz)),
+        sigma=jnp.zeros((6, nx, ny, nz)),
+        simulate_boundaries=False,
+    )
+
+    assert curl_result.shape == (3, nx, ny, nz)
+    assert jnp.allclose(curl_result[2][:-1, :-1, :], -2.0, atol=1e-6)
+
+
+def test_curl_E_nonuniform_quadratic_field_matches_local_physical_derivative():
+    """Forward Yee derivatives use local stretched-cell widths, not index spacing."""
+    config = _make_nonuniform_config()
+    nx, ny, nz = config.grid.shape
+    y = config.grid.y_edges[:-1]
+    z = config.grid.z_edges[:-1]
+    _X, Y, Z = jnp.meshgrid(config.grid.x_edges[:-1], y, z, indexing="ij")
+
+    E = jnp.stack(
+        [
+            jnp.zeros((nx, ny, nz), dtype=jnp.float32),
+            Z**2,
+            Y**2,
+        ],
+        axis=0,
+    )
+    E_pad = pad_fields(E, (False, False, False))
+    psi_H = jnp.zeros((6, nx, ny, nz))
+
+    curl_result, _ = curl_E(
+        config,
+        E_pad,
+        psi_H,
+        alpha=jnp.zeros((6, nx, ny, nz)),
+        kappa=jnp.ones((6, nx, ny, nz)),
+        sigma=jnp.zeros((6, nx, ny, nz)),
+        simulate_boundaries=False,
+    )
+
+    expected_y = y[:-1] + y[1:]
+    expected_z = z[:-1] + z[1:]
+    expected = expected_y[None, :, None] - expected_z[None, None, :]
+    assert jnp.allclose(curl_result[0][:, :-1, :-1], expected, atol=1e-6)
+
+
+def test_curl_E_nonuniform_pml_coefficients_use_time_step():
+    """PML auxiliary coefficients do not require a uniform grid spacing."""
+    config = _make_nonuniform_config()
+    nx, ny, nz = config.grid.shape
+    E = jnp.ones((3, nx, ny, nz), dtype=jnp.float32)
+    E = E.at[2].set(jnp.arange(ny, dtype=jnp.float32).reshape(1, ny, 1))
+    E_pad = pad_fields(E, (False, False, False))
+    psi_H = jnp.zeros((6, nx, ny, nz))
+
+    curl_result, psi_updated = curl_E(
+        config,
+        E_pad,
+        psi_H,
+        alpha=jnp.ones((6, nx, ny, nz)) * 0.05,
+        kappa=jnp.ones((6, nx, ny, nz)),
+        sigma=jnp.ones((6, nx, ny, nz)) * 0.1,
+        simulate_boundaries=True,
+    )
+
+    assert jnp.all(jnp.isfinite(curl_result))
+    assert jnp.all(jnp.isfinite(psi_updated))
+
+
 # ──────────────────────────────────────────────────────────────
 # curl_H
 # ──────────────────────────────────────────────────────────────
@@ -342,3 +465,87 @@ def test_curl_H_mixed_periodic():
 
     assert curl_result.shape == (3, n, n, n)
     assert jnp.all(jnp.isfinite(curl_result))
+
+
+def test_curl_H_nonuniform_metric_no_boundaries():
+    """Backward-difference H curls recover linear physical derivatives at cell centers."""
+    config = _make_nonuniform_config()
+    nx, ny, nz = config.grid.shape
+    x_centers = config.grid.centers(0)
+    z_centers = config.grid.centers(2)
+    X, _Y, Z = jnp.meshgrid(x_centers, config.grid.y_edges[:-1], z_centers, indexing="ij")
+
+    H = jnp.stack([Z, jnp.zeros((nx, ny, nz), dtype=jnp.float32), -X], axis=0)
+    H_pad = pad_fields(H, (False, False, False))
+    psi_E = jnp.zeros((6, nx, ny, nz))
+
+    curl_result, _ = curl_H(
+        config,
+        H_pad,
+        psi_E,
+        alpha=jnp.zeros((6, nx, ny, nz)),
+        kappa=jnp.ones((6, nx, ny, nz)),
+        sigma=jnp.zeros((6, nx, ny, nz)),
+        simulate_boundaries=False,
+    )
+
+    assert curl_result.shape == (3, nx, ny, nz)
+    assert jnp.allclose(curl_result[1][1:, :, 1:], 2.0, atol=1e-6)
+
+
+def test_curl_H_nonuniform_quadratic_field_matches_local_physical_derivative():
+    """Backward Yee derivatives use the inter-center distance (dy[j]+dy[j-1])/2."""
+    config = _make_nonuniform_config()
+    nx, ny, nz = config.grid.shape
+    y_centers = config.grid.centers(1)
+    z_centers = config.grid.centers(2)
+    _X, Y, Z = jnp.meshgrid(config.grid.x_edges[:-1], y_centers, z_centers, indexing="ij")
+
+    H = jnp.stack(
+        [
+            jnp.zeros((nx, ny, nz), dtype=jnp.float32),
+            Z**2,
+            Y**2,
+        ],
+        axis=0,
+    )
+    H_pad = pad_fields(H, (False, False, False))
+    psi_E = jnp.zeros((6, nx, ny, nz))
+
+    curl_result, _ = curl_H(
+        config,
+        H_pad,
+        psi_E,
+        alpha=jnp.zeros((6, nx, ny, nz)),
+        kappa=jnp.ones((6, nx, ny, nz)),
+        sigma=jnp.zeros((6, nx, ny, nz)),
+        simulate_boundaries=False,
+    )
+
+    expected_y = y_centers[1:] + y_centers[:-1]
+    expected_z = z_centers[1:] + z_centers[:-1]
+    expected = expected_y[None, :, None] - expected_z[None, None, :]
+    assert jnp.allclose(curl_result[0][:, 1:, 1:], expected, atol=1e-6)
+
+
+def test_curl_H_nonuniform_pml_coefficients_use_time_step():
+    """H-to-E PML auxiliary coefficients share the nonuniform-safe dt path."""
+    config = _make_nonuniform_config()
+    nx, ny, nz = config.grid.shape
+    H = jnp.ones((3, nx, ny, nz), dtype=jnp.float32)
+    H = H.at[2].set(jnp.arange(ny, dtype=jnp.float32).reshape(1, ny, 1))
+    H_pad = pad_fields(H, (False, False, False))
+    psi_E = jnp.zeros((6, nx, ny, nz))
+
+    curl_result, psi_updated = curl_H(
+        config,
+        H_pad,
+        psi_E,
+        alpha=jnp.ones((6, nx, ny, nz)) * 0.05,
+        kappa=jnp.ones((6, nx, ny, nz)),
+        sigma=jnp.ones((6, nx, ny, nz)) * 0.1,
+        simulate_boundaries=True,
+    )
+
+    assert jnp.all(jnp.isfinite(curl_result))
+    assert jnp.all(jnp.isfinite(psi_updated))

--- a/tests/unit/core/physics/test_modes.py
+++ b/tests/unit/core/physics/test_modes.py
@@ -172,6 +172,57 @@ class TestComputeMode:
         with pytest.raises(Exception, match="Invalid shape of inv_permeabilities"):
             compute_mode(frequency, inv_permittivities, inv_permeabilities, resolution, "+")
 
+    def test_invalid_transverse_coords_shape(self):
+        """Transverse coordinate arrays must match the mode cross-section shape."""
+        inv_permittivities = jnp.ones((1, 2, 2, 1))
+
+        with pytest.raises(ValueError, match="length 3"):
+            compute_mode(
+                frequency=2e14,
+                inv_permittivities=inv_permittivities,
+                inv_permeabilities=1.0,
+                resolution=1e-8,
+                direction="+",
+                transverse_coords=[np.asarray([0.0, 1.0]), np.asarray([0.0, 1.0, 2.0])],
+            )
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_transverse_coords_passed_to_tidy3d_and_normalization(self, mock_normalize, mock_tidy3d_wrapper):
+        """Non-uniform transverse coordinates are passed through and used for normalization weights."""
+        mock_mode = ModeTupleType(
+            neff=1.5 + 0.1j,
+            Ex=np.ones((2, 2), dtype=np.complex64),
+            Ey=np.ones((2, 2), dtype=np.complex64),
+            Ez=np.ones((2, 2), dtype=np.complex64),
+            Hx=np.ones((2, 2), dtype=np.complex64),
+            Hy=np.ones((2, 2), dtype=np.complex64),
+            Hz=np.ones((2, 2), dtype=np.complex64),
+        )
+        mock_tidy3d_wrapper.return_value = [mock_mode]
+        mock_normalize.return_value = (
+            jnp.ones((3, 2, 2, 1), dtype=jnp.complex64),
+            jnp.ones((3, 2, 2, 1), dtype=jnp.complex64),
+        )
+
+        compute_mode(
+            frequency=2e14,
+            inv_permittivities=jnp.ones((1, 2, 2, 1)),
+            inv_permeabilities=1.0,
+            resolution=1e-8,
+            direction="+",
+            transverse_coords=[np.asarray([0.0, 1e-6, 3e-6]), np.asarray([0.0, 2e-6, 5e-6])],
+        )
+
+        wrapper_kwargs = mock_tidy3d_wrapper.call_args.kwargs
+        assert np.allclose(wrapper_kwargs["coords"][0], [0.0, 1.0, 3.0])
+        assert np.allclose(wrapper_kwargs["coords"][1], [0.0, 2.0, 5.0])
+
+        normalize_kwargs = mock_normalize.call_args.kwargs
+        assert normalize_kwargs["axis"] == 2
+        expected_area = jnp.asarray([[[2e-12], [3e-12]], [[4e-12], [6e-12]]], dtype=jnp.float32)
+        assert jnp.allclose(normalize_kwargs["area_weights"], expected_area)
+
 
 class TestAnisotropicModeComputation:
     """Test anisotropic material handling in compute_mode."""

--- a/tests/unit/core/test_grid.py
+++ b/tests/unit/core/test_grid.py
@@ -2,7 +2,117 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from fdtdx.core.grid import calculate_spatial_offsets_yee, calculate_time_offset_yee, polygon_to_mask
+from fdtdx import constants
+from fdtdx.core.grid import (
+    RectilinearGrid,
+    calculate_spatial_offsets_yee,
+    calculate_time_offset_yee,
+    polygon_to_mask,
+)
+
+
+class TestRectilinearGrid:
+    """Tests for the canonical rectilinear grid representation."""
+
+    def test_uniform_constructor_stores_edges(self):
+        """Uniform grids are represented as ordinary rectilinear edge arrays."""
+        grid = RectilinearGrid.uniform(shape=(2, 3, 4), spacing=0.5, origin=(1.0, 2.0, 3.0))
+
+        assert grid.shape == (2, 3, 4)
+        assert np.allclose(np.asarray(grid.x_edges), [1.0, 1.5, 2.0])
+        assert np.allclose(np.asarray(grid.y_edges), [2.0, 2.5, 3.0, 3.5])
+        assert np.allclose(np.asarray(grid.z_edges), [3.0, 3.5, 4.0, 4.5, 5.0])
+        assert grid.is_uniform
+        assert grid.uniform_spacing == 0.5
+
+    def test_custom_constructor_stores_explicit_edges(self):
+        """Custom grids are realized edge arrays, not automatic meshing policies."""
+        grid = RectilinearGrid.custom(
+            x_edges=jnp.asarray([0.0, 1.0, 2.5]),
+            y_edges=jnp.asarray([0.0, 2.0]),
+            z_edges=jnp.asarray([0.0, 0.5, 1.5]),
+        )
+
+        assert grid.shape == (2, 1, 2)
+        assert np.allclose(np.asarray(grid.dx), [1.0, 1.5])
+        assert not grid.is_uniform
+
+    def test_nonuniform_grid_metrics(self):
+        """Non-uniform grids derive widths, centers, extents, areas, and volumes from edges."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 2.0, 5.0]),
+            z_edges=jnp.asarray([0.0, 4.0, 6.0]),
+        )
+        slice_tuple = ((0, 2), (0, 2), (0, 2))
+
+        assert grid.shape == (2, 2, 2)
+        assert np.allclose(np.asarray(grid.dx), [1.0, 2.0])
+        assert np.allclose(np.asarray(grid.centers(1)), [1.0, 3.5])
+        assert grid.min_spacing == 1.0
+        assert not grid.is_uniform
+        assert grid.slice_extent(slice_tuple) == (3.0, 5.0, 6.0)
+        assert np.allclose(np.asarray(grid.face_area(axis=0, slice_tuple=slice_tuple)), [[[8.0, 4.0], [12.0, 6.0]]])
+        assert np.allclose(
+            np.asarray(grid.cell_volume(slice_tuple)),
+            [[[8.0, 4.0], [12.0, 6.0]], [[16.0, 8.0], [24.0, 12.0]]],
+        )
+
+    def test_uniform_spacing_raises_for_nonuniform_grid(self):
+        """Scalar-resolution compatibility paths must fail loudly for non-uniform grids."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 1.0, 2.0]),
+            z_edges=jnp.asarray([0.0, 1.0, 2.0]),
+        )
+
+        with pytest.raises(ValueError, match="requires a uniform grid"):
+            _ = grid.uniform_spacing
+
+    def test_coord_to_index_snapping_rules(self):
+        """Coordinate snapping is centralized so placement code does not open-code searchsorted."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+            y_edges=jnp.asarray([0.0, 1.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+
+        assert grid.coord_to_index(0, 2.2, snap="nearest") == 2
+        assert grid.coord_to_index(0, 2.2, snap="lower") == 1
+        assert grid.coord_to_index(0, 2.2, snap="upper") == 2
+
+    def test_bounds_for_center_uses_physical_interval_centers(self):
+        """Center snapping compares physical interval centers, not index centers."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+            y_edges=jnp.asarray([0.0, 1.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+
+        assert grid.bounds_for_center(axis=0, center=3.6, size=2) == (1, 3)
+
+    def test_bounds_for_anchor_uses_physical_anchor_positions(self):
+        """Relative placement can target physical lower/center/upper anchors."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+            y_edges=jnp.asarray([0.0, 1.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+
+        assert grid.anchor_coordinate(axis=0, bounds=(1, 3), position=-1.0) == 1.0
+        assert grid.anchor_coordinate(axis=0, bounds=(1, 3), position=1.0) == 6.0
+        assert grid.bounds_for_anchor(axis=0, size=1, anchor=3.1, position=-1.0) == (2, 3)
+
+    def test_cfl_time_step_uses_min_spacing_per_axis(self):
+        """The rectilinear CFL limit uses the smallest spacing on each axis."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 2.0, 5.0]),
+            y_edges=jnp.asarray([0.0, 1.0]),
+            z_edges=jnp.asarray([0.0, 4.0]),
+        )
+
+        expected = 0.99 / (constants.c * np.sqrt(1 / 2.0**2 + 1 / 1.0**2 + 1 / 4.0**2))
+        assert np.isclose(grid.cfl_time_step(0.99), expected)
 
 
 def test_calculate_spatial_offsets_yee_basic():
@@ -65,6 +175,44 @@ def test_calculate_time_offset_yee_with_effective_index():
     # Check that results are finite
     assert jnp.all(jnp.isfinite(time_offset_E))
     assert jnp.all(jnp.isfinite(time_offset_H))
+
+
+def test_calculate_time_offset_yee_uniform_coordinates_match_scalar_path():
+    """A uniform RectilinearGrid is a metric-equivalent replacement for scalar spacing."""
+    spacing = 0.2
+    shape = (3, 3, 1)
+    center = jnp.array([1.0, 1.0])
+    wave_vector = jnp.array([0.3, 0.4, -0.5])
+    wave_vector = wave_vector / jnp.linalg.norm(wave_vector)
+    inv_permittivities = jnp.ones(shape)
+    inv_permeabilities = 1.0
+    time_step_duration = 1e-15
+
+    scalar_E, scalar_H = calculate_time_offset_yee(
+        center=center,
+        wave_vector=wave_vector,
+        inv_permittivities=inv_permittivities,
+        inv_permeabilities=inv_permeabilities,
+        resolution=spacing,
+        time_step_duration=time_step_duration,
+    )
+    grid_E, grid_H = calculate_time_offset_yee(
+        center=center,
+        wave_vector=wave_vector,
+        inv_permittivities=inv_permittivities,
+        inv_permeabilities=inv_permeabilities,
+        resolution=spacing,
+        time_step_duration=time_step_duration,
+        coordinate_edges=(
+            spacing * jnp.arange(shape[0] + 1),
+            spacing * jnp.arange(shape[1] + 1),
+            spacing * jnp.arange(shape[2] + 1),
+        ),
+        center_physical=jnp.array([center[0] * spacing, center[1] * spacing, 0.0]),
+    )
+
+    assert jnp.allclose(grid_E, scalar_E, rtol=1e-6, atol=0.2)
+    assert jnp.allclose(grid_H, scalar_H, rtol=1e-6, atol=0.2)
 
 
 def test_calculate_time_offset_yee_invalid_permittivity_shape():
@@ -266,6 +414,31 @@ def test_calculate_time_offset_yee_4d_permeability():
             e_polarization=e_pol,
             h_polarization=h_pol,
         )
+
+
+def test_calculate_time_offset_yee_uses_coordinate_edges():
+    """Explicit rectilinear coordinates produce physical travel offsets."""
+    center = jnp.asarray([0.0, 0.0])
+    wave_vector = jnp.asarray([1.0, 0.0, 0.0])
+    inv_permittivities = jnp.ones((1, 2, 1, 1))
+    time_step_duration = 1.0 / constants.c
+
+    time_offset_E, _time_offset_H = calculate_time_offset_yee(
+        center=center,
+        wave_vector=wave_vector,
+        inv_permittivities=inv_permittivities,
+        inv_permeabilities=1.0,
+        resolution=1.0,
+        time_step_duration=time_step_duration,
+        coordinate_edges=(
+            jnp.asarray([0.0, 1.0, 3.0]),
+            jnp.asarray([0.0, 1.0]),
+            jnp.asarray([0.0, 1.0]),
+        ),
+        center_physical=jnp.asarray([0.0, 0.0, 0.0]),
+    )
+
+    assert jnp.allclose(time_offset_E[0, :, 0, 0], jnp.asarray([-0.5, -2.0]))
 
 
 def test_calculate_time_offset_yee_4d_permeability_without_h_polarization():

--- a/tests/unit/fdtd/test_fdtd.py
+++ b/tests/unit/fdtd/test_fdtd.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import GradientConfig, SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer
 from fdtdx.fdtd.fdtd import checkpointed_fdtd, custom_fdtd_forward, reversible_fdtd
 from fdtdx.fdtd.stop_conditions import TimeStepCondition
@@ -63,7 +64,7 @@ def config_few_steps():
     """Config with ~5 time steps for fast tests."""
     return SimulationConfig(
         time=400e-15,
-        resolution=40e-6,
+        grid=UniformGrid(spacing=40e-6),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,
@@ -75,7 +76,7 @@ def config_few_steps():
 def config_checkpointed():
     return SimulationConfig(
         time=400e-15,
-        resolution=40e-6,
+        grid=UniformGrid(spacing=40e-6),
         backend="gpu",
         dtype=jnp.float32,
         courant_factor=0.99,
@@ -111,7 +112,7 @@ class TestReversibleFdtd:
     def test_zero_time_produces_no_evolution(self, dummy_arrays, dummy_objects, key):
         config = SimulationConfig(
             time=0.0,
-            resolution=40e-6,
+            grid=UniformGrid(spacing=40e-6),
             backend="cpu",
             dtype=jnp.float32,
             courant_factor=0.99,

--- a/tests/unit/fdtd/test_initialization.py
+++ b/tests/unit/fdtd/test_initialization.py
@@ -7,6 +7,7 @@ import pytest
 
 from fdtdx.config import SimulationConfig
 from fdtdx.constants import MAX_SIMULATION_VOLUME_CELLS
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.fdtd.container import ArrayContainer, ObjectContainer
 from fdtdx.fdtd.initialization import (
     _apply_grid_coordinate_constraint,
@@ -46,7 +47,7 @@ from fdtdx.objects.static_material.static import (
 
 @pytest.fixture
 def simple_config():
-    return SimulationConfig(resolution=1.0, time=100e-15)
+    return SimulationConfig(grid=UniformGrid(spacing=1.0), time=100e-15)
 
 
 @pytest.fixture
@@ -165,7 +166,7 @@ def test_resolve_constraints_with_real_margins(simple_config, simple_volume, sim
 
 
 def test_resolve_constraints_with_both_margins(simple_volume, simple_material):
-    config = SimulationConfig(resolution=0.5, time=100e-15)
+    config = SimulationConfig(grid=UniformGrid(spacing=0.5), time=100e-15)
     obj = UniformMaterialObject(name="obj1", partial_grid_shape=(10, 10, 10), material=simple_material)
     constraint = PositionConstraint(
         object="obj1",
@@ -182,7 +183,7 @@ def test_resolve_constraints_with_both_margins(simple_volume, simple_material):
 
 
 def test_resolve_constraints_with_real_offset_in_size(simple_volume, simple_material):
-    config = SimulationConfig(resolution=0.5, time=100e-15)
+    config = SimulationConfig(grid=UniformGrid(spacing=0.5), time=100e-15)
     obj = UniformMaterialObject(name="obj1", material=simple_material)
     constraint = SizeConstraint(
         object="obj1",
@@ -215,7 +216,7 @@ def test_resolve_constraints_with_grid_offset_in_size(simple_config, simple_volu
 
 
 def test_resolve_constraints_size_extension_with_real_offset(simple_volume, simple_material):
-    config = SimulationConfig(resolution=0.5, time=100e-15)
+    config = SimulationConfig(grid=UniformGrid(spacing=0.5), time=100e-15)
     obj1 = UniformMaterialObject(name="obj1", partial_grid_shape=(10, 10, 10), material=simple_material)
     obj2 = UniformMaterialObject(name="obj2", material=simple_material)
     pos_constraint = GridCoordinateConstraint(object="obj1", axes=[0], sides=["-"], coordinates=[20])
@@ -276,7 +277,7 @@ def test_resolve_constraints_size_extension_to_volume_boundary(simple_config, si
 
 
 def test_resolve_constraints_with_partial_real_shape(simple_material):
-    config = SimulationConfig(resolution=0.5, time=100e-15)
+    config = SimulationConfig(grid=UniformGrid(spacing=0.5), time=100e-15)
     volume = SimulationVolume(name="volume", partial_grid_shape=(100, 100, 100))
     obj = UniformMaterialObject(name="obj1", partial_real_shape=(5.0, 5.0, 5.0), material=simple_material)
     constraints = [
@@ -288,6 +289,143 @@ def test_resolve_constraints_with_partial_real_shape(simple_material):
     if resolved_slices["obj1"][0][0] is not None:
         shape = resolved_slices["obj1"][0][1] - resolved_slices["obj1"][0][0]
         assert shape == 10
+
+
+def test_nonuniform_partial_real_shape_covers_metric_size(simple_material):
+    """Real object sizes use grid edges and cover the requested metric length."""
+    grid = RectilinearGrid(
+        x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+        y_edges=jnp.asarray([0.0, 2.0, 5.0]),
+        z_edges=jnp.asarray([0.0, 1.5, 4.0]),
+    )
+    config = SimulationConfig(grid=grid, time=100e-15)
+    volume = SimulationVolume(name="volume", partial_grid_shape=grid.shape)
+    obj = UniformMaterialObject(name="obj1", partial_real_shape=(2.1, 2.1, 2.1), material=simple_material)
+    constraints = [
+        RealCoordinateConstraint(object="obj1", axes=(0, 1, 2), sides=("-", "-", "-"), coordinates=(0.0, 0.0, 0.0))
+    ]
+
+    resolved_slices, errors = resolve_object_constraints([volume, obj], constraints, config)
+
+    assert errors["obj1"] is None
+    assert resolved_slices["obj1"] == ((0, 2), (0, 2), (0, 2))
+
+
+def test_nonuniform_partial_real_position_uses_physical_interval_center(simple_material):
+    """Center placement chooses the grid interval with closest physical center."""
+    grid = RectilinearGrid(
+        x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+        y_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+        z_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+    )
+    config = SimulationConfig(grid=grid, time=100e-15)
+    volume = SimulationVolume(name="volume", partial_grid_shape=grid.shape)
+    obj = UniformMaterialObject(
+        name="obj1",
+        partial_grid_shape=(2, 2, 2),
+        partial_real_position=(3.6, 3.6, 3.6),
+        material=simple_material,
+    )
+
+    resolved_slices, errors = resolve_object_constraints([volume, obj], [], config)
+
+    assert errors["obj1"] is None
+    assert resolved_slices["obj1"] == ((1, 3), (1, 3), (1, 3))
+
+
+def test_nonuniform_real_coordinate_constraint_snaps_to_nearest_edge(simple_material):
+    """Real coordinate constraints use physical edge coordinates on stretched grids."""
+    grid = RectilinearGrid(
+        x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+        y_edges=jnp.asarray([0.0, 1.0]),
+        z_edges=jnp.asarray([0.0, 1.0]),
+    )
+    config = SimulationConfig(grid=grid, time=100e-15)
+    volume = SimulationVolume(name="volume", partial_grid_shape=grid.shape)
+    obj = UniformMaterialObject(name="obj1", partial_grid_shape=(1, 1, 1), material=simple_material)
+    constraint = RealCoordinateConstraint(object="obj1", axes=(0,), sides=("-",), coordinates=(2.7,))
+
+    resolved_slices, errors = resolve_object_constraints([volume, obj], [constraint], config)
+
+    assert errors["obj1"] is None
+    assert resolved_slices["obj1"][0] == (2, 3)
+
+
+def test_nonuniform_grid_coordinate_constraint_is_rejected(simple_material):
+    """Index-space placement coordinates are not allowed on non-uniform grids."""
+    grid = RectilinearGrid(
+        x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+        y_edges=jnp.asarray([0.0, 1.0, 2.0, 3.0]),
+        z_edges=jnp.asarray([0.0, 1.0, 2.0, 3.0]),
+    )
+    config = SimulationConfig(grid=grid, time=100e-15)
+    volume = SimulationVolume(name="volume", partial_grid_shape=grid.shape)
+    obj = UniformMaterialObject(name="obj1", partial_grid_shape=(1, 1, 1), material=simple_material)
+    constraint = GridCoordinateConstraint(object="obj1", axes=(0,), sides=("-",), coordinates=(1,))
+
+    _resolved_slices, errors = resolve_object_constraints([volume, obj], [constraint], config)
+
+    assert "not supported on non-uniform grids" in errors["obj1"]
+
+
+def test_nonuniform_nonzero_grid_margin_is_rejected(simple_material):
+    """Grid margins are index-space distances and must be expressed in metres."""
+    grid = RectilinearGrid(
+        x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0, 10.0]),
+        y_edges=jnp.asarray([0.0, 1.0, 2.0, 3.0, 4.0]),
+        z_edges=jnp.asarray([0.0, 1.0, 2.0, 3.0, 4.0]),
+    )
+    config = SimulationConfig(grid=grid, time=100e-15)
+    volume = SimulationVolume(name="volume", partial_grid_shape=grid.shape)
+    parent = UniformMaterialObject(name="parent", partial_grid_shape=(1, 1, 1), material=simple_material)
+    child = UniformMaterialObject(name="child", partial_grid_shape=(1, 1, 1), material=simple_material)
+    constraints = [
+        RealCoordinateConstraint(object="parent", axes=(0, 1, 2), sides=("-", "-", "-"), coordinates=(0.0, 0.0, 0.0)),
+        child.face_to_face_positive_direction(parent, axes=(0,), grid_margins=(1,)),
+    ]
+
+    _resolved_slices, errors = resolve_object_constraints([volume, parent, child], constraints, config)
+
+    assert "grid_margins" in errors["child"]
+
+
+def test_nonuniform_size_constraint_uses_physical_proportion(simple_material):
+    """SizeConstraint proportions resolve using metric extents on stretched grids.
+
+    Grid x has widths [1, 2, 3] so three cells span 6 m.  A 50 % proportion
+    targets 3 m, which covers the first two cells (edges 0→1→3).
+    """
+    grid = RectilinearGrid(
+        x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),  # widths 1, 2, 3 → total 6 m
+        y_edges=jnp.asarray([0.0, 1.0]),
+        z_edges=jnp.asarray([0.0, 1.0]),
+    )
+    config = SimulationConfig(grid=grid, time=100e-15)
+    volume = SimulationVolume(name="volume", partial_grid_shape=grid.shape)
+    parent = UniformMaterialObject(name="parent", partial_grid_shape=(3, 1, 1), material=simple_material)
+    child = UniformMaterialObject(name="child", material=simple_material)
+    constraints = [
+        RealCoordinateConstraint(object="parent", axes=(0, 1, 2), sides=("-", "-", "-"), coordinates=(0.0, 0.0, 0.0)),
+        RealCoordinateConstraint(object="child", axes=(0, 1, 2), sides=("-", "-", "-"), coordinates=(0.0, 0.0, 0.0)),
+        SizeConstraint(
+            object="child",
+            other_object="parent",
+            axes=[0],
+            other_axes=[0],
+            proportions=[0.5],
+            grid_offsets=[None],
+            offsets=[None],
+        ),
+    ]
+
+    resolved_slices, errors = resolve_object_constraints([volume, parent, child], constraints, config)
+
+    assert errors["parent"] is None
+    assert errors["child"] is None
+    assert resolved_slices["parent"][0] == (0, 3)
+    # 50 % of 6 m = 3 m; upper-snap from lower edge gives 2 cells (0→1→3)
+    child_size = resolved_slices["child"][0][1] - resolved_slices["child"][0][0]
+    assert child_size == 2
 
 
 def test_resolve_constraints_extend_to_infinity(simple_config, simple_volume, simple_material):
@@ -373,7 +511,7 @@ def test_resolve_static_shapes_grid_shape(simple_config, simple_volume, simple_m
 
 
 def test_resolve_static_shapes_real_shape(simple_material):
-    config = SimulationConfig(resolution=0.5, time=100e-15)
+    config = SimulationConfig(grid=UniformGrid(spacing=0.5), time=100e-15)
     volume = SimulationVolume(name="volume", partial_grid_shape=(100, 100, 100))
     obj = UniformMaterialObject(name="obj1", partial_real_shape=(5.0, 10.0, 15.0), material=simple_material)
     obj_map = {"volume": volume, "obj1": obj}
@@ -454,7 +592,7 @@ def test_apply_real_coordinate_constraint_converts_to_grid(simple_config, simple
 
 
 def test_apply_real_coordinate_constraint_sub_resolution(simple_material):
-    config = SimulationConfig(resolution=0.5, time=100e-15)
+    config = SimulationConfig(grid=UniformGrid(spacing=0.5), time=100e-15)
     volume = SimulationVolume(name="volume", partial_grid_shape=(100, 100, 100))
     obj = UniformMaterialObject(name="obj1", partial_grid_shape=(10, 10, 10), material=simple_material)
     obj_map = {"volume": volume, "obj1": obj}
@@ -904,6 +1042,7 @@ def test_apply_size_constraint_conflicting_shape_raises_descriptive(simple_confi
     obj = UniformMaterialObject(name="obj1", material=simple_material)
     obj_map = {"volume": simple_volume, "obj1": obj}
     shape_dict = {"volume": [100, 100, 100], "obj1": [60, None, None]}
+    slice_dict = {"volume": [[0, 100], [0, 100], [0, 100]], "obj1": [[0, 60], [None, None], [None, None]]}
     c = SizeConstraint(
         object="obj1",
         other_object="volume",
@@ -914,7 +1053,7 @@ def test_apply_size_constraint_conflicting_shape_raises_descriptive(simple_confi
         offsets=[None],
     )
     with pytest.raises(Exception, match="geometry"):
-        _apply_size_constraint(c, obj_map, simple_config, shape_dict)
+        _apply_size_constraint(c, obj_map, simple_config, shape_dict, slice_dict)
 
 
 # ---------------------------------------------------------------------------
@@ -1211,9 +1350,12 @@ def test_init_arrays_unknown_static_material_type_raises(mock_create_matrix):
 
     config = Mock(spec=SimulationConfig)
     config.dtype = jnp.float32
-    config.resolution = 1.0
+    config.uniform_spacing.return_value = 1.0
     config.backend = "cpu"
     config.gradient_config = None
+    config.grid = UniformGrid(spacing=1.0)
+    config.resolve_grid.return_value = RectilinearGrid.uniform(shape=(2, 2, 2), spacing=1.0)
+    config.uniform_spacing.return_value = 1.0
 
     objects = Mock(spec=ObjectContainer)
     objects.volume = Mock()
@@ -1252,7 +1394,7 @@ def test_resolve_constraints_with_partial_real_position(simple_material):
     - The conversion uses the simulation resolution correctly
     - Boundaries are computed from center position and size
     """
-    config = SimulationConfig(resolution=0.5, time=100e-15)
+    config = SimulationConfig(grid=UniformGrid(spacing=0.5), time=100e-15)
 
     volume = SimulationVolume(
         name="volume",
@@ -1367,7 +1509,7 @@ def test_resolve_constraints_partial_real_position_with_real_shape(simple_materi
     - Objects can be fully specified using only real-world coordinates
     - The conversion to grid coordinates is accurate for both position and size
     """
-    config = SimulationConfig(resolution=0.25, time=100e-15)
+    config = SimulationConfig(grid=UniformGrid(spacing=0.25), time=100e-15)
 
     volume = SimulationVolume(
         name="volume",
@@ -1527,7 +1669,7 @@ def test_resolve_constraints_partial_real_position_with_different_resolutions(si
     - Fine resolutions work properly with non-integer real positions
     """
     # Test with very fine resolution
-    config_fine = SimulationConfig(resolution=0.1, time=100e-15)
+    config_fine = SimulationConfig(grid=UniformGrid(spacing=0.1), time=100e-15)
 
     volume = SimulationVolume(
         name="volume",

--- a/tests/unit/fdtd/test_initialization.py
+++ b/tests/unit/fdtd/test_initialization.py
@@ -323,7 +323,7 @@ def test_nonuniform_partial_real_position_uses_physical_interval_center(simple_m
     obj = UniformMaterialObject(
         name="obj1",
         partial_grid_shape=(2, 2, 2),
-        partial_real_position=(3.6, 3.6, 3.6),
+        partial_real_position=(0.6, 0.6, 0.6),
         material=simple_material,
     )
 

--- a/tests/unit/fdtd/test_stop_conditions.py
+++ b/tests/unit/fdtd/test_stop_conditions.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.fdtd.container import ArrayContainer, FieldState
 from fdtdx.fdtd.stop_conditions import DetectorConvergenceCondition, EnergyThresholdCondition, TimeStepCondition
@@ -13,7 +14,7 @@ from fdtdx.fdtd.stop_conditions import DetectorConvergenceCondition, EnergyThres
 # ---------------------------------------------------------------------------
 
 # Config with ~525 time steps; time_step_duration ≈ 1.906e-12 s
-_CONFIG = SimulationConfig(time=100e-11, resolution=1e-3, courant_factor=0.99)
+_CONFIG = SimulationConfig(time=100e-11, grid=UniformGrid(spacing=1e-3), courant_factor=0.99)
 
 
 def _make_arrays(time_steps_total=None, detector_states=None):
@@ -196,7 +197,7 @@ class TestEnergyThresholdCondition:
 
 def _detector_config():
     """Config with ~525 steps; dt ≈ 1.906e-12 s."""
-    return SimulationConfig(time=100e-11, resolution=1e-3, courant_factor=0.99)
+    return SimulationConfig(time=100e-11, grid=UniformGrid(spacing=1e-3), courant_factor=0.99)
 
 
 def _detector_arrays(config, name="det", *, readings=None):

--- a/tests/unit/fdtd/test_update.py
+++ b/tests/unit/fdtd/test_update.py
@@ -7,11 +7,13 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.constants import eta0
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.fdtd.container import ArrayContainer, FieldState
 from fdtdx.fdtd.update import (
     add_interfaces,
     collect_interfaces,
     get_wrap_padding_axes,
+    pad_fields_for_boundaries,
     update_detector_states,
     update_E,
     update_E_reverse,
@@ -72,7 +74,7 @@ def _make_objects(sources=None):
 def _make_config(c=0.5):
     cfg = Mock()
     cfg.courant_number = c
-    cfg.resolution = 1.0
+    cfg.uniform_spacing.return_value = 1.0
     return cfg
 
 
@@ -150,6 +152,39 @@ class TestGetWrapPaddingAxes:
         obj = Mock()
         obj.boundary_objects = [wrap, other]
         assert get_wrap_padding_axes(obj) == (False, True, False)
+
+
+class TestPadFieldsForBoundaries:
+    """Tests for boundary padding and pad-correction dispatch."""
+
+    def test_nonuniform_grid_passes_compatibility_spacing_to_boundaries(self):
+        """Boundary padding should not require a scalar grid on stretched meshes."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 2.0]),
+            z_edges=jnp.asarray([0.0, 4.0]),
+        )
+        config = Mock()
+        config.grid = grid
+        config.has_nonuniform_grid = True
+        config.resolved_grid = grid
+        config.uniform_spacing.side_effect = AssertionError("uniform spacing should not be required")
+
+        boundary = Mock()
+        boundary.axis = 0
+        boundary.uses_wrap_padding = True
+        boundary.apply_pad_correction.side_effect = lambda padded, _shape, _spacing: padded
+
+        objects = Mock()
+        objects.boundary_objects = [boundary]
+        objects.volume.grid_shape = grid.shape
+
+        fields = jnp.ones((3, *grid.shape))
+        padded = pad_fields_for_boundaries(fields, objects, config)
+
+        assert padded.shape == (3, 4, 3, 3)
+        boundary.apply_pad_correction.assert_called_once()
+        assert boundary.apply_pad_correction.call_args.args[2] == pytest.approx(1.0)
 
 
 # ─── TestUpdateE ──────────────────────────────────────────────────────────────

--- a/tests/unit/objects/boundaries/test_bloch.py
+++ b/tests/unit/objects/boundaries/test_bloch.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.objects.boundaries.bloch import BlochBoundary
 
 
@@ -15,7 +16,7 @@ from fdtdx.objects.boundaries.bloch import BlochBoundary
 def micro_config():
     return SimulationConfig(
         time=100e-15,
-        resolution=50e-9,
+        grid=UniformGrid(spacing=50e-9),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,
@@ -125,7 +126,7 @@ class TestBlochGetBlochPhase:
         placed = place_bloch(bb, micro_config, jax_key, volume_shape=(10, 10, 10))
         phase = placed.get_bloch_phase(
             volume_shape=(10, 10, 10),
-            resolution=micro_config.resolution,
+            resolution=micro_config.uniform_spacing(),
         )
         assert jnp.abs(phase - 1.0) < 1e-6
 
@@ -135,7 +136,7 @@ class TestBlochGetBlochPhase:
         placed = place_bloch(bb, micro_config, jax_key, volume_shape=(10, 10, 10))
         phase = placed.get_bloch_phase(
             volume_shape=(10, 10, 10),
-            resolution=micro_config.resolution,
+            resolution=micro_config.uniform_spacing(),
         )
         assert jnp.issubdtype(phase.dtype, jnp.complexfloating)
 
@@ -145,7 +146,7 @@ class TestBlochGetBlochPhase:
         placed = place_bloch(bb, micro_config, jax_key, volume_shape=(20, 30, 20))
         phase = placed.get_bloch_phase(
             volume_shape=(20, 30, 20),
-            resolution=micro_config.resolution,
+            resolution=micro_config.uniform_spacing(),
         )
         assert jnp.abs(jnp.abs(phase) - 1.0) < 1e-6
 
@@ -154,7 +155,7 @@ class TestBlochGetBlochPhase:
         k = 1e7
         axis = 2
         Nz = 25
-        resolution = micro_config.resolution
+        resolution = micro_config.uniform_spacing()
         bb = make_bloch(axis=axis, direction="-", bloch_vector=(0.0, 0.0, k))
         # We can call get_bloch_phase without placing (it only uses bloch_vector and axis)
         phase = bb.get_bloch_phase(
@@ -164,10 +165,38 @@ class TestBlochGetBlochPhase:
         expected = jnp.exp(1j * k * Nz * resolution)
         assert jnp.abs(phase - expected) < 1e-6
 
+    def test_nonuniform_grid_uses_physical_axis_extent(self, jax_key):
+        """Bloch phase uses edge extent instead of shape times scalar resolution."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 1.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        k = 0.25
+        bb = make_bloch(axis=0, direction="-", bloch_vector=(k, 0.0, 0.0))
+        placed = place_bloch(bb, config, jax_key, volume_shape=grid.shape)
+
+        phase = placed.get_bloch_phase(volume_shape=grid.shape, resolution=1.0)
+
+        assert jnp.allclose(phase, jnp.exp(1j * k * 3.0))
+
+    def test_uniform_rectilinear_grid_phase_is_jittable(self, jax_key):
+        """Concrete RectilinearGrid phase lookup must not force Python floats inside JAX traces."""
+        grid = RectilinearGrid.uniform(shape=(4, 4, 4), spacing=0.5)
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        k = 0.25
+        bb = make_bloch(axis=0, direction="-", bloch_vector=(k, 0.0, 0.0))
+        placed = place_bloch(bb, config, jax_key, volume_shape=grid.shape)
+
+        phase = jax.jit(lambda: placed.get_bloch_phase(volume_shape=grid.shape, resolution=1.0))()
+
+        assert jnp.allclose(phase, jnp.exp(1j * k * 2.0))
+
     def test_uses_correct_axis_component(self, micro_config):
         """Only the k component for this boundary's axis affects the phase."""
         k_x, k_y, k_z = 1e6, 2e6, 3e6
-        resolution = micro_config.resolution
+        resolution = micro_config.uniform_spacing()
         volume_shape = (10, 20, 30)
 
         for axis, k_axis in enumerate([k_x, k_y, k_z]):

--- a/tests/unit/objects/boundaries/test_boundary.py
+++ b/tests/unit/objects/boundaries/test_boundary.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.objects.boundaries.perfectly_matched_layer import PerfectlyMatchedLayer
 
 
@@ -16,7 +17,7 @@ from fdtdx.objects.boundaries.perfectly_matched_layer import PerfectlyMatchedLay
 def micro_config():
     return SimulationConfig(
         time=100e-15,
-        resolution=50e-9,
+        grid=UniformGrid(spacing=50e-9),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,

--- a/tests/unit/objects/boundaries/test_pec.py
+++ b/tests/unit/objects/boundaries/test_pec.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.objects.boundaries.pec import PerfectElectricConductor
 
 
@@ -15,7 +16,7 @@ from fdtdx.objects.boundaries.pec import PerfectElectricConductor
 def micro_config():
     return SimulationConfig(
         time=100e-15,
-        resolution=50e-9,
+        grid=UniformGrid(spacing=50e-9),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,

--- a/tests/unit/objects/boundaries/test_perfectly_matched_layer.py
+++ b/tests/unit/objects/boundaries/test_perfectly_matched_layer.py
@@ -8,6 +8,8 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.constants import eta0
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.objects.boundaries.perfectly_matched_layer import PerfectlyMatchedLayer
 
 
@@ -15,7 +17,7 @@ from fdtdx.objects.boundaries.perfectly_matched_layer import PerfectlyMatchedLay
 def micro_config():
     return SimulationConfig(
         time=100e-15,
-        resolution=50e-9,
+        grid=UniformGrid(spacing=50e-9),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,
@@ -237,6 +239,36 @@ class TestPMLComputeProfile:
         placed = place_pml(pml, micro_config, jax_key, volume_shape=(10, 10, 20))
         profileE, _profileH = placed._compute_pml_profile(0.0, 1.0, 1.0, jnp.float32)
         assert profileE.shape == (10, 10, 5)
+
+    def test_nonuniform_profile_uses_physical_depth_min_side(self, jax_key):
+        """Stretched PML profiles are graded by physical distance into the boundary."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0, 10.0]),
+            y_edges=jnp.asarray([0.0, 1.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=100e-15, grid=grid, backend="cpu", dtype=jnp.float32)
+        pml = make_pml(axis=0, direction="-", thickness=3, sigma_end=1.0)
+        placed = place_pml(pml, config, jax_key, volume_shape=grid.shape)
+
+        profileE, profileH = placed._compute_pml_profile(0.0, 1.0, 1.0, jnp.float32)
+
+        assert jnp.allclose(profileE[:, 0, 0], jnp.asarray([5 / 6, 3 / 6, 0.0], dtype=jnp.float32))
+        assert float(profileH[-1, 0, 0]) == 0.0
+
+    def test_nonuniform_sigma_end_uses_physical_thickness(self, jax_key):
+        """Default sigma_end is based on physical PML thickness from grid edges."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+            y_edges=jnp.asarray([0.0, 1.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=100e-15, grid=grid, backend="cpu", dtype=jnp.float32)
+        pml = make_pml(axis=0, direction="-", thickness=2)
+        placed = place_pml(pml, config, jax_key, volume_shape=grid.shape)
+
+        expected = -(placed.sigma_order + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * 3.0)
+        assert jnp.isclose(placed.sigma_end, expected)
 
 
 class TestPMLModifyArrays:

--- a/tests/unit/objects/boundaries/test_periodic.py
+++ b/tests/unit/objects/boundaries/test_periodic.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.objects.boundaries.bloch import BlochBoundary
 
 
@@ -16,7 +17,7 @@ from fdtdx.objects.boundaries.bloch import BlochBoundary
 def micro_config():
     return SimulationConfig(
         time=100e-15,
-        resolution=50e-9,
+        grid=UniformGrid(spacing=50e-9),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,

--- a/tests/unit/objects/boundaries/test_pmc.py
+++ b/tests/unit/objects/boundaries/test_pmc.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.objects.boundaries.pmc import PerfectMagneticConductor
 
 
@@ -15,7 +16,7 @@ from fdtdx.objects.boundaries.pmc import PerfectMagneticConductor
 def micro_config():
     return SimulationConfig(
         time=100e-15,
-        resolution=50e-9,
+        grid=UniformGrid(spacing=50e-9),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,

--- a/tests/unit/objects/detectors/conftest.py
+++ b/tests/unit/objects/detectors/conftest.py
@@ -5,14 +5,15 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 
 
 @pytest.fixture
 def simulation_config():
     """Create a minimal SimulationConfig for testing."""
     return SimulationConfig(
-        time=1e-12,  # 1 picosecond
-        resolution=1e-7,  # 100 nm
+        time=1e-12,
+        grid=UniformGrid(spacing=1e-7),
         backend="cpu",
     )
 

--- a/tests/unit/objects/detectors/test_detector.py
+++ b/tests/unit/objects/detectors/test_detector.py
@@ -8,6 +8,8 @@ import numpy as np
 import pytest
 from matplotlib.figure import Figure
 
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.objects.detectors.energy import EnergyDetector
 from fdtdx.objects.detectors.field import FieldDetector
@@ -82,6 +84,24 @@ class TestDrawPlotLinePlots:
         assert isinstance(figs["fields"], Figure)
         plt.close(figs["fields"])
 
+    def test_1d_single_timestep_nonuniform_uses_cell_centers(self, random_key, single_switch):
+        """Non-uniform spatial line plots use physical cell centers in micrometres."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0e-6, 4.0e-6, 10.0e-6]),
+            y_edges=jnp.asarray([0.0, 1.0e-6]),
+            z_edges=jnp.asarray([0.0, 1.0e-6]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        detector = FieldDetector(components=("Ex",), switch=single_switch)
+        detector = detector.place_on_grid(((0, 3), (0, 1), (0, 1)), config, random_key)
+        state_np = {"fields": np.asarray([1.0, 2.0, 3.0])}
+
+        figs = detector.draw_plot(state_np)
+
+        xdata = figs["fields"].axes[0].lines[0].get_xdata()
+        assert np.allclose(xdata, np.asarray([0.5, 2.5, 7.0]))
+        plt.close(figs["fields"])
+
 
 class TestDrawPlotWaterfallAndSlices:
     """Tests for draw_plot → 2D data branches."""
@@ -111,6 +131,27 @@ class TestDrawPlotWaterfallAndSlices:
 
         assert "sliced_plot" in figs
         assert isinstance(figs["sliced_plot"], Figure)
+        plt.close(figs["sliced_plot"])
+
+    def test_2d_single_timestep_nonuniform_slices_plot(self, random_key, single_switch):
+        """Non-uniform slice plots use rectilinear physical extents."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0e-6, 4.0e-6]),
+            y_edges=jnp.asarray([0.0, 2.0e-6, 5.0e-6]),
+            z_edges=jnp.asarray([0.0, 3.0e-6, 7.0e-6]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        detector = EnergyDetector(as_slices=True, switch=single_switch)
+        detector = detector.place_on_grid(((0, 2), (0, 2), (0, 2)), config, random_key)
+        state = detector.init_state()
+        state_np = {k: np.asarray(v) for k, v in state.items()}
+
+        figs = detector.draw_plot(state_np)
+
+        assert "sliced_plot" in figs
+        assert isinstance(figs["sliced_plot"], Figure)
+        assert figs["sliced_plot"].axes[0].get_xlim() == pytest.approx((0.0, 4.0))
+        assert figs["sliced_plot"].axes[0].get_ylim() == pytest.approx((0.0, 5.0))
         plt.close(figs["sliced_plot"])
 
     def test_2d_single_timestep_wrong_keys_raises(self, simulation_config, small_grid_slice, random_key, single_switch):
@@ -191,6 +232,25 @@ class TestDrawPlot4D:
 
 class TestDrawPlotErrors:
     """Tests for draw_plot error cases."""
+
+    def test_nonuniform_scalar_time_series_still_plots(self, random_key, small_switch):
+        """Reduced scalar plots do not need spatial axes on non-uniform grids."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+            y_edges=jnp.asarray([0.0, 1.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        detector = PoyntingFluxDetector(direction="+", switch=small_switch)
+        detector = detector.place_on_grid(((0, 3), (0, 1), (0, 1)), config, random_key)
+        state = detector.init_state()
+        state_np = {k: np.asarray(v) for k, v in state.items()}
+
+        figs = detector.draw_plot(state_np)
+
+        assert "poynting_flux" in figs
+        assert isinstance(figs["poynting_flux"], Figure)
+        plt.close(figs["poynting_flux"])
 
     def test_empty_state_raises(self, simulation_config, plane_grid_slice, random_key, small_switch):
         """Empty state dict raises with 'empty state' message."""

--- a/tests/unit/objects/detectors/test_detector.py
+++ b/tests/unit/objects/detectors/test_detector.py
@@ -91,7 +91,7 @@ class TestDrawPlotLinePlots:
             y_edges=jnp.asarray([0.0, 1.0e-6]),
             z_edges=jnp.asarray([0.0, 1.0e-6]),
         )
-        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        config = SimulationConfig(time=1e-13, grid=grid, backend="cpu")
         detector = FieldDetector(components=("Ex",), switch=single_switch)
         detector = detector.place_on_grid(((0, 3), (0, 1), (0, 1)), config, random_key)
         state_np = {"fields": np.asarray([1.0, 2.0, 3.0])}
@@ -140,7 +140,7 @@ class TestDrawPlotWaterfallAndSlices:
             y_edges=jnp.asarray([0.0, 2.0e-6, 5.0e-6]),
             z_edges=jnp.asarray([0.0, 3.0e-6, 7.0e-6]),
         )
-        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        config = SimulationConfig(time=1e-13, grid=grid, backend="cpu")
         detector = EnergyDetector(as_slices=True, switch=single_switch)
         detector = detector.place_on_grid(((0, 2), (0, 2), (0, 2)), config, random_key)
         state = detector.init_state()

--- a/tests/unit/objects/detectors/test_diffractive.py
+++ b/tests/unit/objects/detectors/test_diffractive.py
@@ -3,6 +3,8 @@
 import jax.numpy as jnp
 import pytest
 
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.objects.detectors.diffractive import DiffractiveDetector
 
 
@@ -220,6 +222,44 @@ class TestDiffractiveDetectorUpdate:
         )
 
         assert jnp.allclose(jnp.abs(new_state["diffractive"]), 0.0)
+
+    def test_update_resamples_nonuniform_grid(self, random_key):
+        """Nonuniform transverse samples are resampled before FFT order analysis."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 2.0, 5.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        det = DiffractiveDetector(frequencies=[3e14], direction="+")
+        det = det.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
+        state = det.init_state()
+        E = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32).at[0].set(1.0)
+        H = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32).at[1].set(1.0)
+
+        new_state = det.update(jnp.array(0), E, H, state, jnp.ones((1, 2, 2, 1)), 1.0)
+
+        assert new_state["diffractive"].shape == (1, 1, 1)
+        assert jnp.any(jnp.abs(new_state["diffractive"]) > 0)
+
+    def test_nonuniform_resample_preserves_constant_field_zeroth_order(self, random_key):
+        """A constant field remains constant through the nonuniform resampling path."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 4.0, 10.0]),
+            y_edges=jnp.asarray([0.0, 2.0, 3.0, 9.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        det = DiffractiveDetector(frequencies=[3e14], direction="+")
+        det = det.place_on_grid(((0, 3), (0, 3), (0, 1)), config, random_key)
+        state = det.init_state()
+        E = jnp.zeros((3, 3, 3, 1), dtype=jnp.float32).at[0].set(1.0)
+        H = jnp.zeros((3, 3, 3, 1), dtype=jnp.float32).at[1].set(1.0)
+
+        new_state = det.update(jnp.array(0), E, H, state, jnp.ones((1, 3, 3, 1)), 1.0)
+
+        assert jnp.isfinite(new_state["diffractive"]).all()
+        assert jnp.abs(new_state["diffractive"][0, 0, 0]) > 0
 
     def test_update_preserves_shape(
         self,

--- a/tests/unit/objects/detectors/test_energy.py
+++ b/tests/unit/objects/detectors/test_energy.py
@@ -3,6 +3,8 @@
 import jax.numpy as jnp
 import pytest
 
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.objects.detectors.energy import EnergyDetector
 
 
@@ -204,6 +206,90 @@ class TestEnergyDetectorUpdate:
 
         # Higher E field should give higher energy
         assert state["energy"][1, 0] > state["energy"][0, 0]
+
+    def test_reduce_volume_integrates_nonuniform_cell_volume(self, random_key):
+        """A constant energy density integrates to density times physical volume."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 3.0, 7.0]),
+            z_edges=jnp.asarray([0.0, 2.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        detector = EnergyDetector(reduce_volume=True)
+        detector = detector.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
+        state = detector.init_state()
+
+        E = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32).at[0].set(1.0)
+        H = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32)
+        inv_permittivity = jnp.ones((3, 2, 2, 1), dtype=jnp.float32)
+
+        new_state = detector.update(jnp.array(0), E, H, state, inv_permittivity, 1.0)
+
+        assert jnp.allclose(new_state["energy"][0], jnp.asarray([21.0], dtype=jnp.float32))
+
+    def test_cell_volume_weights_are_cached(self, random_key):
+        """Detector volume weights are placement metrics and should be reused."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 3.0, 7.0]),
+            z_edges=jnp.asarray([0.0, 2.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        detector = EnergyDetector(reduce_volume=True)
+        detector = detector.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
+
+        assert detector._cell_volume_weights() is detector._cell_volume_weights()
+
+    def test_reduce_volume_uses_cell_volume_on_uniform_grid(self, random_key):
+        """Reduced energy is a physical volume integral on uniform grids."""
+        spacing = 2e-7
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, spacing, 2 * spacing]),
+            y_edges=jnp.asarray([0.0, spacing, 2 * spacing]),
+            z_edges=jnp.asarray([0.0, spacing]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        E = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32).at[0].set(1.0)
+        H = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32)
+        inv_permittivity = jnp.ones((3, 2, 2, 1), dtype=jnp.float32)
+
+        detector = EnergyDetector(reduce_volume=True)
+        detector = detector.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
+        state = detector.init_state()
+
+        new_state = detector.update(jnp.array(0), E, H, state, inv_permittivity, 1.0)
+
+        assert jnp.allclose(new_state["energy"][0], jnp.asarray([2 * spacing**3], dtype=jnp.float32))
+
+    def test_as_slices_uses_nonuniform_cell_centers_for_positions(self, random_key):
+        """Explicit slice positions are selected by physical cell centers."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 4.0]),
+            y_edges=jnp.asarray([0.0, 2.0, 5.0]),
+            z_edges=jnp.asarray([0.0, 1.0, 7.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        detector = EnergyDetector(as_slices=True, x_slice=2.4, y_slice=0.9, z_slice=4.1)
+        detector = detector.place_on_grid(((0, 2), (0, 2), (0, 2)), config, random_key)
+        state = detector.init_state()
+
+        values = jnp.asarray(
+            [
+                [[1.0, 2.0], [3.0, 4.0]],
+                [[5.0, 6.0], [7.0, 8.0]],
+            ],
+            dtype=jnp.float32,
+        )
+        E = jnp.zeros((3, 2, 2, 2), dtype=jnp.float32).at[0].set(values)
+        H = jnp.zeros((3, 2, 2, 2), dtype=jnp.float32)
+        inv_permittivity = jnp.ones((3, 2, 2, 2), dtype=jnp.float32)
+        energy = 0.5 * values**2
+
+        new_state = detector.update(jnp.array(0), E, H, state, inv_permittivity, 1.0)
+
+        assert jnp.allclose(new_state["XY Plane"][0], energy[:, :, 1])
+        assert jnp.allclose(new_state["XZ Plane"][0], energy[:, 0, :])
+        assert jnp.allclose(new_state["YZ Plane"][0], energy[1, :, :])
 
 
 class TestEnergyDetectorConfiguration:

--- a/tests/unit/objects/detectors/test_energy.py
+++ b/tests/unit/objects/detectors/test_energy.py
@@ -248,7 +248,7 @@ class TestEnergyDetectorUpdate:
             y_edges=jnp.asarray([0.0, spacing, 2 * spacing]),
             z_edges=jnp.asarray([0.0, spacing]),
         )
-        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        config = SimulationConfig(time=1e-13, grid=grid, backend="cpu")
         E = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32).at[0].set(1.0)
         H = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32)
         inv_permittivity = jnp.ones((3, 2, 2, 1), dtype=jnp.float32)

--- a/tests/unit/objects/detectors/test_field.py
+++ b/tests/unit/objects/detectors/test_field.py
@@ -2,6 +2,8 @@
 
 import jax.numpy as jnp
 
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.objects.detectors.field import FieldDetector
 
 
@@ -170,6 +172,27 @@ class TestFieldDetectorUpdate:
 
         assert jnp.isclose(state["fields"][0, 0], 1.0)  # t=0
         assert jnp.isclose(state["fields"][1, 0], 2.0)  # t=1
+
+    def test_reduce_volume_uses_nonuniform_volume_weighted_mean(self, random_key):
+        """Reduced fields report a physical volume average on stretched grids."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 3.0, 7.0]),
+            z_edges=jnp.asarray([0.0, 2.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        detector = FieldDetector(reduce_volume=True, components=("Ex",))
+        detector = detector.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
+        state = detector.init_state()
+
+        E = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32)
+        E = E.at[0, :, :, 0].set(jnp.asarray([[1.0, 2.0], [3.0, 4.0]], dtype=jnp.float32))
+        H = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32)
+
+        new_state = detector.update(jnp.array(0), E, H, state, jnp.ones((1, 2, 2, 1)), 1.0)
+
+        expected = (1 * 6 + 2 * 8 + 3 * 12 + 4 * 16) / 42
+        assert jnp.allclose(new_state["fields"][0, 0], jnp.asarray(expected, dtype=jnp.float32))
 
     def test_update_with_sinusoidal_field(
         self,

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -1,8 +1,12 @@
 """Tests for objects/detectors/mode.py - ModeOverlapDetector."""
 
+from unittest.mock import patch
+
 import jax.numpy as jnp
 import pytest
 
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.detectors.mode import ModeOverlapDetector
 
@@ -321,11 +325,71 @@ class TestModeOverlapDetectorComputeOverlap:
         phasors_H = phasors[0, 0, 3:]
         E_cross_H = jnp.cross(mode_E, jnp.conj(phasors_H), axis=0)[det.propagation_axis]
         E_cross_H_back = jnp.cross(jnp.conj(phasors_E), mode_H, axis=0)[det.propagation_axis]
-        expected = jnp.sum(E_cross_H + E_cross_H_back) / 4.0
+        expected = jnp.sum((E_cross_H + E_cross_H_back) * det._face_area_weights()) / 4.0
 
         overlap = det.compute_overlap_to_mode(state=state, mode_E=mode_E, mode_H=mode_H)
 
         assert jnp.isclose(overlap, expected)
+
+    def test_compute_overlap_integrates_nonuniform_face_area(self, random_key, single_frequency):
+        """A constant overlap integrand integrates to the detector face area."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 3.0, 7.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
+        det = det.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
+
+        state = det.init_state()
+        phasor = jnp.zeros_like(state["phasor"]).at[0, 0, 4].set(1.0)
+        state = {"phasor": phasor}
+        mode_E = jnp.zeros((3, 2, 2, 1), dtype=jnp.complex64).at[0].set(1.0)
+        mode_H = jnp.zeros((3, 2, 2, 1), dtype=jnp.complex64)
+
+        overlap = det.compute_overlap_to_mode(state=state, mode_E=mode_E, mode_H=mode_H)
+
+        assert jnp.allclose(overlap, jnp.asarray(21.0 / 4.0, dtype=jnp.complex64))
+
+    def test_transverse_edge_coordinates_follow_detector_slice(self, random_key, single_frequency):
+        """Mode solving receives the physical edge arrays for the transverse detector axes."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 3.0, 7.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
+        det = det.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
+
+        x_edges, y_edges = det._transverse_edge_coordinates()
+
+        assert jnp.allclose(x_edges, jnp.asarray([0.0, 1.0, 3.0]))
+        assert jnp.allclose(y_edges, jnp.asarray([0.0, 3.0, 7.0]))
+
+    @patch("fdtdx.objects.detectors.mode.compute_mode")
+    def test_apply_passes_nonuniform_mode_coordinates(self, mock_compute_mode, random_key, single_frequency):
+        """Mode detector apply should not require a scalar grid spacing on stretched grids."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 3.0, 7.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        mock_compute_mode.return_value = (
+            jnp.ones((3, 2, 2, 1), dtype=jnp.complex64),
+            jnp.ones((3, 2, 2, 1), dtype=jnp.complex64),
+            jnp.asarray(1.5 + 0j, dtype=jnp.complex64),
+        )
+        det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
+        det = det.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
+
+        det.apply(random_key, jnp.ones((1, 2, 2, 1), dtype=jnp.float32), 1.0)
+
+        kwargs = mock_compute_mode.call_args.kwargs
+        assert kwargs["resolution"] == grid.min_spacing
+        assert kwargs["transverse_coords"] is not None
 
 
 class TestModeOverlapDetectorComputeOverlapPath:

--- a/tests/unit/objects/detectors/test_phasor.py
+++ b/tests/unit/objects/detectors/test_phasor.py
@@ -3,6 +3,8 @@
 import jax.numpy as jnp
 import pytest
 
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.detectors.phasor import PhasorDetector
 
@@ -231,6 +233,28 @@ class TestPhasorDetectorUpdate:
 
         # Should be reduced to (1, 1, 6) - 1 latent step, 1 freq, 6 components
         assert new_state["phasor"].shape == (1, 1, 6)
+
+    def test_reduce_volume_uses_nonuniform_volume_weighted_mean(self, random_key, single_frequency):
+        """Reduced phasors average spatial samples by physical cell volume."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 3.0, 7.0]),
+            z_edges=jnp.asarray([0.0, 2.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        detector = PhasorDetector(wave_characters=single_frequency, reduce_volume=True, components=("Ex",))
+        detector = detector.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
+        state = detector.init_state()
+
+        E = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32)
+        E = E.at[0, :, :, 0].set(jnp.asarray([[1.0, 2.0], [3.0, 4.0]], dtype=jnp.float32))
+        H = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32)
+
+        new_state = detector.update(jnp.array(0), E, H, state, jnp.ones((1, 2, 2, 1)), 1.0)
+
+        static_scale = 2 / detector.num_time_steps_recorded
+        expected = static_scale * (1 * 6 + 2 * 8 + 3 * 12 + 4 * 16) / 42
+        assert jnp.allclose(new_state["phasor"][0, 0, 0], jnp.asarray(expected, dtype=jnp.complex64))
 
     def test_update_multiple_frequencies(
         self,

--- a/tests/unit/objects/detectors/test_poynting_flux.py
+++ b/tests/unit/objects/detectors/test_poynting_flux.py
@@ -3,6 +3,8 @@
 import jax.numpy as jnp
 import pytest
 
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.objects.detectors.poynting_flux import PoyntingFluxDetector
 
 
@@ -266,8 +268,60 @@ class TestPoyntingFluxDetectorUpdate:
         # Flux values should be finite
         assert jnp.all(jnp.isfinite(flux_after_step0))
         assert jnp.all(jnp.isfinite(flux_after_step1))
-        # Doubled E and H should produce different (larger) flux than unit fields
-        assert not jnp.allclose(flux_after_step0, flux_after_step1)
+        # Doubled E and H should produce 4x the flux at the second recorded time step.
+        assert flux_after_step1[1, 0] > flux_after_step0[0, 0]
+
+    def test_reduce_volume_integrates_nonuniform_face_area(self, random_key):
+        """A constant flux density integrates to the physical detector area."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 3.0, 7.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        detector = PoyntingFluxDetector(direction="+", reduce_volume=True)
+        detector = detector.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
+        state = detector.init_state()
+
+        E = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32).at[0].set(1.0)
+        H = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32).at[1].set(1.0)
+
+        new_state = detector.update(jnp.array(0), E, H, state, jnp.ones((1, 2, 2, 1)), 1.0)
+
+        assert jnp.allclose(new_state["poynting_flux"][0], jnp.asarray([21.0], dtype=jnp.float32))
+
+    def test_face_area_weights_are_cached(self, random_key):
+        """Detector face-area weights are placement metrics and should be reused."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 3.0, 7.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        detector = PoyntingFluxDetector(direction="+", reduce_volume=True)
+        detector = detector.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
+
+        assert detector._face_area_weights() is detector._face_area_weights()
+
+    def test_reduce_volume_uses_face_area_on_uniform_grid(self, random_key):
+        """Reduced flux is a physical surface integral on uniform grids."""
+        spacing = 2e-7
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, spacing, 2 * spacing]),
+            y_edges=jnp.asarray([0.0, spacing, 2 * spacing]),
+            z_edges=jnp.asarray([0.0, spacing]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        E = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32).at[0].set(1.0)
+        H = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32).at[1].set(1.0)
+
+        detector = PoyntingFluxDetector(direction="+", reduce_volume=True)
+        detector = detector.place_on_grid(((0, 2), (0, 2), (0, 1)), config, random_key)
+        state = detector.init_state()
+
+        new_state = detector.update(jnp.array(0), E, H, state, jnp.ones((1, 2, 2, 1)), 1.0)
+
+        assert jnp.allclose(new_state["poynting_flux"][0], jnp.asarray([4 * spacing**2], dtype=jnp.float32))
 
 
 class TestPoyntingFluxDetectorConfiguration:

--- a/tests/unit/objects/detectors/test_poynting_flux.py
+++ b/tests/unit/objects/detectors/test_poynting_flux.py
@@ -311,7 +311,7 @@ class TestPoyntingFluxDetectorUpdate:
             y_edges=jnp.asarray([0.0, spacing, 2 * spacing]),
             z_edges=jnp.asarray([0.0, spacing]),
         )
-        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        config = SimulationConfig(time=1e-13, grid=grid, backend="cpu")
         E = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32).at[0].set(1.0)
         H = jnp.zeros((3, 2, 2, 1), dtype=jnp.float32).at[1].set(1.0)
 

--- a/tests/unit/objects/device/parameters/test_discrete.py
+++ b/tests/unit/objects/device/parameters/test_discrete.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.core.misc import PaddingConfig
 from fdtdx.materials import Material
 from fdtdx.objects.device.parameters.discrete import (
@@ -40,7 +41,7 @@ def dummy_config():
     """Minimal simulation config."""
     return SimulationConfig(
         time=100e-15,
-        resolution=500e-9,
+        grid=UniformGrid(spacing=500e-9),
         backend="cpu",
     )
 

--- a/tests/unit/objects/device/parameters/test_discretization.py
+++ b/tests/unit/objects/device/parameters/test_discretization.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.materials import Material
 from fdtdx.objects.device.parameters.discretization import (
     BrushConstraint2D,
@@ -92,7 +93,7 @@ class TestClosestIndex:
         """Minimal simulation config."""
         return SimulationConfig(
             time=100e-15,
-            resolution=500e-9,
+            grid=UniformGrid(spacing=500e-9),
             backend="cpu",
         )
 
@@ -200,7 +201,7 @@ class TestBrushConstraint2D:
         """Minimal simulation config."""
         return SimulationConfig(
             time=100e-15,
-            resolution=500e-9,
+            grid=UniformGrid(spacing=500e-9),
             backend="cpu",
         )
 
@@ -328,7 +329,7 @@ class TestPillarDiscretization:
         """Minimal simulation config."""
         return SimulationConfig(
             time=100e-15,
-            resolution=500e-9,
+            grid=UniformGrid(spacing=500e-9),
             backend="cpu",
         )
 

--- a/tests/unit/objects/device/parameters/test_projection.py
+++ b/tests/unit/objects/device/parameters/test_projection.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.materials import Material
 from fdtdx.objects.device.parameters.projection import (
     SubpixelSmoothedProjection,
@@ -203,7 +204,7 @@ class TestTanhProjectionClass:
         """Minimal simulation config."""
         return SimulationConfig(
             time=100e-15,
-            resolution=500e-9,
+            grid=UniformGrid(spacing=500e-9),
             backend="cpu",
         )
 
@@ -297,7 +298,7 @@ class TestSubpixelSmoothedProjectionClass:
         """Minimal simulation config."""
         return SimulationConfig(
             time=100e-15,
-            resolution=500e-9,
+            grid=UniformGrid(spacing=500e-9),
             backend="cpu",
         )
 

--- a/tests/unit/objects/device/test_device.py
+++ b/tests/unit/objects/device/test_device.py
@@ -10,6 +10,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.core.jax.pytrees import autoinit
 from fdtdx.materials import Material
 from fdtdx.objects.device.device import Device
@@ -35,7 +36,7 @@ class _ConcreteDevice(Device):
 def config():
     return SimulationConfig(
         time=100e-15,
-        resolution=50e-9,
+        grid=UniformGrid(spacing=50e-9),
         backend="cpu",
         dtype=jnp.float32,
         gradient_config=None,
@@ -132,7 +133,7 @@ class TestPlaceOnGrid:
     def test_single_voxel_real_shape(self, config, key, two_materials):
         device = _make_device(two_materials, voxel_grid=(2, 2, 2))
         placed = _place_device(device, config, key)
-        res = config.resolution
+        res = config.uniform_spacing()
         assert placed.single_voxel_real_shape == pytest.approx((2 * res, 2 * res, 2 * res))
 
     def test_voxel_size_from_real_shape(self, config, key, two_materials):
@@ -144,6 +145,40 @@ class TestPlaceOnGrid:
         )
         placed = _place_device(device, config, key, ((0, 10), (0, 10), (0, 10)))
         assert placed.single_voxel_grid_shape == (2, 2, 2)
+
+    def test_nonuniform_grid_index_voxels_place(self, key, two_materials):
+        """Cell-count design voxels can be placed on non-uniform grids."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 2.0, 5.0]),
+            z_edges=jnp.asarray([0.0, 4.0, 9.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        device = _make_device(two_materials, voxel_grid=(1, 1, 1))
+
+        placed = _place_device(device, config, key, ((0, 2), (0, 2), (0, 2)))
+
+        assert placed.single_voxel_grid_shape == (1, 1, 1)
+        assert placed.matrix_voxel_grid_shape == (2, 2, 2)
+        assert placed.single_voxel_real_shape == pytest.approx((1.5, 2.5, 4.5))
+
+    def test_nonuniform_physical_and_grid_voxels_cannot_mix(self, key, two_materials):
+        """Mixed physical/index design voxel specs are ambiguous on stretched grids."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 2.0, 5.0]),
+            z_edges=jnp.asarray([0.0, 4.0, 9.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        device = _ConcreteDevice(
+            materials=two_materials,
+            param_transforms=[],
+            partial_voxel_grid_shape=(1, None, None),
+            partial_voxel_real_shape=(None, 2.5, 9.0),
+        )
+
+        with pytest.raises(ValueError, match="cannot be mixed"):
+            _place_device(device, config, key, ((0, 2), (0, 2), (0, 2)))
 
     def test_overspecified_voxel_raises(self, config, key, two_materials):
         """Providing both grid and real shape for the same axis should raise."""

--- a/tests/unit/objects/sources/test_dipole.py
+++ b/tests/unit/objects/sources/test_dipole.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.sources.dipole import PointDipoleSource
 
@@ -19,7 +20,7 @@ def micro_config():
     """Minimal simulation config for source testing."""
     return SimulationConfig(
         time=100e-15,
-        resolution=100e-9,
+        grid=UniformGrid(spacing=100e-9),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,

--- a/tests/unit/objects/sources/test_linear_polarization.py
+++ b/tests/unit/objects/sources/test_linear_polarization.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.sources.linear_polarization import (
     GaussianPlaneSource,
@@ -23,7 +24,7 @@ def micro_config():
     """Minimal simulation config for source testing."""
     return SimulationConfig(
         time=100e-15,
-        resolution=100e-9,
+        grid=UniformGrid(spacing=100e-9),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,
@@ -211,6 +212,58 @@ class TestGaussianPlaneSource:
         assert placed.horizontal_axis == 0
         assert placed.vertical_axis == 1
 
+    def test_nonuniform_grid_apply_uses_physical_gaussian_profile(self, jax_key):
+        """Normal-incidence Gaussian sources sample profiles on rectilinear cell centers."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 2.0, 5.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        source = GaussianPlaneSource(
+            partial_grid_shape=(2, 2, 1),
+            wave_character=WaveCharacter(wavelength=1.55e-6),
+            direction="-",
+            radius=3.0,
+            normalize_by_energy=False,
+            fixed_E_polarization_vector=(1, 0, 0),
+        )
+        placed = source.place_on_grid(((0, 2), (0, 2), (0, 1)), config, jax_key)
+
+        applied = placed.apply(jax_key, jnp.ones((1, 2, 2, 1)), 1.0)
+
+        assert applied._E.shape == (3, 2, 2, 1)
+        assert applied._H.shape == (3, 2, 2, 1)
+        assert applied._time_offset_E.shape == (3, 2, 2, 1)
+        assert jnp.isclose(jnp.linalg.norm(applied._E), jnp.linalg.norm(applied._H))
+
+    def test_nonuniform_tilted_apply_uses_physical_projection(self, jax_key):
+        """Tilted non-uniform plane sources project profiles in physical coordinates."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+            y_edges=jnp.asarray([0.0, 1.0, 2.0, 4.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        source = GaussianPlaneSource(
+            partial_grid_shape=(3, 3, 1),
+            wave_character=WaveCharacter(wavelength=1.55e-6),
+            direction="-",
+            radius=3.0,
+            azimuth_angle=15.0,
+            elevation_angle=5.0,
+            normalize_by_energy=False,
+            fixed_E_polarization_vector=(1, 0, 0),
+        )
+        placed = source.place_on_grid(((0, 3), (0, 3), (0, 1)), config, jax_key)
+
+        applied = placed.apply(jax_key, jnp.ones((1, 3, 3, 1)), 1.0)
+
+        assert applied._E.shape == (3, 3, 3, 1)
+        assert applied._H.shape == (3, 3, 3, 1)
+        assert applied._time_offset_E.shape == (3, 3, 3, 1)
+        assert jnp.any(applied._E[1] != 0) or jnp.any(applied._E[2] != 0)
+
 
 class TestUniformPlaneSource:
     """Unit tests for UniformPlaneSource."""
@@ -277,6 +330,55 @@ class TestUniformPlaneSource:
             direction="-",
         )
         assert source.direction == "-"
+
+    def test_apply_uniform_source_on_nonuniform_grid(self, jax_key):
+        """Normal-incidence uniform plane sources can use rectilinear Yee offsets."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 2.0, 5.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        source = UniformPlaneSource(
+            partial_grid_shape=(2, 2, 1),
+            wave_character=WaveCharacter(wavelength=1.55e-6),
+            direction="-",
+            normalize_by_energy=False,
+            fixed_E_polarization_vector=(1, 0, 0),
+        )
+        placed = source.place_on_grid(((0, 2), (0, 2), (0, 1)), config, jax_key)
+
+        applied = placed.apply(jax_key, jnp.ones((1, 2, 2, 1)), 1.0)
+
+        assert applied._E.shape == (3, 2, 2, 1)
+        assert applied._H.shape == (3, 2, 2, 1)
+        assert applied._time_offset_E.shape == (3, 2, 2, 1)
+
+    def test_nonuniform_tilted_uniform_source_preserves_constant_profile(self, jax_key):
+        """Physical tilted projection must not distort a constant source profile."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 0.4, 1.1, 2.0]),
+            y_edges=jnp.asarray([0.0, 0.6, 1.0, 2.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        source = UniformPlaneSource(
+            partial_grid_shape=(3, 3, 1),
+            wave_character=WaveCharacter(wavelength=1.55e-6),
+            direction="-",
+            amplitude=2.0,
+            azimuth_angle=20.0,
+            elevation_angle=7.0,
+            normalize_by_energy=False,
+            fixed_E_polarization_vector=(1, 0, 0),
+        )
+        placed = source.place_on_grid(((0, 3), (0, 3), (0, 1)), config, jax_key)
+
+        applied = placed.apply(jax_key, jnp.ones((1, 3, 3, 1)), 1.0)
+
+        active = jnp.abs(applied._E) > 1e-6
+        normalized = jnp.where(active, applied._E / applied._E[:, :1, :1, :], 1.0)
+        assert jnp.allclose(normalized[active], 1.0, atol=1e-6)
 
 
 class TestLinearlyPolarizedPlaneSourceApply:

--- a/tests/unit/objects/sources/test_mode.py
+++ b/tests/unit/objects/sources/test_mode.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.sources.mode import ModePlaneSource
 
@@ -58,7 +59,7 @@ def micro_config():
     """Minimal simulation config for mode source testing."""
     return SimulationConfig(
         time=100e-15,
-        resolution=100e-9,
+        grid=UniformGrid(spacing=100e-9),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,
@@ -388,6 +389,44 @@ class TestModePlaneSourceGetEHVariation:
         assert call_kwargs["mode_index"] == 1
         assert call_kwargs["filter_pol"] == "te"
         assert call_kwargs["direction"] == "-"
+
+    @patch("fdtdx.objects.sources.mode.compute_mode")
+    @patch("fdtdx.objects.sources.mode.calculate_time_offset_yee")
+    def test_nonuniform_grid_passes_mode_and_time_coordinates(self, mock_time_offset, mock_compute_mode, jax_key):
+        """Non-uniform mode sources pass local edge coordinates to both mode helpers."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0]),
+            y_edges=jnp.asarray([0.0, 2.0, 5.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu", dtype=jnp.float32)
+        mock_compute_mode.return_value = (
+            jnp.ones((3, 3, 2, 1), dtype=jnp.complex64),
+            jnp.ones((3, 3, 2, 1), dtype=jnp.complex64),
+            jnp.array(1.5 + 0j, dtype=jnp.complex64),
+        )
+        mock_time_offset.return_value = (
+            jnp.zeros((3, 3, 2, 1)),
+            jnp.zeros((3, 3, 2, 1)),
+        )
+        source = ModePlaneSource(
+            partial_grid_shape=(3, 2, 1),
+            wave_character=WaveCharacter(wavelength=1.55e-6),
+            direction="-",
+        )
+        placed = source.place_on_grid(((0, 3), (0, 2), (0, 1)), config, jax_key)
+
+        inv_perm = jnp.ones((1, 3, 2, 1), dtype=jnp.float32)
+        placed.apply(jax_key, inv_perm, 1.0)
+
+        mode_kwargs = mock_compute_mode.call_args.kwargs
+        x_edges, y_edges = mode_kwargs["transverse_coords"]
+        assert jnp.allclose(x_edges, jnp.asarray([0.0, 1.0, 3.0, 6.0]))
+        assert jnp.allclose(y_edges, jnp.asarray([0.0, 2.0, 5.0]))
+
+        time_kwargs = mock_time_offset.call_args.kwargs
+        assert time_kwargs["coordinate_edges"] is not None
+        assert jnp.allclose(time_kwargs["center_physical"], jnp.asarray([3.0, 2.5, 0.0], dtype=jnp.float32))
 
 
 class TestModePlaneSourceProperties:

--- a/tests/unit/objects/sources/test_source.py
+++ b/tests/unit/objects/sources/test_source.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.sources.source import (
@@ -22,7 +23,7 @@ def micro_config():
     """Minimal simulation config for source testing."""
     return SimulationConfig(
         time=100e-15,
-        resolution=100e-9,
+        grid=UniformGrid(spacing=100e-9),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,

--- a/tests/unit/objects/sources/test_tfsf.py
+++ b/tests/unit/objects/sources/test_tfsf.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.sources.linear_polarization import GaussianPlaneSource
 
@@ -19,7 +20,7 @@ def micro_config():
     """Minimal simulation config for source testing."""
     return SimulationConfig(
         time=100e-15,
-        resolution=100e-9,
+        grid=UniformGrid(spacing=100e-9),
         backend="cpu",
         dtype=jnp.float32,
         courant_factor=0.99,
@@ -126,6 +127,32 @@ class TestTFSFPlaneSourceProperties:
         )
         # At 100nm resolution, 200nm offset = 2 grid points
         assert np.isclose(placed.max_horizontal_offset_grid, 2.0)
+
+    def test_nonuniform_random_offsets_use_physical_units(self, jax_key):
+        """Random offsets remain physical source-plane distances on stretched grids."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 2.0, 5.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        source = GaussianPlaneSource(
+            partial_grid_shape=(2, 2, 1),
+            wave_character=WaveCharacter(wavelength=1.55e-6),
+            direction="-",
+            radius=1.0,
+            max_horizontal_offset=0.5,
+            max_vertical_offset=0.5,
+        )
+        placed = source.place_on_grid(((0, 2), (0, 2), (0, 1)), config, jax_key)
+
+        center = placed._get_center(jax_key)
+
+        assert placed.max_horizontal_offset_grid == pytest.approx(0.5)
+        assert placed.max_vertical_offset_grid == pytest.approx(0.5)
+        assert center.shape == (2,)
+        assert jnp.abs(center[0] - 1.5) <= 0.5
+        assert jnp.abs(center[1] - 2.5) <= 0.5
 
 
 class TestTFSFPlaneSourceRandomization:

--- a/tests/unit/objects/static_material/test_cylinder.py
+++ b/tests/unit/objects/static_material/test_cylinder.py
@@ -7,11 +7,14 @@ Note: get_voxel_mask_for_shape returns a mask with size 1 along the fiber
 fiber-axis dimension is 1 (relying on broadcasting for application).
 """
 
+import math
+
 import jax
 import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.materials import Material
 from fdtdx.objects.static_material.cylinder import Cylinder
 
@@ -24,7 +27,7 @@ from fdtdx.objects.static_material.cylinder import Cylinder
 def config():
     return SimulationConfig(
         time=100e-15,
-        resolution=50e-9,
+        grid=UniformGrid(spacing=50e-9),
         backend="cpu",
         dtype=jnp.float32,
         gradient_config=None,
@@ -157,6 +160,43 @@ class TestGetVoxelMaskForShape:
             placed = cyl.place_on_grid(slices, config, key)
             mask = placed.get_voxel_mask_for_shape()
             assert mask.shape[axis] == 1, f"Expected size 1 along fiber axis={axis}"
+
+    def test_nonuniform_grid_uses_physical_cell_centers(self, key, two_materials):
+        """Cylinder masks use rectilinear transverse coordinates."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        cyl = _make_cylinder(two_materials, axis=2, radius=0.75)
+        placed = _place(cyl, config, key, ((0, 2), (0, 2), (0, 1)))
+
+        mask = placed.get_voxel_mask_for_shape()
+
+        assert mask.shape == (2, 2, 1)
+        assert bool(jnp.any(mask))
+
+    def test_nonuniform_weighted_cross_section_matches_circle_area(self, key, two_materials):
+        """A resolved stretched-grid cylinder has the expected transverse area."""
+        n = 18
+        t = jnp.linspace(0.0, 1.0, n + 1)
+        grid = RectilinearGrid(
+            x_edges=2.0 * t**1.2,
+            y_edges=2.0 * t**1.4,
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        radius = 0.7
+        cyl = _make_cylinder(two_materials, axis=2, radius=radius)
+        placed = _place(cyl, config, key, ((0, n), (0, n), (0, 1)))
+
+        mask = placed.get_voxel_mask_for_shape()
+        cell_areas = grid.face_area(axis=2, slice_tuple=((0, n), (0, n), (0, 1)))
+        measured_area = jnp.sum(mask * cell_areas)
+        analytic_area = math.pi * radius**2
+
+        assert abs(float(measured_area) - analytic_area) / analytic_area < 0.04
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/objects/static_material/test_polygon.py
+++ b/tests/unit/objects/static_material/test_polygon.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.materials import Material
 from fdtdx.objects.static_material.polygon import (
     ExtrudedPolygon,
@@ -26,7 +27,7 @@ from fdtdx.objects.static_material.polygon import (
 def config():
     return SimulationConfig(
         time=100e-15,
-        resolution=50e-9,
+        grid=UniformGrid(spacing=50e-9),
         backend="cpu",
         dtype=jnp.float32,
         gradient_config=None,
@@ -209,6 +210,22 @@ class TestGetVoxelMaskForShape:
         mask = placed.get_voxel_mask_for_shape()
         for x in range(mask.shape[0]):
             assert jnp.array_equal(mask[x, :, :], mask[0, :, :])
+
+    def test_nonuniform_grid_uses_explicit_cell_centers(self, key, two_materials):
+        """Polygon masks evaluate the shape at rectilinear cell centers."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        poly = _make_polygon(two_materials, axis=2, vertices=_square_vertices(half_side=0.8))
+        placed = _place(poly, config, key, ((0, 2), (0, 2), (0, 1)))
+
+        mask = placed.get_voxel_mask_for_shape()
+
+        assert mask.shape == (2, 2, 1)
+        assert bool(jnp.any(mask))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/objects/static_material/test_sphere.py
+++ b/tests/unit/objects/static_material/test_sphere.py
@@ -3,11 +3,14 @@
 Tests Sphere (and ellipsoid variant) shape generation and material mapping.
 """
 
+import math
+
 import jax
 import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.materials import Material
 from fdtdx.objects.static_material.sphere import Sphere
 
@@ -20,7 +23,7 @@ from fdtdx.objects.static_material.sphere import Sphere
 def config():
     return SimulationConfig(
         time=100e-15,
-        resolution=50e-9,
+        grid=UniformGrid(spacing=50e-9),
         backend="cpu",
         dtype=jnp.float32,
         gradient_config=None,
@@ -128,6 +131,42 @@ class TestGetVoxelMaskForShape:
         mask_d = placed_d.get_voxel_mask_for_shape()
         mask_e = placed_e.get_voxel_mask_for_shape()
         assert jnp.array_equal(mask_d, mask_e)
+
+    def test_nonuniform_grid_uses_physical_cell_centers(self, key, two_materials):
+        """Sphere masks use rectilinear cell-center coordinates instead of scalar spacing."""
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            z_edges=jnp.asarray([0.0, 1.0, 3.0]),
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        sphere = _make_sphere(two_materials, radius=0.9)
+        placed = _place(sphere, config, key, ((0, 2), (0, 2), (0, 2)))
+
+        mask = placed.get_voxel_mask_for_shape()
+
+        assert mask.shape == (2, 2, 2)
+        assert bool(jnp.any(mask))
+
+    def test_nonuniform_weighted_mask_volume_matches_sphere_volume(self, key, two_materials):
+        """A resolved stretched-grid sphere has the expected physical volume."""
+        n = 16
+        t = jnp.linspace(0.0, 1.0, n + 1)
+        grid = RectilinearGrid(
+            x_edges=2.0 * t**1.35,
+            y_edges=2.0 * t**1.15,
+            z_edges=2.0 * t**1.05,
+        )
+        config = SimulationConfig(time=1e-8, grid=grid, backend="cpu")
+        radius = 0.75
+        sphere = _make_sphere(two_materials, radius=radius)
+        placed = _place(sphere, config, key, ((0, n), (0, n), (0, n)))
+
+        mask = placed.get_voxel_mask_for_shape()
+        measured_volume = jnp.sum(mask * grid.cell_volume(((0, n), (0, n), (0, n))))
+        analytic_volume = 4.0 / 3.0 * math.pi * radius**3
+
+        assert abs(float(measured_volume) - analytic_volume) / analytic_volume < 0.03
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/objects/static_material/test_static.py
+++ b/tests/unit/objects/static_material/test_static.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.colors import XKCD_LIGHT_GREY
+from fdtdx.core.grid import UniformGrid
 from fdtdx.core.jax.pytrees import autoinit
 from fdtdx.materials import Material
 from fdtdx.objects.static_material.static import (
@@ -78,7 +79,7 @@ class TestStaticMultiMaterialObject:
 
         return SimulationConfig(
             time=100e-15,
-            resolution=50e-9,
+            grid=UniformGrid(spacing=50e-9),
             backend="cpu",
             dtype=jnp.float32,
             gradient_config=None,

--- a/tests/unit/objects/test_object.py
+++ b/tests/unit/objects/test_object.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
 from fdtdx.core.jax.pytrees import autoinit
 from fdtdx.objects.object import (
     GridCoordinateConstraint,
@@ -58,7 +59,7 @@ def _place(obj, config, key, slices=((0, 10), (0, 10), (0, 10))):
 def config():
     return SimulationConfig(
         time=100e-15,
-        resolution=50e-9,
+        grid=UniformGrid(spacing=50e-9),
         backend="cpu",
         dtype=jnp.float32,
         gradient_config=None,
@@ -258,7 +259,7 @@ class TestPlaceOnGrid:
     def test_real_shape_after_placement(self, config, key):
         obj = _make()
         placed = _place(obj, config, key, ((0, 4), (0, 6), (0, 10)))
-        res = config.resolution
+        res = config.uniform_spacing()
         assert placed.real_shape == pytest.approx((4 * res, 6 * res, 10 * res))
 
     def test_grid_slice_returns_python_slices(self, config, key):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -8,6 +8,7 @@ import pytest
 
 from fdtdx import constants
 from fdtdx.config import DUMMY_SIMULATION_CONFIG, GradientConfig, SimulationConfig
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 
 
 class TestGradientConfigConstruction:
@@ -58,13 +59,13 @@ class TestSimulationConfigConstruction:
 
         config = SimulationConfig(
             time=1e-12,
-            resolution=1e-9,
+            grid=UniformGrid(spacing=1e-9),
             backend="cpu",
             dtype=jnp.float64,
             courant_factor=0.95,
         )
         assert config.time == 1e-12
-        assert config.resolution == 1e-9
+        assert config.uniform_spacing() == 1e-9
         assert config.backend == "cpu"
         assert config.dtype == jnp.float64
         assert config.courant_factor == 0.95
@@ -82,7 +83,7 @@ class TestSimulationConfigBackendHandling:
         mock_get_backend.return_value = _create_mock_backend("gpu")
         mock_devices.return_value = [MagicMock()]
 
-        config = SimulationConfig(time=1e-12, resolution=1e-9, backend="gpu")
+        config = SimulationConfig(time=1e-12, grid=UniformGrid(spacing=1e-9), backend="gpu")
         assert config.backend == "gpu"
         mock_config_update.assert_called_with("jax_platform_name", "gpu")
 
@@ -94,7 +95,7 @@ class TestSimulationConfigBackendHandling:
         mock_get_backend.return_value = _create_mock_backend("cpu")
         mock_devices.side_effect = RuntimeError("No GPU found")
 
-        config = SimulationConfig(time=1e-12, resolution=1e-9, backend="gpu")
+        config = SimulationConfig(time=1e-12, grid=UniformGrid(spacing=1e-9), backend="gpu")
         assert config.backend == "cpu"
 
     @patch("fdtdx.config.jax.config.update")
@@ -105,7 +106,7 @@ class TestSimulationConfigBackendHandling:
         mock_get_backend.return_value = _create_mock_backend("tpu")
         mock_devices.return_value = [MagicMock()]
 
-        config = SimulationConfig(time=1e-12, resolution=1e-9, backend="tpu")
+        config = SimulationConfig(time=1e-12, grid=UniformGrid(spacing=1e-9), backend="tpu")
         assert config.backend == "tpu"
         mock_config_update.assert_called_with("jax_platform_name", "tpu")
 
@@ -117,7 +118,7 @@ class TestSimulationConfigBackendHandling:
         mock_get_backend.return_value = _create_mock_backend("cpu")
         mock_devices.side_effect = RuntimeError("No TPU found")
 
-        config = SimulationConfig(time=1e-12, resolution=1e-9, backend="tpu")
+        config = SimulationConfig(time=1e-12, grid=UniformGrid(spacing=1e-9), backend="tpu")
         assert config.backend == "cpu"
 
     @patch("fdtdx.config.jax.config.update")
@@ -127,7 +128,7 @@ class TestSimulationConfigBackendHandling:
         """Test explicit CPU backend."""
         mock_get_backend.return_value = _create_mock_backend("cpu")
 
-        config = SimulationConfig(time=1e-12, resolution=1e-9, backend="cpu")
+        config = SimulationConfig(time=1e-12, grid=UniformGrid(spacing=1e-9), backend="cpu")
         assert config.backend == "cpu"
         mock_config_update.assert_called_with("jax_platform_name", "cpu")
 
@@ -139,7 +140,7 @@ class TestSimulationConfigBackendHandling:
         mock_get_backend.return_value = _create_mock_backend("METAL")
         mock_devices.return_value = [MagicMock()]
 
-        config = SimulationConfig(time=1e-12, resolution=1e-9, backend="gpu")
+        config = SimulationConfig(time=1e-12, grid=UniformGrid(spacing=1e-9), backend="gpu")
         assert config.backend == "METAL"
         mock_config_update.assert_called_with("jax_platform_name", "metal")
 
@@ -151,7 +152,7 @@ class TestSimulationConfigBackendHandling:
         mock_get_backend.return_value = _create_mock_backend("cpu")
         mock_devices.side_effect = RuntimeError("METAL init failed")
 
-        config = SimulationConfig(time=1e-12, resolution=1e-9, backend="METAL")
+        config = SimulationConfig(time=1e-12, grid=UniformGrid(spacing=1e-9), backend="METAL")
         assert config.backend == "cpu"
 
 
@@ -165,7 +166,7 @@ class TestSimulationConfigProperties:
         """Test courant_number calculation."""
         mock_get_backend.return_value = _create_mock_backend("cpu")
 
-        config = SimulationConfig(time=1e-12, resolution=1e-9, backend="cpu", courant_factor=0.5)
+        config = SimulationConfig(time=1e-12, grid=UniformGrid(spacing=1e-9), backend="cpu", courant_factor=0.5)
         expected = 0.5 / math.sqrt(3)
         assert abs(config.courant_number - expected) < 1e-10
 
@@ -177,9 +178,77 @@ class TestSimulationConfigProperties:
         mock_get_backend.return_value = _create_mock_backend("cpu")
 
         resolution = 1e-9
-        config = SimulationConfig(time=1e-12, resolution=resolution, backend="cpu")
+        config = SimulationConfig(time=1e-12, grid=UniformGrid(spacing=resolution), backend="cpu")
         expected = config.courant_number * resolution / constants.c
         assert abs(config.time_step_duration - expected) < 1e-30
+
+    @patch("fdtdx.config.jax.config.update")
+    @patch("fdtdx.config.jax.devices")
+    @patch("jax.extend.backend.get_backend")
+    def test_time_step_duration_uses_grid_min_spacing(self, mock_get_backend, *_):
+        """Non-uniform grids use the per-axis minimum-spacing CFL formula."""
+        mock_get_backend.return_value = _create_mock_backend("cpu")
+
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 2e-9, 5e-9]),
+            y_edges=jnp.asarray([0.0, 1e-9]),
+            z_edges=jnp.asarray([0.0, 4e-9]),
+        )
+        config = SimulationConfig(time=1e-12, grid=grid, backend="cpu")
+        expected = grid.cfl_time_step(config.courant_factor)
+        assert math.isclose(config.time_step_duration, expected, rel_tol=1e-6)
+
+    @patch("fdtdx.config.jax.config.update")
+    @patch("fdtdx.config.jax.devices")
+    @patch("jax.extend.backend.get_backend")
+    def test_uniform_grid_time_step_matches_scalar_resolution(self, mock_get_backend, *_):
+        """Uniform RectilinearGrid configs preserve scalar-resolution CFL behavior."""
+        mock_get_backend.return_value = _create_mock_backend("cpu")
+
+        spacing = 2e-9
+        scalar_config = SimulationConfig(
+            time=1e-12, grid=UniformGrid(spacing=spacing), backend="cpu", courant_factor=0.8
+        )
+        grid_config = SimulationConfig(
+            time=1e-12,
+            grid=RectilinearGrid.uniform(shape=(3, 4, 5), spacing=spacing),
+            backend="cpu",
+            courant_factor=0.8,
+        )
+
+        assert math.isclose(grid_config.uniform_spacing(), scalar_config.uniform_spacing(), rel_tol=1e-6)
+        assert math.isclose(grid_config.courant_number, scalar_config.courant_number, rel_tol=1e-6)
+        assert math.isclose(grid_config.time_step_duration, scalar_config.time_step_duration, rel_tol=1e-6)
+
+    @patch("fdtdx.config.jax.config.update")
+    @patch("fdtdx.config.jax.devices")
+    @patch("jax.extend.backend.get_backend")
+    def test_resolve_grid_builds_uniform_grid_from_resolution(self, mock_get_backend, *_):
+        """Legacy resolution configs create a concrete RectilinearGrid when the volume shape is known."""
+        mock_get_backend.return_value = _create_mock_backend("cpu")
+
+        config = SimulationConfig(time=1e-12, grid=UniformGrid(spacing=2e-9), backend="cpu")
+        grid = config.resolve_grid((2, 3, 4))
+
+        assert grid.shape == (2, 3, 4)
+        assert math.isclose(grid.uniform_spacing, 2e-9, rel_tol=1e-6)
+
+    @patch("fdtdx.config.jax.config.update")
+    @patch("fdtdx.config.jax.devices")
+    @patch("jax.extend.backend.get_backend")
+    def test_uniform_spacing_rejects_nonuniform_grid(self, mock_get_backend, *_):
+        """Scalar compatibility access fails instead of masking non-uniform metrics."""
+        mock_get_backend.return_value = _create_mock_backend("cpu")
+
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0]),
+            y_edges=jnp.asarray([0.0, 1.0]),
+            z_edges=jnp.asarray([0.0, 1.0]),
+        )
+        config = SimulationConfig(time=1e-12, grid=grid, backend="cpu")
+
+        with pytest.raises(ValueError, match="requires a uniform grid"):
+            config.uniform_spacing()
 
     @patch("fdtdx.config.jax.config.update")
     @patch("fdtdx.config.jax.devices")
@@ -188,7 +257,7 @@ class TestSimulationConfigProperties:
         """Test time_steps_total calculation."""
         mock_get_backend.return_value = _create_mock_backend("cpu")
 
-        config = SimulationConfig(time=1e-12, resolution=1e-9, backend="cpu")
+        config = SimulationConfig(time=1e-12, grid=UniformGrid(spacing=1e-9), backend="cpu")
         expected = round(config.time / config.time_step_duration)
         assert config.time_steps_total == expected
 
@@ -200,7 +269,7 @@ class TestSimulationConfigProperties:
         mock_get_backend.return_value = _create_mock_backend("cpu")
 
         time = 1e-12
-        config = SimulationConfig(time=time, resolution=1e-9, backend="cpu")
+        config = SimulationConfig(time=time, grid=UniformGrid(spacing=1e-9), backend="cpu")
         expected = constants.c * time
         assert abs(config.max_travel_distance - expected) < 1e-20
 
@@ -215,7 +284,7 @@ class TestSimulationConfigGradientProperties:
         """Test only_forward is True when gradient_config is None."""
         mock_get_backend.return_value = _create_mock_backend("cpu")
 
-        config = SimulationConfig(time=1e-12, resolution=1e-9, backend="cpu")
+        config = SimulationConfig(time=1e-12, grid=UniformGrid(spacing=1e-9), backend="cpu")
         assert config.only_forward is True
         assert config.invertible_optimization is False
 
@@ -228,7 +297,9 @@ class TestSimulationConfigGradientProperties:
 
         mock_recorder = MagicMock()
         gradient_config = GradientConfig(method="reversible", recorder=mock_recorder)
-        config = SimulationConfig(time=1e-12, resolution=1e-9, backend="cpu", gradient_config=gradient_config)
+        config = SimulationConfig(
+            time=1e-12, grid=UniformGrid(spacing=1e-9), backend="cpu", gradient_config=gradient_config
+        )
         assert config.only_forward is False
         assert config.invertible_optimization is True
 
@@ -240,7 +311,9 @@ class TestSimulationConfigGradientProperties:
         mock_get_backend.return_value = _create_mock_backend("cpu")
 
         gradient_config = GradientConfig(method="checkpointed", num_checkpoints=10)
-        config = SimulationConfig(time=1e-12, resolution=1e-9, backend="cpu", gradient_config=gradient_config)
+        config = SimulationConfig(
+            time=1e-12, grid=UniformGrid(spacing=1e-9), backend="cpu", gradient_config=gradient_config
+        )
         assert config.only_forward is False
         assert config.invertible_optimization is False
 
@@ -252,4 +325,4 @@ class TestDummySimulationConfig:
         """Test DUMMY_SIMULATION_CONFIG has expected sentinel values."""
         assert isinstance(DUMMY_SIMULATION_CONFIG, SimulationConfig)
         assert DUMMY_SIMULATION_CONFIG.time == -1
-        assert DUMMY_SIMULATION_CONFIG.resolution == -1
+        assert DUMMY_SIMULATION_CONFIG.uniform_spacing() == 1

--- a/tests/unit/utils/test_plot_material.py
+++ b/tests/unit/utils/test_plot_material.py
@@ -6,16 +6,19 @@ from unittest.mock import MagicMock
 
 import matplotlib
 import numpy as np
+import pytest
 
 matplotlib.use("Agg")
+import jax.numpy as jnp
 import matplotlib.pyplot as plt
 
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.utils.plot_material import plot_material, plot_material_from_side
 
 
 def _make_config(resolution: float = 50e-9) -> MagicMock:
     config = MagicMock()
-    config.resolution = resolution
+    config.uniform_spacing.return_value = resolution
     return config
 
 
@@ -50,6 +53,23 @@ class TestPlotMaterialFromSide:
         _fig, ax = plt.subplots()
         result = plot_material_from_side(config=config, arrays=arrays, viewing_side="z", ax=ax)
         assert result is not None
+        plt.close("all")
+
+    def test_nonuniform_grid_uses_rectilinear_edges(self):
+        """Material plots use pcolormesh with RectilinearGrid physical extents."""
+        config = _make_config()
+        config.grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0e-6, 4.0e-6]),
+            y_edges=jnp.asarray([0.0, 2.0e-6, 5.0e-6]),
+            z_edges=jnp.asarray([0.0, 1.0e-6, 3.0e-6]),
+        )
+        arrays = _make_arrays(shape=(1, 2, 2, 2))
+        _fig, ax = plt.subplots()
+        plot_material_from_side(config=config, arrays=arrays, viewing_side="z", ax=ax, plot_legend=False)
+
+        assert len(ax.collections) == 1
+        assert ax.get_xlim() == pytest.approx((0.0, 4.0))
+        assert ax.get_ylim() == pytest.approx((0.0, 5.0))
         plt.close("all")
 
     def test_viewing_side_y_returns_figure(self):
@@ -216,6 +236,35 @@ class TestPlotMaterialFromSide:
         _fig, ax = plt.subplots()
         plot_material_from_side(config=config, arrays=arrays, viewing_side="z", ax=ax, position=-100e-3)
         assert len(ax.get_images()) == 1
+        plt.close("all")
+
+    def test_nonuniform_position_selects_nearest_cell_center(self):
+        """Nonuniform slice positions are offsets from physical domain center."""
+        config = _make_config()
+        config.grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0e-6]),
+            y_edges=jnp.asarray([0.0, 1.0e-6]),
+            z_edges=jnp.asarray([0.0, 1.0e-6, 4.0e-6, 10.0e-6]),
+        )
+        inv_perm = np.zeros((1, 1, 1, 3))
+        for z in range(3):
+            inv_perm[0, :, :, z] = 1.0 / (z + 1)
+        arrays = MagicMock()
+        arrays.inv_permittivities = inv_perm
+        arrays.inv_permeabilities = np.ones_like(inv_perm)
+        _fig, ax = plt.subplots()
+
+        plot_material_from_side(
+            config=config,
+            arrays=arrays,
+            viewing_side="z",
+            ax=ax,
+            position=-4.5e-6,
+            plot_legend=False,
+        )
+
+        plotted_values = np.asarray(ax.collections[0].get_array())
+        assert np.allclose(plotted_values, 1.0)
         plt.close("all")
 
     def test_saves_file_when_filename_given(self):

--- a/tests/unit/utils/test_plot_setup.py
+++ b/tests/unit/utils/test_plot_setup.py
@@ -8,8 +8,10 @@ import matplotlib
 import pytest
 
 matplotlib.use("Agg")
+import jax.numpy as jnp
 import matplotlib.pyplot as plt
 
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.utils.plot_setup import plot_setup, plot_setup_from_side
 
 
@@ -54,7 +56,7 @@ def _make_container(objects=None, volume_grid_shape=(50, 50, 50)):
 
 def _make_config(resolution: float = 50e-9) -> MagicMock:
     config = MagicMock()
-    config.resolution = resolution
+    config.uniform_spacing.return_value = resolution
     return config
 
 
@@ -95,6 +97,28 @@ class TestPlotSetupFromSide:
         _fig, ax = plt.subplots()
         with pytest.raises(ValueError, match="Invalid viewing_side"):
             plot_setup_from_side(config=config, objects=container, viewing_side="w", ax=ax)
+        plt.close("all")
+
+    def test_nonuniform_grid_uses_physical_extents(self):
+        """Setup plots use RectilinearGrid edge coordinates for stretched cells."""
+        config = _make_config()
+        config.grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0e-6, 4.0e-6]),
+            y_edges=jnp.asarray([0.0, 2.0e-6, 5.0e-6]),
+            z_edges=jnp.asarray([0.0, 1.0e-6]),
+        )
+        obj = _MockObj("box", "blue", ((1, 2), (0, 2), (0, 1)))
+        container = _make_container(objects=[obj], volume_grid_shape=(2, 2, 1))
+        _fig, ax = plt.subplots()
+        plot_setup_from_side(config=config, objects=container, viewing_side="z", ax=ax, plot_legend=False)
+
+        patch = ax.patches[0]
+        assert patch.get_x() == pytest.approx(1.0)
+        assert patch.get_width() == pytest.approx(3.0)
+        assert patch.get_y() == pytest.approx(0.0)
+        assert patch.get_height() == pytest.approx(5.0)
+        assert ax.get_xlim() == pytest.approx((0.0, 4.0))
+        assert ax.get_ylim() == pytest.approx((0.0, 5.0))
         plt.close("all")
 
     def test_axis_labels_and_title_z(self):


### PR DESCRIPTION
This PR re-applies #312 (which was reverted in #339), with two additional fixes on top:

1. Addressing https://github.com/ymahlau/fdtdx/issues/335 and https://github.com/ymahlau/fdtdx/issues/329: JAX-native edge coordinates — the follow-up PR #331 fixed TracerArrayConversionError by storing grid edges as Python tuples (frozen pytree aux data)
so they stay concrete under jax.jit. This is the wrong approach: grids with the same shape but different spacings would force
recompilation. Instead, this PR keeps edges as JAX arrays and passes them as explicit jax.pure_callback arguments to the tidy3d mode solver —
np.asarray() only happens inside the callback where values are always concrete, so no workaround is needed.
2. Test config fixes — unit tests that used sub-µm RectilinearGrid spacings with time=1e-8 s were generating millions of time steps, causing slow
place_on_grid calls due to O(time_steps) Python loops in OnOffSwitch. Fixed time= to 1e-13 s in the affected tests. Also updated all files still using
the removed resolution= kwarg on SimulationConfig.


Tests ran in 6 m 44 s (https://github.com/ymahlau/fdtdx/actions/runs/25975400480/job/76354551181?pr=344)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for non-uniform (rectilinear) simulation grids and VTR export for rectilinear snapshots.
  * Mode solver and sources accept explicit transverse coordinates for non-uniform meshes.

* **Bug Fixes / Improvements**
  * Plots, detectors, PML, and diagnostics now respect physical grid coordinates and use correct area/volume weighting.
  * Examples, docs, and tests updated to the new grid API.

* **Chores**
  * Grid configuration migrated from scalar resolution to explicit grid objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->