### PR TITLE
Fix: nonuniform PML staggered profile

### DIFF
--- a/src/fdtdx/objects/boundaries/perfectly_matched_layer.py
+++ b/src/fdtdx/objects/boundaries/perfectly_matched_layer.py
@@ -198,16 +198,15 @@ class PerfectlyMatchedLayer(BaseBoundary):
         norm = float(edges[-1] - edges[0])
         centers = 0.5 * (edges[:-1] + edges[1:])
 
+        zero = jnp.asarray(0.0, dtype=dtype)
         if self.direction == "-":
             interface = edges[-1]
             dE = interface - edges[1:]
-            dH = interface - centers
-            dH = dH.at[-1].set(0)
+            dH = jnp.concatenate([interface - centers[1:], zero.reshape(1)])
         else:
             interface = edges[0]
-            dE = edges[:-1] - interface
-            dH = centers - interface
-            dH = dH.at[0].set(0)
+            dE = jnp.concatenate([zero.reshape(1), centers[:-1] - interface])
+            dH = edges[:-1] - interface
 
         return dE, dH, norm
 

--- a/tests/unit/objects/boundaries/test_perfectly_matched_layer.py
+++ b/tests/unit/objects/boundaries/test_perfectly_matched_layer.py
@@ -256,6 +256,30 @@ class TestPMLComputeProfile:
         assert jnp.allclose(profileE[:, 0, 0], jnp.asarray([5 / 6, 3 / 6, 0.0], dtype=jnp.float32))
         assert float(profileH[-1, 0, 0]) == 0.0
 
+    @pytest.mark.parametrize("direction", ["-", "+"])
+    def test_nonuniform_profile_matches_uniform_limit_on_uniform_axis(self, jax_key, direction):
+        """A uniform PML axis must keep the historical staggered profile."""
+        thickness = 4
+        volume_shape = (8, 1, 1)
+        uniform_config = SimulationConfig(time=100e-15, grid=UniformGrid(spacing=1.0), backend="cpu", dtype=jnp.float32)
+        nonuniform_grid = RectilinearGrid(
+            x_edges=jnp.arange(volume_shape[0] + 1, dtype=jnp.float32),
+            y_edges=jnp.asarray([0.0, 1.01], dtype=jnp.float32),
+            z_edges=jnp.asarray([0.0, 1.0], dtype=jnp.float32),
+        )
+        nonuniform_config = SimulationConfig(time=100e-15, grid=nonuniform_grid, backend="cpu", dtype=jnp.float32)
+
+        uniform_pml = make_pml(axis=0, direction=direction, thickness=thickness, sigma_end=1.0)
+        nonuniform_pml = make_pml(axis=0, direction=direction, thickness=thickness, sigma_end=1.0)
+        uniform_placed = place_pml(uniform_pml, uniform_config, jax_key, volume_shape=volume_shape)
+        nonuniform_placed = place_pml(nonuniform_pml, nonuniform_config, jax_key, volume_shape=volume_shape)
+
+        uniform_E, uniform_H = uniform_placed._compute_pml_profile(0.0, 1.0, 1.0, jnp.float32)
+        nonuniform_E, nonuniform_H = nonuniform_placed._compute_pml_profile(0.0, 1.0, 1.0, jnp.float32)
+
+        assert jnp.allclose(nonuniform_E[:, 0, 0], uniform_E[:, 0, 0])
+        assert jnp.allclose(nonuniform_H[:, 0, 0], uniform_H[:, 0, 0])
+
     def test_nonuniform_sigma_end_uses_physical_thickness(self, jax_key):
         """Default sigma_end is based on physical PML thickness from grid edges."""
         grid = RectilinearGrid(


### PR DESCRIPTION
## Summary

Fixes a bug in the nonuniform-grid PML profile calculation.

For a `RectilinearGrid` whose PML axis is uniformly spaced, the nonuniform-grid PML path should reduce to the same Yee-staggered E/H profile as `UniformGrid`. The previous implementation used inconsistent center/edge offsets, shifting the E and H PML depth profiles.

This PR updates the nonuniform PML depth calculation to match the uniform-grid staggering convention, and adds a regression test covering both `-` and `+` PML directions.

In a local point-source validation case, the angular-distribution error relative to the analytic reference decreased from about `0.038` to `0.001`, bringing the FDTDX result into close agreement with the corresponding Tidy3D reference.

## Tests

Added:

- Regression test verifying that nonuniform-grid PML profiles match `UniformGrid` profiles on a uniformly spaced axis.

Passed:

- `uv run pre-commit run -a --show-diff-on-failure`
- `sh docs/scripts/sync_notebooks.sh && uv run sphinx-build -W --keep-going docs/source/ docs/build/`
- `uv sync --locked`
- Full local pytest coverage:
  - `2441 passed`
  - `1 xfailed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of PML depth profiles at the interface so edge values are built more consistently across directions.
  * Fixed nonuniform-axis profile calculations to better match the expected uniform-grid behavior.

* **Tests**
  * Added coverage to verify nonuniform PML profiles match the uniform limit on the uniform axis for both directions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->