### PR TITLE
Support frequency-indexed mode-overlap and S-parameter results

### DIFF
--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -18,14 +18,16 @@ from fdtdx.typing import SliceTuple3D
 class ModeOverlapDetector(PhasorDetector):
     """
     Detector for measuring the overlap of a waveguide mode with the simulation fields.
-    This detector computes the overlap of a mode with the phasor fields at a specified
-    frequency, enabling frequency-domain analysis of the electromagnetic fields.
+    This detector computes the overlap integral at every frequency in ``wave_characters``,
+    enabling broadband frequency-domain analysis of the electromagnetic fields.
 
     The mode overlap is calculated by integrating the cross product of the mode fields
     with the simulation fields over a cross-sectional plane. This is useful for
     analyzing waveguide coupling efficiency, transmission coefficients, and modal
     decomposition of electromagnetic fields.
 
+    ``compute_overlap()`` returns a complex array of shape ``(num_freqs,)``, where
+    ``num_freqs = len(wave_characters)``.
     """
 
     #: Direction of mode propagation, either "+" (forward) or "-" (backward).
@@ -89,8 +91,6 @@ class ModeOverlapDetector(PhasorDetector):
             config=config,
             key=key,
         )
-        if len(self.wave_characters) > 1:
-            raise NotImplementedError()
         if (self.bend_radius is None) != (self.bend_axis is None):
             raise ValueError("bend_radius and bend_axis must both be set or both be None")
         if self.bend_axis is not None and self.bend_axis == self.propagation_axis:
@@ -158,42 +158,47 @@ class ModeOverlapDetector(PhasorDetector):
         else:
             inv_permeability_slice = inv_permeabilities
 
-        # Frequency-correct the permittivity seen by the mode solver so the
-        # reference mode profile reflects ε(ω_c) of any dispersive medium the
-        # detector sits in, not just ε∞. Matches the pattern in
-        # ModePlaneSource.apply. Cells with no pole have c1=c2=c3=0, in which
-        # case effective_inv_permittivity returns inv_eps unchanged.
+        c1_slice = c2_slice = c3_slice = None
         if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
             c1_slice = dispersive_c1[:, :, *self.grid_slice]
             c2_slice = dispersive_c2[:, :, *self.grid_slice]
             c3_slice = dispersive_c3[:, :, *self.grid_slice]
