### PR TITLE
Small fix: Add symmetry helper functions to api.rst

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run tests
-        run: uv run python -m pytest tests -m "unit or integration" --cov --cov-branch --cov-config=pyproject.toml --cov-report=xml
+        run: uv run python -m pytest tests -m "unit or integration or docs" --cov --cov-branch --cov-config=pyproject.toml --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ uv run python -m pytest tests
 ```bash
 uv run python -m pytest tests -m unit
 uv run python -m pytest tests -m integration
+uv run python -m pytest tests -m docs
 uv run python -m pytest tests -m simulation
 ```
 
@@ -33,7 +34,7 @@ uv run python -m pytest tests/unit/test_example.py::test_name
 
 ### Run tests with coverage (as CI does)
 ```bash
-uv run python -m pytest tests -m "unit or integration" --cov --cov-branch --cov-config=pyproject.toml --cov-report=xml
+uv run python -m pytest tests -m "unit or integration or docs" --cov --cov-branch --cov-config=pyproject.toml --cov-report=xml
 ```
 
 ### Lint and format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-For a detailed guide how to contribute code to this repository, look at the guide [here](https://fdtdx.readthedocs.io/en/latest/contributing.html)
+For a detailed guide how to contribute code to this repository, look at the guide [here](https://fdtdx.readthedocs.io/en/latest/05_contributing.html)

--- a/docs/source/05_contributing.rst
+++ b/docs/source/05_contributing.rst
@@ -50,7 +50,6 @@ This is a checklist that you should go through before making a PR. The individua
 * [ ] Implement your feature and unit tests for your new feature
 * [ ] Check if all unit tests run: ``pytest tests/``
 * [ ] Check if all pre-commit checks are passing: ``uv run pre-commit run --all``
-* [ ] Add an entry of your changes / fixes / new features to the ``changelog.md`` file
 * [ ] If you added any new features, that should be top-level imported, add them to ``__all__`` in ``src/fdtdx/__init__.py``
 * [ ] If you want your new feature to be present in the documentation, add an entry to ``docs/source/api.rst``
 * [ ] Optional: If you want to go above and beyond, add a notebook showcasing your feature in the `notebooks repository <https://github.com/ymahlau/fdtdx-notebooks/>`__. Afterwards you can add an entry in the docs to include your new notebook.

--- a/docs/source/07_api.rst
+++ b/docs/source/07_api.rst
@@ -116,6 +116,10 @@ API
     fdtdx.TanhProjection
     fdtdx.TemporalProfile
     fdtdx.TreeClass
+    fdtdx.unfold_array
+    fdtdx.unfold_detector_states
+    fdtdx.unfold_fields
+    fdtdx.unfold_source_mode
     fdtdx.UniformGrid
     fdtdx.UniformMaterialObject
     fdtdx.UniformPlaneSource

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ testpaths = ["tests"]
 markers = [
     "unit: marks tests as unit tests (deselect with '-m \"not unit\"')",
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
+    "docs: marks tests as docs tests (deselect with '-m \"not docs\"')",
     "simulation: marks tests as simulation tests",
 ]
 

--- a/tests/docs/conftest.py
+++ b/tests/docs/conftest.py
@@ -1,0 +1,17 @@
+"""Pytest configuration for docs tests.
+
+All tests in this directory are automatically marked as docs tests.
+Run only docs tests with: pytest -m docs
+Run all tests except docs tests with: pytest -m "not docs"
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    """Automatically mark all tests in the docs folder with the 'docs' marker."""
+    for item in items:
+        if "docs" in Path(str(item.fspath)).parts:
+            item.add_marker(pytest.mark.docs)


### PR DESCRIPTION
Tiny doc fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- Updated the contributing guide link to the newest ReadTheDocs page.
- Expanded API documentation with additional `fdtdx` entries: `unfold_array`, `unfold_detector_states`, `unfold_fields`, and `unfold_source_mode`.

## Tests
- Added support for a `docs` pytest marker and auto-tagging of documentation tests for consistent `-m docs` / `-m "not docs"` runs.

## CI
- Broadened the CI “Run tests” selection to include documentation tests, while keeping coverage collection and reporting unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->