### PR TITLE
Fix: guard setup functions against JIT tracing + remove illegal float() cast in PML

### DIFF
--- a/src/fdtdx/core/jax/guards.py
+++ b/src/fdtdx/core/jax/guards.py
@@ -1,0 +1,32 @@
+import jax
+import jax.core
+import jax.numpy as jnp
+
+
+def check_not_tracing(fn_name: str) -> None:
+    """Raise a clear error if called inside a JAX JIT trace.
+
+    Setup functions allocate concrete device memory and resolve static grid
+    geometry. Both require eager execution and are incompatible with JIT
+    tracing. This guard surfaces that constraint with an actionable message
+    instead of a cryptic internal JAX error.
+
+    Works by checking whether a freshly created jnp array is a Tracer —
+    which it is under JIT, and is not in eager mode.
+    """
+    if isinstance(jnp.empty(()), jax.core.Tracer):
+        raise TypeError(
+            f"`{fn_name}` is a setup function and cannot be called inside "
+            f"`jax.jit()`. It allocates device arrays and resolves concrete "
+            f"grid geometry, both of which require eager execution.\n\n"
+            f"Move all fdtdx setup calls outside any JIT boundary and only "
+            f"JIT-compile the simulation time-stepping loop:\n\n"
+            f"  # Correct\n"
+            f"  objects, arrays, config, _ = fdtdx.place_objects(...)\n"
+            f"  result = jax.jit(run_simulation)(arrays, ...)\n\n"
+            f"  # Wrong\n"
+            f"  @jax.jit\n"
+            f"  def run():\n"
+            f"      objects, arrays, config, _ = fdtdx.place_objects(...)  # ERROR\n"
+            f"      return run_simulation(arrays, ...)\n"
+        )

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -4,6 +4,7 @@ import jax
 import jax.numpy as jnp
 
 from fdtdx.config import SimulationConfig
+from fdtdx.core.jax.guards import check_not_tracing
 from fdtdx.core.jax.sharding import create_named_sharded_matrix
 from fdtdx.core.jax.ste import straight_through_estimator
 from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer, ParameterContainer
@@ -66,6 +67,8 @@ def place_objects(
     Raises:
         ValueError: If constraint resolution fails for one or more objects.
     """
+    # Step 0: Check if called inside a JIT trace
+    check_not_tracing("fdtdx.place_objects")
 
     # Step 1: Resolve constraints into grid slices
     resolved_slices, errors = resolve_object_constraints(
@@ -188,6 +191,10 @@ def apply_params(
         # and keep evolving polarization in the device's voxels.
         # compute_allowed_dispersive_coefficients zero-pads non-dispersive materials.
         write_dispersive = num_dispersive_poles > 0
+
+        # Initialise dispersive slots; populated below when write_dispersive is True.
+        allowed_c1_arr = allowed_c2_arr = allowed_c3_arr = None
+        new_c1_slice = new_c2_slice = new_c3_slice = None
         if write_dispersive:
             assert (
                 arrays.dispersive_c1 is not None
@@ -211,6 +218,7 @@ def apply_params(
             # cur_material_indices: (*grid_shape) broadcasts with (num_components, 1, 1, 1)
             new_perm_slice = (1 - cur_material_indices) * inv_allowed_bc[0] + cur_material_indices * inv_allowed_bc[1]
             if write_dispersive:
+                assert allowed_c1_arr is not None and allowed_c2_arr is not None and allowed_c3_arr is not None
                 # Linear interpolation of dispersive coefficients between the two bracketing materials.
                 # Note: this follows the same straight-through-estimator convention as the
                 # permittivity path above — it is *not* equivalent to a material whose
@@ -237,6 +245,7 @@ def apply_params(
             component_values = straight_through_estimator(cur_material_indices, component_values)
             new_perm_slice = component_values
             if write_dispersive:
+                assert allowed_c1_arr is not None and allowed_c2_arr is not None and allowed_c3_arr is not None
                 int_idx = cur_material_indices.astype(jnp.int32)
                 # allowed_cN_arr[int_idx]: (Nx, Ny, Nz, num_poles) -> moveaxis -> (num_poles, Nx, Ny, Nz)
                 new_c1_slice = jnp.moveaxis(allowed_c1_arr[int_idx], -1, 0)[:, None, ...]

--- a/src/fdtdx/objects/boundaries/perfectly_matched_layer.py
+++ b/src/fdtdx/objects/boundaries/perfectly_matched_layer.py
@@ -89,7 +89,7 @@ class PerfectlyMatchedLayer(BaseBoundary):
             assert self.sigma_order is not None, "sigma_order should be set by __post_init__"
             pml_thickness = self.thickness * self._config.resolution
             sigma_end_calculated = -(self.sigma_order + 1) * jnp.log(1e-6) / (2 * (eta0 / 1.0) * pml_thickness)
-            self = self.aset("sigma_end", float(sigma_end_calculated))
+            self = self.aset("sigma_end", sigma_end_calculated.astype(float))
 
         return self
 


### PR DESCRIPTION
This is a small PR that doesn't change any already functional behavior.

In the setup functions, place_objects and its callees allocate device memory and resolve concrete grid geometry. Both are incompatible with JAX JIT tracing, but the errors produced (ConcretizationTypeError, make_array_from_single_device_arrays with tracers) were cryptic and gave no guidance.

This PR does the following:

-   Adds check_not_tracing() utility in a guards.py file
-   Calls it at the entry point of place_objects
-   Removes float() cast on sigma_end_calculated in PerfectlyMatchedLayer.place_on_grid, which caused a separate                    
    ConcretizationTypeError for the same root reason
-   Fixes minor static typing errors with None initializations and asserts

Previous error message:
ValueError: jax.make_array_from_single_device_arrays requires a list of concrete arrays as input, but got types {<class 'jax._src.interpreters.partial_eval.DynamicJaxprTracer'>}

New error message:
TypeError: fdtdx.place_objects is a setup function and cannot be called inside jax.jit(). It allocates device arrays and resolves concrete grid geometry, both of which require eager execution.

Move all fdtdx setup calls outside any JIT boundary and only JIT-compile the simulation time-stepping loop:

Correct
objects, arrays, config, _ = fdtdx.place_objects(...)
result = jax.jit(run_simulation)(arrays, ...)

Wrong
@jax.jit
def run():
objects, arrays, config, _ = fdtdx.place_objects(...) # ERROR
return run_simulation(arrays, ...)