-            inv_permittivity_slice = effective_inv_permittivity(
-                inv_eps=inv_permittivity_slice,
-                c1=c1_slice,
-                c2=c2_slice,
-                c3=c3_slice,
-                omega=2.0 * np.pi * self.wave_characters[0].get_frequency(),
-                dt=self._config.time_step_duration,
+
+        all_mode_Es: list[jax.Array] = []
+        all_mode_Hs: list[jax.Array] = []
+        all_mode_neffs: list[jax.Array] = []
+        for wc in self.wave_characters:
+            inv_eps_i = inv_permittivity_slice
+            if c1_slice is not None and c2_slice is not None and c3_slice is not None:
+                inv_eps_i = effective_inv_permittivity(
+                    inv_eps=inv_permittivity_slice,
+                    c1=c1_slice,
+                    c2=c2_slice,
+                    c3=c3_slice,
+                    omega=2.0 * np.pi * wc.get_frequency(),
+                    dt=self._config.time_step_duration,
+                )
+            mode_E, mode_H, mode_neff = compute_mode(
+                frequency=wc.get_frequency(),
+                inv_permittivities=inv_eps_i,
+                inv_permeabilities=inv_permeability_slice,
+                resolution=self._mode_solver_resolution(),
+                direction=self.direction,
+                mode_index=self.mode_index,
+                filter_pol=self.filter_pol,
+                dtype=self._config.dtype,
+                bend_radius=self.bend_radius,
+                bend_axis=self.bend_axis,
+                symmetry=self.symmetry,
+                transverse_coords=self._transverse_edge_coordinates(),
             )
+            all_mode_Es.append(mode_E)
+            all_mode_Hs.append(mode_H)
+            all_mode_neffs.append(mode_neff)
 
-        mode_E, mode_H, mode_neff = compute_mode(
-            frequency=self.wave_characters[0].get_frequency(),
-            inv_permittivities=inv_permittivity_slice,
-            inv_permeabilities=inv_permeability_slice,
-            resolution=self._mode_solver_resolution(),
-            direction=self.direction,
-            mode_index=self.mode_index,
-            filter_pol=self.filter_pol,
-            dtype=self._config.dtype,
-            bend_radius=self.bend_radius,
-            bend_axis=self.bend_axis,
-            symmetry=self.symmetry,
-            transverse_coords=self._transverse_edge_coordinates(),
-        )
-
-        self = self.aset("_mode_E", mode_E, create_new_ok=True)
-        self = self.aset("_mode_H", mode_H, create_new_ok=True)
-        self = self.aset("_mode_neff", mode_neff, create_new_ok=True)
+        self = self.aset("_mode_E", jnp.stack(all_mode_Es, axis=0), create_new_ok=True)
+        self = self.aset("_mode_H", jnp.stack(all_mode_Hs, axis=0), create_new_ok=True)
+        self = self.aset("_mode_neff", jnp.stack(all_mode_neffs, axis=0), create_new_ok=True)
         return self
 
     def compute_overlap_to_mode(
@@ -201,11 +206,24 @@ class ModeOverlapDetector(PhasorDetector):
         state: DetectorState,
         mode_E: jax.Array,
         mode_H: jax.Array,
+        freq_idx: int = 0,
     ) -> jax.Array:
+        """Compute the overlap integral of *one* mode against phasors at ``freq_idx``.
+
+        Args:
+            state: Detector state holding the phasor array of shape
+                ``(1, num_freqs, 6, *spatial)``.
+            mode_E: Electric mode field of shape ``(3, *spatial)``.
+            mode_H: Magnetic mode field of shape ``(3, *spatial)``.
+            freq_idx: Index into the phasor frequency axis to use.
+
+        Returns:
+            Complex scalar overlap coefficient.
+        """
         # shape (time step, num_freqs, num_components, *spatial)
         # time steps is always 1 and num_components always 6
         phasors = state["phasor"]
-        phasors_E, phasors_H = phasors[0, 0, :3], phasors[0, 0, 3:]
+        phasors_E, phasors_H = phasors[0, freq_idx, :3], phasors[0, freq_idx, 3:]
 
         E_cross_H_star_sim = jnp.cross(
             mode_E,
@@ -233,10 +251,20 @@ class ModeOverlapDetector(PhasorDetector):
         self,
         state: DetectorState,
     ) -> jax.Array:
+        """Compute mode overlaps at every frequency in ``wave_characters``.
+
+        Returns:
+            Complex array of shape ``(num_freqs,)``.
+        """
         if isinstance(self._mode_E, Null) or isinstance(self._mode_H, Null):
             raise Exception("Need to call apply on ModeOverlapDetector before calling compute_mode_overlap!")
-        return self.compute_overlap_to_mode(
-            state=state,
-            mode_E=self._mode_E,
-            mode_H=self._mode_H,
-        )
+        overlaps = [
+            self.compute_overlap_to_mode(
+                state=state,
+                mode_E=self._mode_E[i],
+                mode_H=self._mode_H[i],
+                freq_idx=i,
+            )
+            for i in range(len(self.wave_characters))
+        ]
+        return jnp.stack(overlaps, axis=0)

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -206,16 +206,16 @@ class ModeOverlapDetector(PhasorDetector):
         state: DetectorState,
         mode_E: jax.Array,
         mode_H: jax.Array,
-        freq_idx: int = 0,
+        wave_character_index: int = 0,
     ) -> jax.Array:
-        """Compute the overlap integral of *one* mode against phasors at ``freq_idx``.
+        """Compute the overlap integral of *one* mode against phasors at ``wave_character_index``.
 
         Args:
             state: Detector state holding the phasor array of shape
                 ``(1, num_freqs, 6, *spatial)``.
             mode_E: Electric mode field of shape ``(3, *spatial)``.
             mode_H: Magnetic mode field of shape ``(3, *spatial)``.
-            freq_idx: Index into the phasor frequency axis to use.
+            wave_character_index: Index into the phasor frequency axis to use.
 
         Returns:
             Complex scalar overlap coefficient.
@@ -223,7 +223,7 @@ class ModeOverlapDetector(PhasorDetector):
         # shape (time step, num_freqs, num_components, *spatial)
         # time steps is always 1 and num_components always 6
         phasors = state["phasor"]
-        phasors_E, phasors_H = phasors[0, freq_idx, :3], phasors[0, freq_idx, 3:]
+        phasors_E, phasors_H = phasors[0, wave_character_index, :3], phasors[0, wave_character_index, 3:]
 
         E_cross_H_star_sim = jnp.cross(
             mode_E,
@@ -263,7 +263,7 @@ class ModeOverlapDetector(PhasorDetector):
                 state=state,
                 mode_E=self._mode_E[i],
                 mode_H=self._mode_H[i],
-                freq_idx=i,
+                wave_character_index=i,
             )
             for i in range(len(self.wave_characters))
         ]

--- a/src/fdtdx/utils/sparams.py
+++ b/src/fdtdx/utils/sparams.py
@@ -263,9 +263,11 @@ def calculate_sparam(
 
     Returns:
         A 2-tuple ``(sparams, detector_states)`` where *sparams* maps
-        ``(detector_name, input_port_name)`` to a complex scattering amplitude
-        and *detector_states* is the final :class:`~fdtdx.DetectorState` dict
-        for every detector in the simulation.
+        ``(detector_name, input_port_name)`` to a complex scattering-amplitude
+        array indexed by frequency. For the single-frequency detectors created
+        by :func:`setup_sparams_simulation`, each value has shape ``(1,)``.
+        *detector_states* is the final :class:`~fdtdx.DetectorState` dict for
+        every detector in the simulation.
     """
     if key is None:
         key = jax.random.PRNGKey(0)

--- a/tests/integration/utils/test_sparams.py
+++ b/tests/integration/utils/test_sparams.py
@@ -500,7 +500,8 @@ class TestCalculateSparamMultiSource:
 
         result, _states, _objs = two_source_sparam_result
         for (det_name, _), s_param in result.items():
-            assert jnp.isfinite(jnp.abs(s_param)), f"S-param for {det_name!r} is not finite"
+            assert s_param.shape == (1,)
+            assert jnp.all(jnp.isfinite(jnp.abs(s_param))), f"S-param for {det_name!r} is not finite"
 
 
 # ---------------------------------------------------------------------------
@@ -611,4 +612,5 @@ class TestCalculateSparamsWrapper:
     def test_s_params_are_finite(self, sparams_wrapper_result):
         result, _states, _objs = sparams_wrapper_result
         for (det_name, _), s_param in result.items():
-            assert jnp.isfinite(jnp.abs(s_param)), f"S-param for {det_name!r} is not finite"
+            assert s_param.shape == (1,)
+            assert jnp.all(jnp.isfinite(jnp.abs(s_param))), f"S-param for {det_name!r} is not finite"

--- a/tests/simulation/physics/test_sparams.py
+++ b/tests/simulation/physics/test_sparams.py
@@ -196,7 +196,9 @@ def test_waveguide_sparam_transmission():
 
     for (det_name, src_name), s_param in result.items():
         assert src_name == "source", f"Unexpected source name in key: {src_name!r}"
-        power = float(abs(np.array(s_param)) ** 2)
+        s_param = np.asarray(s_param)
+        assert s_param.shape == (1,)
+        power = float(abs(s_param[0]) ** 2)
         print(f"{power=}")
         assert power > (1.0 - _TOLERANCE) and power <= 1.0001, (
             f"|S({det_name!r}, 'source')|² = {power}, "

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -5,9 +5,9 @@ from unittest.mock import patch
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from tidy3d.constants import C_0
 
 from fdtdx.config import SimulationConfig
+from fdtdx.constants import c
 from fdtdx.core.grid import RectilinearGrid
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.detectors.mode import ModeOverlapDetector
@@ -415,7 +415,8 @@ class TestModeOverlapDetectorComputeOverlapPath:
         )
         config = SimulationConfig(time=1e-12, grid=grid, backend="cpu")
 
-        frequency_center = C_0 / 2.0
+        center_wavelength = 2.0e-6
+        frequency_center = c / center_wavelength
         frequency_width = frequency_center / 3.0
         frequencies = np.linspace(
             frequency_center - frequency_width,

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -3,7 +3,9 @@
 from unittest.mock import patch
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
+from tidy3d.constants import C_0
 
 from fdtdx.config import SimulationConfig
 from fdtdx.core.grid import RectilinearGrid
@@ -132,13 +134,13 @@ class TestModeOverlapDetectorPlaceOnGrid:
         placed = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         assert placed is not None
 
-    def test_multiple_wave_chars_raises_not_implemented(
+    def test_multiple_wave_chars_placement_succeeds(
         self, simulation_config, plane_grid_slice, random_key, two_frequencies
     ):
-        """Multiple wave characters raise NotImplementedError (not yet supported)."""
+        """Multiple wave characters placement succeeds."""
         det = ModeOverlapDetector(wave_characters=two_frequencies, direction="+")
-        with pytest.raises(NotImplementedError):
-            det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        placed = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
+        assert placed is not None
 
 
 class TestModeOverlapDetectorComputeOverlap:
@@ -395,6 +397,77 @@ class TestModeOverlapDetectorComputeOverlap:
 class TestModeOverlapDetectorComputeOverlapPath:
     """Tests for compute_overlap() - the stored-mode path (via aset)."""
 
+    @staticmethod
+    def _layered_waveguide_detector(mode_index, random_key):
+        """Build an asymmetric layered waveguide with frequency-dependent mode ordering.
+
+        The unequal upper and lower high-index layers support higher-order mode
+        families with different dispersion. Their effective-index curves cross
+        over this sweep, so sorting each frequency only by effective index swaps
+        the modes stored at indices 5 and 6.
+        """
+        spacing = 0.1e-6
+        transverse_edges = jnp.arange(-5e-6, 5e-6 + spacing / 2, spacing)
+        grid = RectilinearGrid(
+            x_edges=transverse_edges,
+            y_edges=jnp.asarray([0.0, spacing]),
+            z_edges=transverse_edges,
+        )
+        config = SimulationConfig(time=1e-12, grid=grid, backend="cpu")
+
+        frequency_center = C_0 / 2.0
+        frequency_width = frequency_center / 3.0
+        frequencies = np.linspace(
+            frequency_center - frequency_width,
+            frequency_center + frequency_width,
+            7,
+        )
+        det = ModeOverlapDetector(
+            wave_characters=[WaveCharacter(frequency=float(frequency)) for frequency in frequencies],
+            direction="+",
+            mode_index=mode_index,
+        )
+        det = det.place_on_grid(((0, 100), (0, 1), (0, 100)), config, random_key)
+
+        centers_um = 0.5 * (np.asarray(transverse_edges[:-1]) + np.asarray(transverse_edges[1:])) / 1e-6
+        x, z = np.meshgrid(centers_um, centers_um, indexing="ij")
+        permittivity = np.ones_like(x)
+        permittivity[(np.abs(x) <= 0.75) & (np.abs(z) <= 0.5)] = 4.0
+        permittivity[(np.abs(x) <= 0.75) & (z >= -1.3) & (z <= -0.3)] = 8.0
+        permittivity[(np.abs(x) <= 0.75) & (z >= 0.3) & (z <= 1.1)] = 8.0
+        inv_permittivity = jnp.asarray(1.0 / permittivity, dtype=jnp.float32)[None, :, None, :]
+
+        return det.apply(random_key, inv_permittivity, 1.0)
+
+    @staticmethod
+    def _minimum_consecutive_mode_overlap(det):
+        consecutive_overlaps = []
+        for mode_a, mode_b in zip(det._mode_E[:-1], det._mode_E[1:], strict=True):
+            mode_a = mode_a.ravel()
+            mode_b = mode_b.ravel()
+            overlap = jnp.abs(jnp.vdot(mode_a, mode_b)) / jnp.sqrt(
+                jnp.real(jnp.vdot(mode_a, mode_a)) * jnp.real(jnp.vdot(mode_b, mode_b))
+            )
+            consecutive_overlaps.append(overlap)
+
+        return jnp.min(jnp.asarray(consecutive_overlaps))
+
+    def test_multifrequency_apply_keeps_fundamental_mode_identity(self, random_key):
+        """The real fundamental mode remains continuous across the frequency sweep."""
+        det = self._layered_waveguide_detector(mode_index=0, random_key=random_key)
+
+        assert self._minimum_consecutive_mode_overlap(det) > 0.9
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="ModeOverlapDetector solves each frequency independently and does not track physical mode identity",
+    )
+    def test_multifrequency_apply_tracks_higher_order_mode_identity(self, random_key):
+        """The real higher-order mode requires overlap tracking across frequencies."""
+        det = self._layered_waveguide_detector(mode_index=5, random_key=random_key)
+
+        assert self._minimum_consecutive_mode_overlap(det) > 0.9
+
     def test_compute_overlap_without_apply_raises(
         self, single_frequency, simulation_config, plane_grid_slice, random_key
     ):
@@ -421,21 +494,23 @@ class TestModeOverlapDetectorComputeOverlapPath:
         det = ModeOverlapDetector(wave_characters=single_frequency, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
 
-        # Manually set mode fields (simulating what apply() would do)
-        mode_E = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64) * 0.5
-        mode_H = jnp.ones((3, 8, 8, 1), dtype=jnp.complex64) * 0.5
+        # Manually set mode fields (simulating what apply() would do).
+        # Shape is (N, 3, *spatial) where N=len(wave_characters)=1.
+        mode_E = jnp.ones((1, 3, 8, 8, 1), dtype=jnp.complex64) * 0.5
+        mode_H = jnp.ones((1, 3, 8, 8, 1), dtype=jnp.complex64) * 0.5
         det = det.aset("_mode_E", mode_E, create_new_ok=True)
         det = det.aset("_mode_H", mode_H, create_new_ok=True)
 
         state = det.init_state()
         state = det.update(jnp.array(0), constant_E_field, constant_H_field, state, inv_permittivity, inv_permeability)
 
-        # compute_overlap() should work and give same result as compute_overlap_to_mode()
+        # compute_overlap() returns (N,); compute_overlap_to_mode returns a scalar.
         result_stored = det.compute_overlap(state=state)
-        result_explicit = det.compute_overlap_to_mode(state=state, mode_E=mode_E, mode_H=mode_H)
+        result_explicit = det.compute_overlap_to_mode(state=state, mode_E=mode_E[0], mode_H=mode_H[0])
 
         assert jnp.iscomplexobj(result_stored)
-        assert jnp.isclose(result_stored, result_explicit)
+        assert result_stored.shape == (1,)
+        assert jnp.isclose(result_stored[0], result_explicit)
 
 
 class TestModeOverlapDetectorBentWaveguide:


### PR DESCRIPTION
Partially addresses https://github.com/ymahlau/fdtdx/issues/330

- ModeOverlapDetector.apply() now computes and stores reference mode fields for every wave_character.

**Breaking changes:**
- compute_overlap() now returns a complex array with shape (num_freqs,).
- calculate_sparam() / calculate_sparams() now expose S-parameter values as frequency-indexed arrays. Existing single-frequency setups return shape (1,).

- Added real mode-solver tests for frequency-dependent mode ordering:
    - Fundamental mode continuity passes.
    - A higher-order asymmetric layered-waveguide case is marked strict xfail because physical mode identity can swap when modes are independently sorted by effective index.
    - Reference example: https://docs.flexcompute.com/projects/tidy3d/en/v2.8.3/notebooks/ModeSolver.html#Mode-tracking
- Updated S-parameter tests to treat results as arrays instead of scalars.

TODO: future PR to track mode overlap across frequencies to prevent mode crossing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mode overlap detector now supports broadband (multi-frequency) overlap, returning one overlap coefficient per frequency, and placement succeeds with multiple wave characters.
* **Documentation**
  * Clarified S-parameter return descriptions and broadband mode-overlap expectations.
* **Tests**
  * Updated S-parameter tests to verify finiteness and exact 1-element shapes.
  * Expanded mode detector tests to cover multi-frequency mode continuity across the sweep (including an xfail for higher-order identity tracking).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->