### PR TITLE
Modes for 2D simulations and etched devices

### DIFF
--- a/docs/source/07_api.rst
+++ b/docs/source/07_api.rst
@@ -20,6 +20,7 @@ API
     fdtdx.compute_energy
     fdtdx.compute_eps_spectrum_from_coefficients
     fdtdx.compute_impedance_corrected_temporal_profile
+    fdtdx.compute_integrated_power
     fdtdx.compute_mode
     fdtdx.compute_pole_coefficients
     fdtdx.compute_poynting_flux

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -26,6 +26,7 @@ from fdtdx.core.jax.pytrees import (
 from fdtdx.core.physics.losses import metric_efficiency
 from fdtdx.core.physics.metrics import (
     compute_energy,
+    compute_integrated_power,
     compute_poynting_flux,
     normalize_by_energy,
     normalize_by_poynting_flux,
@@ -238,6 +239,7 @@ __all__ = [
     "compute_energy",
     "compute_eps_spectrum_from_coefficients",
     "compute_impedance_corrected_temporal_profile",
+    "compute_integrated_power",
     "compute_mode",
     "compute_pole_coefficients",
     "compute_poynting_flux",

--- a/src/fdtdx/conversion/vti.py
+++ b/src/fdtdx/conversion/vti.py
@@ -184,7 +184,7 @@ def export_vti(
         f.write(b"\n</AppendedData>\n</VTKFile>")
 
 
-def _validate_vtk_cell_data(cell_data: dict[str, jax.Array]) -> tuple[int, int, int]:
+def _validate_vtk_cell_data(cell_data: dict[str, jax.Array]) -> tuple[int, ...]:
     """Validate common VTK cell-data constraints and return spatial shape."""
     shape = next(iter(cell_data.values())).shape[-3:]
     if not all(a.shape[-3:] == shape for a in cell_data.values()):

--- a/src/fdtdx/core/grid.py
+++ b/src/fdtdx/core/grid.py
@@ -554,6 +554,18 @@ class RectilinearGrid(TreeClass):
             self.axis_extent(2, slice_tuple[2]),
         )
 
+    def subgrid(
+        self,
+        grid_slice: tuple[slice, slice, slice],
+    ):
+        """Convenience wrapper to get the sub-grid of a placed fdtdx.SimulationObject given its grid_slice"""
+        subgrid = self.custom(
+            self.x_edges[slice(grid_slice[0].start, grid_slice[0].stop + 1)],
+            self.y_edges[slice(grid_slice[1].start, grid_slice[1].stop + 1)],
+            self.z_edges[slice(grid_slice[2].start, grid_slice[2].stop + 1)],
+        )
+        return subgrid
+
     def coord_to_index(self, axis: int, coord: float, snap: str = "nearest") -> int:
         """Map a physical coordinate to a grid edge index.
 

--- a/src/fdtdx/core/physics/metrics.py
+++ b/src/fdtdx/core/physics/metrics.py
@@ -117,6 +117,36 @@ def compute_poynting_flux(E: jax.Array, H: jax.Array, axis: int = 0) -> jax.Arra
     )
 
 
+def compute_integrated_power(
+    E: jax.Array,
+    H: jax.Array,
+    axis: int,
+    area_weights: jax.Array | None = None,
+) -> jax.Array:
+    """Computes the integrated power (Poynting flux) across a transverse plane.
+
+    Args:
+        E (jax.Array): Electric field array with component axis first.
+        H (jax.Array): Magnetic field array with component axis first.
+        axis (int): Physical propagation axis whose Poynting component is integrated.
+        area_weights (jax.Array | None, optional): Optional detector-plane area weights
+            broadcastable to ``E[axis]``. Defaults to None.
+
+    Returns:
+        jax.Array: The absolute integrated power.
+    """
+    # Compute Poynting vector components
+    S_complex = jnp.cross(jnp.conj(E), H, axisa=0, axisb=0, axisc=0)
+    S_real = 0.5 * jnp.real(S_complex[axis])  # power flow in desired direction
+
+    if area_weights is not None:
+        S_real = S_real * area_weights
+
+    # Integrate over transverse plane (axis orthogonal to `axis`)
+    power = jnp.abs(jnp.sum(S_real))
+    return power
+
+
 def normalize_by_poynting_flux(
     E: jax.Array,
     H: jax.Array,
@@ -126,27 +156,24 @@ def normalize_by_poynting_flux(
     """Normalize fields so the integrated Poynting flux along ``axis`` is one.
 
     Args:
-        E: Electric field array with component axis first.
-        H: Magnetic field array with component axis first.
-        axis: Physical propagation axis whose Poynting component is integrated.
-        area_weights: Optional detector-plane area weights broadcastable to
-            ``E[axis]``.  Uniform-grid callers may omit this for the historical
-            raw-sum normalization; non-uniform callers should provide weights so
-            refinement alone does not change the normalization.
-    """
-    # Compute Poynting vector components
-    S_complex = jnp.cross(jnp.conj(E), H, axisa=0, axisb=0, axisc=0)
-    S_real = 0.5 * jnp.real(S_complex[axis])  # power flow in desired direction
-    if area_weights is not None:
-        S_real = S_real * area_weights
+        E (jax.Array): Electric field array with component axis first.
+        H (jax.Array): Magnetic field array with component axis first.
+        axis (int): Physical propagation axis whose Poynting component is integrated.
+        area_weights (jax.Array | None, optional): Optional detector-plane area weights
+            broadcastable to ``E[axis]``. Uniform-grid callers may omit this for the
+            historical raw-sum normalization; non-uniform callers should provide weights
+            so refinement alone does not change the normalization.
 
-    # Integrate over transverse plane (axis orthogonal to `axis`)
-    power = jnp.abs(jnp.sum(S_real))
+    Returns:
+        tuple[jax.Array, jax.Array]: Tuple of (normalized E field, normalized H field)
+    """
+    power = compute_integrated_power(E, H, axis, area_weights)
 
     # Normalize
     norm_factor = jnp.sqrt(power)
     E_norm = E / norm_factor
     H_norm = H / norm_factor
+
     return E_norm, H_norm
 
 

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -167,8 +167,25 @@ def compute_mode(
     np_complex_dtype = np.complex128 if dtype == jnp.float64 else np.complex64
 
     def mode_helper(permittivity, permeability, c0_um, c1_um):
-        # c0_um, c1_um are concrete numpy arrays here (materialised by pure_callback)
         coords = [np.asarray(c0_um), np.asarray(c1_um)]
+
+        # Implicitly detect 2D mode if any transverse dimension is exactly 2
+        mode_2d = 2 in permittivity.shape[1:]  # permittivity.shape=(N_comp, dim1, dim2)
+
+        if mode_2d:
+            collapsed_axis = permittivity.shape[1:].index(2)
+            sl = (slice(None), slice(None), [0]) if collapsed_axis == 1 else (slice(None), [0], slice(None))
+
+            assert np.allclose(permittivity, permittivity[sl]), "Permittivity is not uniform across the collapsed axis!"
+            assert len(coords[collapsed_axis]) == 3, f"Assumption: Permittivity {permittivity.shape[1:]=}+1 matches ({coords[0].shape=}, {coords[1].shape})"
+            permittivity = permittivity[sl]
+
+            if isinstance(permeability, np.ndarray) and permeability.ndim > 0:
+                permeability = permeability[sl]
+
+            # Adjust coordinates for the collapsed dimension
+            coords[collapsed_axis] = coords[collapsed_axis][:2]
+
         if bend_radius is not None:
             assert bend_axis is not None
             transverse_axes = get_transverse_axes(propagation_axis)
@@ -214,6 +231,13 @@ def compute_mode(
             )
         else:
             raise Exception("This should never happen")
+
+        if mode_2d:
+            # Re-expand the collapsed dimension
+            # Axis is shifted by 1 because stack adds the vector components to axis 0.
+            import ipdb; ipdb.set_trace()
+            mode_E = np.repeat(mode_E, 2, axis=collapsed_axis + 1)
+            mode_H = np.repeat(mode_H, 2, axis=collapsed_axis + 1)
 
         neff = np.asarray(mode.neff).astype(np_complex_dtype)
         return mode_E, mode_H, neff

--- a/src/fdtdx/core/physics/modes.py
+++ b/src/fdtdx/core/physics/modes.py
@@ -177,7 +177,9 @@ def compute_mode(
             sl = (slice(None), slice(None), [0]) if collapsed_axis == 1 else (slice(None), [0], slice(None))
 
             assert np.allclose(permittivity, permittivity[sl]), "Permittivity is not uniform across the collapsed axis!"
-            assert len(coords[collapsed_axis]) == 3, f"Assumption: Permittivity {permittivity.shape[1:]=}+1 matches ({coords[0].shape=}, {coords[1].shape})"
+            assert len(coords[collapsed_axis]) == 3, (
+                f"Assumption: Permittivity {permittivity.shape[1:]=}+1 matches ({coords[0].shape=}, {coords[1].shape})"
+            )
             permittivity = permittivity[sl]
 
             if isinstance(permeability, np.ndarray) and permeability.ndim > 0:
@@ -234,9 +236,10 @@ def compute_mode(
 
         if mode_2d:
             # Re-expand the collapsed dimension
-            # Axis is shifted by 1 because stack adds the vector components to axis 0.
-            import ipdb; ipdb.set_trace()
+            mode_E = np.expand_dims(mode_E, axis=collapsed_axis + 1)
             mode_E = np.repeat(mode_E, 2, axis=collapsed_axis + 1)
+
+            mode_H = np.expand_dims(mode_H, axis=collapsed_axis + 1)
             mode_H = np.repeat(mode_H, 2, axis=collapsed_axis + 1)
 
         neff = np.asarray(mode.neff).astype(np_complex_dtype)

--- a/src/fdtdx/fdtd/container.py
+++ b/src/fdtdx/fdtd/container.py
@@ -370,6 +370,10 @@ class ArrayContainer(TreeClass):
     #: Shape ``(num_poles, 1, Nx, Ny, Nz)``. ``None`` for non-dispersive simulations.
     dispersive_inv_c2: jax.Array | None = None
 
+    #: Backup of inverse permittivity values array.
+    #: Only used when etching a device.
+    initial_inv_permittivities: jax.Array | None = None
+
     def reset(
         self,
         reset_detector_states: bool = True,

--- a/src/fdtdx/fdtd/fdtd.py
+++ b/src/fdtdx/fdtd/fdtd.py
@@ -143,6 +143,7 @@ def reversible_fdtd(
             dispersive_c2=dispersive_c2,
             dispersive_c3=dispersive_c3,
             dispersive_inv_c2=arrays.dispersive_inv_c2,
+            initial_inv_permittivities=arrays.initial_inv_permittivities,
         )
         state = reversible_fdtd_base(arr)
         return (
@@ -262,6 +263,7 @@ def reversible_fdtd(
             dispersive_c2=res_dispersive_c2,
             dispersive_c3=res_dispersive_c3,
             dispersive_inv_c2=arrays.dispersive_inv_c2,
+            initial_inv_permittivities=arrays.initial_inv_permittivities,
         )
 
         _, cot = eqxi.while_loop(
@@ -324,6 +326,7 @@ def reversible_fdtd(
             dispersive_c2=dispersive_c2,
             dispersive_c3=dispersive_c3,
             dispersive_inv_c2=arrays.dispersive_inv_c2,
+            initial_inv_permittivities=arrays.initial_inv_permittivities,
         )
         s_k = reversible_fdtd_base(arr)
 
@@ -406,6 +409,7 @@ def reversible_fdtd(
         dispersive_c2=dispersive_c2,
         dispersive_c3=dispersive_c3,
         dispersive_inv_c2=arrays.dispersive_inv_c2,
+        initial_inv_permittivities=arrays.initial_inv_permittivities,
     )
     return time_step, out_arrs
 

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -202,14 +202,32 @@ def place_objects(
     )
 
     # Step 10: Initialize parameters and arrays
-    params = _init_params(objects=objects_container, key=key)
+    key, subkey = jax.random.split(key)
+    params = _init_params(objects=objects_container, key=subkey)
     arrays, config, info = _init_arrays(objects=objects_container, config=config)
 
-    # Step 11: Update object configs with compiled configuration
+    # Step 11: Update object configs and apply objects if possible
+    disp_c1 = None if arrays.dispersive_c1 is None else jax.lax.stop_gradient(arrays.dispersive_c1)
+    disp_c2 = None if arrays.dispersive_c2 is None else jax.lax.stop_gradient(arrays.dispersive_c2)
+    disp_c3 = None if arrays.dispersive_c3 is None else jax.lax.stop_gradient(arrays.dispersive_c3)
     new_object_list = []
-    for o in objects_container.objects:
-        o = o.aset("_config", config)
-        new_object_list.append(o)
+    devices = objects_container.devices
+    for obj in objects_container.objects:
+        # Update object configs with compiled configuration
+        obj = obj.aset("_config", config)
+
+        # Apply objects which do not depend on any devices
+        if not any([d.check_overlap(obj) for d in devices]):
+            key, subkey = jax.random.split(key)
+            obj = obj.apply(
+                key=subkey,
+                inv_permittivities=jax.lax.stop_gradient(arrays.inv_permittivities),
+                inv_permeabilities=jax.lax.stop_gradient(arrays.inv_permeabilities),
+                dispersive_c1=disp_c1,
+                dispersive_c2=disp_c2,
+                dispersive_c3=disp_c3,
+            )
+        new_object_list.append(obj)
 
     objects_container = ObjectContainer(
         object_list=new_object_list,
@@ -367,17 +385,20 @@ def apply_params(
     disp_c2 = None if arrays.dispersive_c2 is None else jax.lax.stop_gradient(arrays.dispersive_c2)
     disp_c3 = None if arrays.dispersive_c3 is None else jax.lax.stop_gradient(arrays.dispersive_c3)
     new_objects = []
+    devices = objects.devices
     for obj in objects.object_list:
-        key, subkey = jax.random.split(key)
-        new_obj = obj.apply(
-            key=subkey,
-            inv_permittivities=jax.lax.stop_gradient(arrays.inv_permittivities),
-            inv_permeabilities=jax.lax.stop_gradient(arrays.inv_permeabilities),
-            dispersive_c1=disp_c1,
-            dispersive_c2=disp_c2,
-            dispersive_c3=disp_c3,
-        )
-        new_objects.append(new_obj)
+        # Only need to apply objects that overlap with devices, the others were applied in place_objects
+        if any([d.check_overlap(obj) for d in devices]):
+            key, subkey = jax.random.split(key)
+            obj = obj.apply(
+                key=subkey,
+                inv_permittivities=jax.lax.stop_gradient(arrays.inv_permittivities),
+                inv_permeabilities=jax.lax.stop_gradient(arrays.inv_permeabilities),
+                dispersive_c1=disp_c1,
+                dispersive_c2=disp_c2,
+                dispersive_c3=disp_c3,
+            )
+        new_objects.append(obj)
     new_objects = ObjectContainer(
         object_list=new_objects,
         volume_idx=objects.volume_idx,

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -250,6 +250,9 @@ def apply_params(
 
     num_dispersive_poles = arrays.dispersive_c1.shape[0] if arrays.dispersive_c1 is not None else 0
 
+    if arrays.initial_inv_permittivities is not None:
+        arrays = arrays.at["inv_permittivities"].set(arrays.initial_inv_permittivities)
+
     # apply parameter to devices
     for device in objects.devices:
         cur_material_indices = device(params[device.name], expand_to_sim_grid=True, **transform_kwargs)
@@ -261,11 +264,6 @@ def apply_params(
                 diagonally_anisotropic=diagonally_anisotropic,
             )
         )  # shape: (num_materials, num_components)
-        if isotropic or diagonally_anisotropic:
-            inv_allowed = 1.0 / allowed_perm_array  # (num_materials, num_components)
-        else:
-            # Fully anisotropic: reshape to 3x3 matrix, invert, and flatten back to 9 elements
-            inv_allowed = jnp.array([jnp.linalg.inv(perm.reshape(3, 3)).flatten() for perm in allowed_perm_array])
 
         # When any object in the sim is dispersive (num_dispersive_poles > 0) we
         # always write the coefficient stack into the device's grid_slice — even
@@ -295,19 +293,41 @@ def apply_params(
             allowed_c3_arr = jnp.asarray(allowed_c3_np, dtype=arrays.dispersive_c3.dtype)
 
         if device.output_type == ParameterType.CONTINUOUS:
-            # Linear interpolation between two materials
+            # Linear interpolation between two materials via their permittivities
             # Add spatial broadcast dims for element-wise multiplication
-            inv_allowed_bc = inv_allowed[:, :, None, None, None]
+            perm_bc = allowed_perm_array[:, :, None, None, None]
             # cur_material_indices: (*grid_shape) broadcasts with (num_components, 1, 1, 1)
-            new_perm_slice = (1 - cur_material_indices) * inv_allowed_bc[0] + cur_material_indices * inv_allowed_bc[1]
+            if device.use_etching:
+                old_inv_perm_slice = arrays.inv_permittivities[:, *device.grid_slice]
+
+                # Invert inv_permittivites back to permittivities.
+                # When using a single etched device, the outcome is static
+                if isotropic or diagonally_anisotropic:
+                    old_perm_slice = 1 / old_inv_perm_slice
+                else:
+                    grid_shape = old_inv_perm_slice.shape[1:]
+                    mat_slice = jnp.moveaxis(old_inv_perm_slice.reshape(3, 3, *grid_shape), (0, 1), (-2, -1))
+                    inv_mat_slice = jnp.linalg.inv(mat_slice) # Inverts over the last two dimensions
+                    old_perm_slice = jnp.moveaxis(inv_mat_slice, (-2, -1), (0, 1)).reshape(9, *grid_shape)
+
+                interp_perm = (1 - cur_material_indices) * old_perm_slice + cur_material_indices * perm_bc[0]
+            else:
+                interp_perm = (1 - cur_material_indices) * perm_bc[0] + cur_material_indices * perm_bc[1]
+
+            # Compute inverse permittivities from the interpolated actual permittivities
+            if isotropic or diagonally_anisotropic:
+                new_inv_perm_slice = 1.0 / interp_perm
+            else:
+                # Fully anisotropic: interp_perm shape is (9, Nx, Ny, Nz)
+                # Reshape and move spatial axes to invert the 3x3 matrix at each voxel via jnp.linalg.inv
+                grid_shape = interp_perm.shape[1:]
+                mat_slice = jnp.moveaxis(interp_perm.reshape(3, 3, *grid_shape), (0, 1), (-2, -1))
+                inv_mat_slice = jnp.linalg.inv(mat_slice) # Inverts over the last two dimensions
+                new_inv_perm_slice = jnp.moveaxis(inv_mat_slice, (-2, -1), (0, 1)).reshape(9, *grid_shape)
+
             if write_dispersive:
                 assert allowed_c1_arr is not None and allowed_c2_arr is not None and allowed_c3_arr is not None
                 # Linear interpolation of dispersive coefficients between the two bracketing materials.
-                # Note: this follows the same straight-through-estimator convention as the
-                # permittivity path above — it is *not* equivalent to a material whose
-                # epsilon and poles are linearly interpolated, but it is the same
-                # continuous relaxation used for inv_permittivities, so gradients still
-                # flow smoothly through the device parameters during inverse design.
                 # allowed_cN_arr: (num_materials, num_poles) — here num_materials == 2.
                 # reshape to (num_poles, 1, 1, 1, 1) for broadcast over (num_poles, 1, Nx, Ny, Nz)
                 w0 = (1 - cur_material_indices)[None, None, ...]  # (1, 1, Nx, Ny, Nz)
@@ -323,10 +343,17 @@ def apply_params(
                 new_c3_slice = w0 * c3_0 + w1 * c3_1
         else:
             # Discrete material selection
+            # Precompute inverse permittivities since the selection result is binary
+            if isotropic or diagonally_anisotropic:
+                inv_allowed = 1.0 / allowed_perm_array  # (num_materials, num_components)
+            else:
+                # Fully anisotropic: reshape to 3x3 matrix, invert, and flatten back to 9 elements
+                inv_allowed = jnp.array([jnp.linalg.inv(perm.reshape(3, 3)).flatten() for perm in allowed_perm_array])
+                
             # inv_allowed[indices] -> (*grid_shape, num_components), then moveaxis -> (num_components, *grid_shape)
             component_values = jnp.moveaxis(inv_allowed[cur_material_indices.astype(jnp.int32)], -1, 0)
-            component_values = straight_through_estimator(cur_material_indices, component_values)
-            new_perm_slice = component_values
+            new_inv_perm_slice = straight_through_estimator(cur_material_indices, component_values)
+            
             if write_dispersive:
                 assert allowed_c1_arr is not None and allowed_c2_arr is not None and allowed_c3_arr is not None
                 int_idx = cur_material_indices.astype(jnp.int32)
@@ -336,8 +363,8 @@ def apply_params(
                 new_c3_slice = jnp.moveaxis(allowed_c3_arr[int_idx], -1, 0)[:, None, ...]
 
         # Update all components of inv_permittivities array at once
-        new_perm = arrays.inv_permittivities.at[:, *device.grid_slice].set(new_perm_slice)
-        arrays = arrays.at["inv_permittivities"].set(new_perm)
+        new_inv_perm = arrays.inv_permittivities.at[:, *device.grid_slice].set(new_inv_perm_slice)
+        arrays = arrays.at["inv_permittivities"].set(new_inv_perm)
 
         if write_dispersive:
             assert (
@@ -895,6 +922,10 @@ def _init_arrays(
     dispersive_inv_c2 = None
     if dispersive_c2 is not None:
         dispersive_inv_c2 = jnp.where(dispersive_c2 == 0, 0.0, 1.0 / dispersive_c2)
+    
+    # Save backup of initial inv_permittivities when using etched_devices
+    using_etching = any(d.use_etching for d in objects.devices)
+    initial_inv_permittivities = jnp.copy(inv_permittivities) if using_etching else None
 
     arrays = ArrayContainer(
         fields=FieldState(E=E, H=H, psi_E=psi_E, psi_H=psi_H),
@@ -913,6 +944,7 @@ def _init_arrays(
         dispersive_c2=dispersive_c2,
         dispersive_c3=dispersive_c3,
         dispersive_inv_c2=dispersive_inv_c2,
+        initial_inv_permittivities=initial_inv_permittivities,
     )
     return arrays, config, info
 

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -378,11 +378,11 @@ def apply_params(
             else:
                 # Fully anisotropic: reshape to 3x3 matrix, invert, and flatten back to 9 elements
                 inv_allowed = jnp.array([jnp.linalg.inv(perm.reshape(3, 3)).flatten() for perm in allowed_perm_array])
-                
+
             # inv_allowed[indices] -> (*grid_shape, num_components), then moveaxis -> (num_components, *grid_shape)
             component_values = jnp.moveaxis(inv_allowed[cur_material_indices.astype(jnp.int32)], -1, 0)
             new_inv_perm_slice = straight_through_estimator(cur_material_indices, component_values)
-            
+
             if write_dispersive:
                 assert allowed_c1_arr is not None and allowed_c2_arr is not None and allowed_c3_arr is not None
                 int_idx = cur_material_indices.astype(jnp.int32)
@@ -945,7 +945,7 @@ def _init_arrays(
     dispersive_inv_c2 = None
     if dispersive_c2 is not None:
         dispersive_inv_c2 = jnp.where(dispersive_c2 == 0, 0.0, 1.0 / dispersive_c2)
-    
+
     # Save backup of initial inv_permittivities when using etched_devices
     using_etching = any(d.use_etching for d in objects.devices)
     initial_inv_permittivities = jnp.copy(inv_permittivities) if using_etching else None
@@ -1912,7 +1912,9 @@ def _handle_unresolved_objects(
 def _invert_property(arr: jax.Array):
     """Inverts a property array, e.g. inv_permittivities of shape (num_comp, *grid_shape)."""
     num_components = arr.shape[0]
-    assert arr.ndim == 4 and num_components in [1, 3, 9], f"Expecting shape (num_comp, *grid_shape), got shape {arr.shape}"
+    assert arr.ndim == 4 and num_components in [1, 3, 9], (
+        f"Expecting shape (num_comp, *grid_shape), got shape {arr.shape}"
+    )
 
     if num_components in (1, 3):
         return 1.0 / arr

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -296,34 +296,16 @@ def apply_params(
             # Linear interpolation between two materials via their permittivities
             # Add spatial broadcast dims for element-wise multiplication
             perm_bc = allowed_perm_array[:, :, None, None, None]
-            # cur_material_indices: (*grid_shape) broadcasts with (num_components, 1, 1, 1)
             if device.use_etching:
-                old_inv_perm_slice = arrays.inv_permittivities[:, *device.grid_slice]
-
-                # Invert inv_permittivites back to permittivities.
-                # When using a single etched device, the outcome is static
-                if isotropic or diagonally_anisotropic:
-                    old_perm_slice = 1 / old_inv_perm_slice
-                else:
-                    grid_shape = old_inv_perm_slice.shape[1:]
-                    mat_slice = jnp.moveaxis(old_inv_perm_slice.reshape(3, 3, *grid_shape), (0, 1), (-2, -1))
-                    inv_mat_slice = jnp.linalg.inv(mat_slice) # Inverts over the last two dimensions
-                    old_perm_slice = jnp.moveaxis(inv_mat_slice, (-2, -1), (0, 1)).reshape(9, *grid_shape)
-
-                interp_perm = (1 - cur_material_indices) * old_perm_slice + cur_material_indices * perm_bc[0]
+                # interpolate between existing background material and etch material
+                perm_slice = _invert_property(arrays.inv_permittivities[:, *device.grid_slice])
+                perm_slice = perm_slice + cur_material_indices * (perm_bc[0] - perm_slice)
             else:
-                interp_perm = (1 - cur_material_indices) * perm_bc[0] + cur_material_indices * perm_bc[1]
+                # interpolate between two device materials
+                # cur_material_indices: (*grid_shape) broadcasts with (num_components, 1, 1, 1)
+                perm_slice = perm_bc[0] + cur_material_indices * (perm_bc[1] - perm_bc[0])
 
-            # Compute inverse permittivities from the interpolated actual permittivities
-            if isotropic or diagonally_anisotropic:
-                new_inv_perm_slice = 1.0 / interp_perm
-            else:
-                # Fully anisotropic: interp_perm shape is (9, Nx, Ny, Nz)
-                # Reshape and move spatial axes to invert the 3x3 matrix at each voxel via jnp.linalg.inv
-                grid_shape = interp_perm.shape[1:]
-                mat_slice = jnp.moveaxis(interp_perm.reshape(3, 3, *grid_shape), (0, 1), (-2, -1))
-                inv_mat_slice = jnp.linalg.inv(mat_slice) # Inverts over the last two dimensions
-                new_inv_perm_slice = jnp.moveaxis(inv_mat_slice, (-2, -1), (0, 1)).reshape(9, *grid_shape)
+            new_inv_perm_slice = _invert_property(perm_slice)
 
             if write_dispersive:
                 assert allowed_c1_arr is not None and allowed_c2_arr is not None and allowed_c3_arr is not None
@@ -783,17 +765,15 @@ def _init_arrays(
                     diagonally_anisotropic=diagonally_anisotropic_permittivity,
                 )
             )
-            if num_perm_components == 1 or num_perm_components == 3:
-                allowed_inv_perms = 1 / allowed_perms  # shape: (num_materials, num_components)
-            else:
-                # Fully anisotropic: reshape to 3x3 matrix, invert, and flatten back to 9 elements
-                allowed_inv_perms = jnp.array([jnp.linalg.inv(perm.reshape(3, 3)).flatten() for perm in allowed_perms])
 
-            # allowed_inv_perms[indices] -> (*grid_shape, num_components)
+            # allowed_perms[indices] -> (*grid_shape, num_components)
             # After moveaxis -> (num_components, *grid_shape)
-            component_values = jnp.moveaxis(allowed_inv_perms[indices], -1, 0)
-            diff = component_values - inv_permittivities[:, *o.grid_slice]
-            inv_permittivities = inv_permittivities.at[:, *o.grid_slice].add(mask * diff)
+            component_values = jnp.moveaxis(allowed_perms[indices], -1, 0)
+            perm_slice = _invert_property(inv_permittivities[:, *o.grid_slice])
+
+            # Linearly interpolate in the forward domain
+            perm_slice = perm_slice + mask * (component_values - perm_slice)
+            inv_permittivities = inv_permittivities.at[:, *o.grid_slice].set(_invert_property(perm_slice))
 
             if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
                 allowed_perms = jnp.asarray(
@@ -803,17 +783,12 @@ def _init_arrays(
                         diagonally_anisotropic=diagonally_anisotropic_permeability,
                     )
                 )
-                if num_permeability_components == 1 or num_permeability_components == 3:
-                    allowed_inv_perms = 1 / allowed_perms
-                else:
-                    # Fully anisotropic: reshape to 3x3 matrix, invert, and flatten back to 9 elements
-                    allowed_inv_perms = jnp.array(
-                        [jnp.linalg.inv(perm.reshape(3, 3)).flatten() for perm in allowed_perms]
-                    )
 
-                component_values = jnp.moveaxis(allowed_inv_perms[indices], -1, 0)
-                diff = component_values - inv_permeabilities[:, *o.grid_slice]
-                inv_permeabilities = inv_permeabilities.at[:, *o.grid_slice].add(mask * diff)
+                component_values = jnp.moveaxis(allowed_perms[indices], -1, 0)
+                perm_slice = _invert_property(inv_permeabilities[:, *o.grid_slice])
+
+                perm_slice = perm_slice + mask * (component_values - perm_slice)
+                inv_permeabilities = inv_permeabilities.at[:, *o.grid_slice].set(_invert_property(perm_slice))
 
             if electric_conductivity is not None:
                 allowed_conds = jnp.asarray(
@@ -1856,3 +1831,20 @@ def _handle_unresolved_objects(
         if any([slice_dict[obj_name][a][0] is None or slice_dict[obj_name][a][1] is None for a in range(3)]):
             errors[obj_name] = f"Could not resolve position/size of {obj.name} ({obj.__class__})."
     return errors
+
+
+def _invert_property(arr: jax.Array):
+    """Inverts a property array, e.g. inv_permittivities of shape (num_comp, *grid_shape)."""
+    num_components = arr.shape[0]
+    assert arr.ndim == 4 and num_components in [1, 3, 9], f"Expecting shape (num_comp, *grid_shape), got shape {arr.shape}"
+
+    if num_components in (1, 3):
+        return 1.0 / arr
+    else:
+        # Full tensor inversion: move 9-component axis to the end, reshape, invert, and flatten back
+        arr_reshaped = jnp.moveaxis(arr, 0, -1)
+        spatial_shape = arr_reshaped.shape[:-1]
+        matrices = arr_reshaped.reshape(*spatial_shape, 3, 3)
+        inv_matrices = jnp.linalg.inv(matrices)
+        inv_flattened = inv_matrices.reshape(*spatial_shape, 9)
+        return jnp.moveaxis(inv_flattened, -1, 0)

--- a/src/fdtdx/objects/device/device.py
+++ b/src/fdtdx/objects/device/device.py
@@ -49,6 +49,11 @@ class Device(OrderableObject, ABC):
     #: For all three axes, either the voxel grid or real shape needs to be defined.
     partial_voxel_real_shape: PartialRealShape3D = frozen_field(default=UNDEFINED_SHAPE_3D)
 
+    #: Determines the material placement behavior.
+    #: If False, the device fully populates its defined 3D space using its material permittivities.
+    #: If True, it acts as an etch, either leaving the space unmodified or replacing it with a single material (e.g., air) based on the parameters.
+    use_etching: bool = frozen_field(default=False)
+
     _single_voxel_grid_shape: tuple[int, int, int] = frozen_private_field(default=INVALID_SHAPE_3D)
     _matrix_voxel_grid_shape_override: tuple[int, int, int] = frozen_private_field(default=INVALID_SHAPE_3D)
     _physical_design_voxel_shape: tuple[float, float, float] | None = frozen_private_field(default=None)
@@ -239,11 +244,22 @@ class Device(OrderableObject, ABC):
 
         # set own input shape dtype
         self = self.aset("param_transforms", module_list)
-        if self.output_type == ParameterType.CONTINUOUS and len(self.materials) != 2:
-            raise Exception(
-                f"Need exactly two materials in device when parameter mapping outputs continuous permittivity indices, "
-                f"but got {self.materials}"
-            )
+        if self.output_type == ParameterType.CONTINUOUS:
+            if self.use_etching:
+                if len(self.materials) != 1:
+                    raise Exception(
+                        f"Need exactly one material in etched device when parameter mapping outputs continuous permittivity indices"
+                        f"which replaces the eroded original materials, but got {self.materials}"
+                )
+            else:
+                if len(self.materials) != 2:
+                    raise Exception(
+                        f"Need exactly two materials in device when parameter mapping outputs continuous permittivity indices, "
+                        f"but got {self.materials}"
+                    )
+        else: # if self.output_type == ParameterType.BINARY or self.output_type == ParameterType.DISCRETE:
+            if self.use_etching:
+                raise Exception(f"Etched devices only support continous parameters, {self.name} outputs {self.output_type}")
         return self
 
     @staticmethod

--- a/src/fdtdx/objects/device/device.py
+++ b/src/fdtdx/objects/device/device.py
@@ -248,7 +248,7 @@ class Device(OrderableObject, ABC):
             if self.use_etching:
                 if len(self.materials) != 1:
                     raise Exception(
-                        f"Need exactly one material in etched device when parameter mapping outputs continuous permittivity indices"
+                        f"Need exactly one material in etched device when parameter mapping outputs continuous permittivity indices "
                         f"which replaces the eroded original materials, but got {self.materials}"
                     )
             else:
@@ -260,7 +260,7 @@ class Device(OrderableObject, ABC):
         else:  # if self.output_type == ParameterType.BINARY or self.output_type == ParameterType.DISCRETE:
             if self.use_etching:
                 raise Exception(
-                    f"Etched devices only support continous parameters, {self.name} outputs {self.output_type}"
+                    f"Etched devices only support continuous parameters, {self.name} outputs {self.output_type}"
                 )
         return self
 

--- a/src/fdtdx/objects/device/device.py
+++ b/src/fdtdx/objects/device/device.py
@@ -250,16 +250,18 @@ class Device(OrderableObject, ABC):
                     raise Exception(
                         f"Need exactly one material in etched device when parameter mapping outputs continuous permittivity indices"
                         f"which replaces the eroded original materials, but got {self.materials}"
-                )
+                    )
             else:
                 if len(self.materials) != 2:
                     raise Exception(
                         f"Need exactly two materials in device when parameter mapping outputs continuous permittivity indices, "
                         f"but got {self.materials}"
                     )
-        else: # if self.output_type == ParameterType.BINARY or self.output_type == ParameterType.DISCRETE:
+        else:  # if self.output_type == ParameterType.BINARY or self.output_type == ParameterType.DISCRETE:
             if self.use_etching:
-                raise Exception(f"Etched devices only support continous parameters, {self.name} outputs {self.output_type}")
+                raise Exception(
+                    f"Etched devices only support continous parameters, {self.name} outputs {self.output_type}"
+                )
         return self
 
     @staticmethod

--- a/tests/docs/test_api_rst.py
+++ b/tests/docs/test_api_rst.py
@@ -66,6 +66,7 @@ class TestApiDocsCompleteness:
         documented = _parse_rst_entries(API_RST)
 
         missing = sorted(exported - documented)
+        print(missing)
         assert not missing, (
             f"{len(missing)} symbol(s) are in fdtdx.__all__ but missing from {API_RST}:\n"
             + "\n".join(f"  fdtdx.{name}" for name in missing)

--- a/tests/docs/test_api_rst.py
+++ b/tests/docs/test_api_rst.py
@@ -66,7 +66,6 @@ class TestApiDocsCompleteness:
         documented = _parse_rst_entries(API_RST)
 
         missing = sorted(exported - documented)
-        print(missing)
         assert not missing, (
             f"{len(missing)} symbol(s) are in fdtdx.__all__ but missing from {API_RST}:\n"
             + "\n".join(f"  fdtdx.{name}" for name in missing)

--- a/tests/integration/utils/test_sparams.py
+++ b/tests/integration/utils/test_sparams.py
@@ -7,6 +7,9 @@ exercises the aset call on line 269 of sparams.py.  Full S-parameter physics
 are tested separately in tests/simulation/physics/test_sparams.py.
 """
 
+import contextlib
+from unittest.mock import patch
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -14,6 +17,10 @@ import pytest
 from fdtdx.config import SimulationConfig
 from fdtdx.fdtd.container import ArrayContainer, ObjectContainer
 from fdtdx.objects.boundaries.perfectly_matched_layer import PerfectlyMatchedLayer
+from fdtdx.objects.detectors.mode import ModeOverlapDetector
+from fdtdx.objects.sources.mode import ModePlaneSource
+from fdtdx.objects.static_material.polygon import ExtrudedPolygon
+from fdtdx.objects.static_material.static import SimulationVolume
 from fdtdx.utils.sparams import (
     PortSpec,
     _make_port_shape,
@@ -41,8 +48,25 @@ _PORT_WIDTH = 0.8e-6
 _PORT_HEIGHT = 0.8e-6
 
 
+@contextlib.contextmanager
+def mock_apply_context():
+    """Temporarily bypasses .apply() inside this context block."""
+
+    def no_op_apply(self, **kwargs):
+        return self
+
+    with (
+        patch.object(ModePlaneSource, "apply", new=no_op_apply, create=True),
+        patch.object(ModeOverlapDetector, "apply", new=no_op_apply, create=True),
+        patch.object(SimulationVolume, "apply", new=no_op_apply, create=True),
+        patch.object(PerfectlyMatchedLayer, "apply", new=no_op_apply, create=True),
+        patch.object(ExtrudedPolygon, "apply", new=no_op_apply, create=True),
+    ):
+        yield
+
+
 def _make_setup(**kwargs):
-    """Thin wrapper around setup_sparams_simulation with shared defaults."""
+    """Thin wrapper around setup_sparams_simulation with shared defaults and mocked apply."""
     defaults = dict(
         polygons=[],
         wavelength=_WAVELENGTH,
@@ -53,7 +77,10 @@ def _make_setup(**kwargs):
         key=jax.random.PRNGKey(0),
     )
     defaults.update(kwargs)
-    return setup_sparams_simulation(**defaults)
+
+    # Only objects created inside this block will have their .apply() bypassed
+    with mock_apply_context():
+        return setup_sparams_simulation(**defaults)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/physics/test_modes.py
+++ b/tests/unit/core/physics/test_modes.py
@@ -192,35 +192,139 @@ class TestComputeMode:
         """Non-uniform transverse coordinates are passed through and used for normalization weights."""
         mock_mode = ModeTupleType(
             neff=1.5 + 0.1j,
-            Ex=np.ones((2, 2), dtype=np.complex64),
-            Ey=np.ones((2, 2), dtype=np.complex64),
-            Ez=np.ones((2, 2), dtype=np.complex64),
-            Hx=np.ones((2, 2), dtype=np.complex64),
-            Hy=np.ones((2, 2), dtype=np.complex64),
-            Hz=np.ones((2, 2), dtype=np.complex64),
+            Ex=np.ones((3, 3), dtype=np.complex64),
+            Ey=np.ones((3, 3), dtype=np.complex64),
+            Ez=np.ones((3, 3), dtype=np.complex64),
+            Hx=np.ones((3, 3), dtype=np.complex64),
+            Hy=np.ones((3, 3), dtype=np.complex64),
+            Hz=np.ones((3, 3), dtype=np.complex64),
         )
         mock_tidy3d_wrapper.return_value = [mock_mode]
         mock_normalize.return_value = (
-            jnp.ones((3, 2, 2, 1), dtype=jnp.complex64),
-            jnp.ones((3, 2, 2, 1), dtype=jnp.complex64),
+            jnp.ones((3, 3, 3, 1), dtype=jnp.complex64),
+            jnp.ones((3, 3, 3, 1), dtype=jnp.complex64),
         )
 
         compute_mode(
             frequency=2e14,
-            inv_permittivities=jnp.ones((1, 2, 2, 1)),
+            inv_permittivities=jnp.ones((1, 3, 3, 1)),
             inv_permeabilities=1.0,
             resolution=1e-8,
             direction="+",
-            transverse_coords=[np.asarray([0.0, 1e-6, 3e-6]), np.asarray([0.0, 2e-6, 5e-6])],
+            transverse_coords=[np.asarray([0.0, 1e-6, 3e-6, 4e-6]), np.asarray([0.0, 2e-6, 5e-6, 6e-6])],
         )
 
         wrapper_kwargs = mock_tidy3d_wrapper.call_args.kwargs
-        assert np.allclose(wrapper_kwargs["coords"][0], [0.0, 1.0, 3.0])
-        assert np.allclose(wrapper_kwargs["coords"][1], [0.0, 2.0, 5.0])
+        assert np.allclose(wrapper_kwargs["coords"][0], [0.0, 1.0, 3.0, 4.0])
+        assert np.allclose(wrapper_kwargs["coords"][1], [0.0, 2.0, 5.0, 6.0])
 
         normalize_kwargs = mock_normalize.call_args.kwargs
         assert normalize_kwargs["axis"] == 2
-        expected_area = jnp.asarray([[[2e-12], [3e-12]], [[4e-12], [6e-12]]], dtype=jnp.float32)
+
+        expected_area = jnp.asarray(
+            [
+                [[2e-12], [3e-12], [1e-12]],
+                [[4e-12], [6e-12], [2e-12]],
+                [[2e-12], [3e-12], [1e-12]],
+            ],
+            dtype=jnp.float32,
+        )
+        assert jnp.allclose(normalize_kwargs["area_weights"], expected_area)
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_transverse_coords_passed_to_tidy3d_and_normalization_321(self, mock_normalize, mock_tidy3d_wrapper):
+        """Non-uniform transverse coordinates are passed through and used for normalization weights."""
+        mock_mode = ModeTupleType(
+            neff=1.5 + 0.1j,
+            Ex=np.ones((3,), dtype=np.complex64),
+            Ey=np.ones((3,), dtype=np.complex64),
+            Ez=np.ones((3,), dtype=np.complex64),
+            Hx=np.ones((3,), dtype=np.complex64),
+            Hy=np.ones((3,), dtype=np.complex64),
+            Hz=np.ones((3,), dtype=np.complex64),
+        )
+        mock_tidy3d_wrapper.return_value = [mock_mode]
+        mock_normalize.return_value = (
+            jnp.ones((3, 3, 2, 1), dtype=jnp.complex64),
+            jnp.ones((3, 3, 2, 1), dtype=jnp.complex64),
+        )
+
+        compute_mode(
+            frequency=2e14,
+            inv_permittivities=jnp.ones((1, 3, 3, 1)),
+            inv_permeabilities=1.0,
+            resolution=1e-8,
+            direction="+",
+            transverse_coords=[np.asarray([0.0, 1e-6, 3e-6, 4e-6]), np.asarray([0.0, 2e-6, 5e-6, 6e-6])],
+        )
+
+        wrapper_kwargs = mock_tidy3d_wrapper.call_args.kwargs
+        assert np.allclose(wrapper_kwargs["coords"][0], [0.0, 1.0, 3.0, 4.0])
+        assert np.allclose(wrapper_kwargs["coords"][1], [0.0, 2.0, 5.0, 6.0])
+
+        normalize_kwargs = mock_normalize.call_args.kwargs
+        assert normalize_kwargs["axis"] == 2
+
+        expected_area = jnp.asarray(
+            [
+                [[2e-12], [3e-12], [1e-12]],
+                [[4e-12], [6e-12], [2e-12]],
+                [[2e-12], [3e-12], [1e-12]],
+            ],
+            dtype=jnp.float32,
+        )
+        assert jnp.allclose(normalize_kwargs["area_weights"], expected_area)
+
+    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
+    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
+    def test_transverse_coords_passed_to_tidy3d_and_normalization_2d(self, mock_normalize, mock_tidy3d_wrapper):
+        """Non-uniform transverse coordinates are passed through and used for normalization weights."""
+
+        mock_mode = ModeTupleType(
+            neff=1.5 + 0.1j,
+            Ex=np.ones((5,), dtype=np.complex64),
+            Ey=np.ones((5,), dtype=np.complex64),
+            Ez=np.ones((5,), dtype=np.complex64),
+            Hx=np.ones((5,), dtype=np.complex64),
+            Hy=np.ones((5,), dtype=np.complex64),
+            Hz=np.ones((5,), dtype=np.complex64),
+        )
+        mock_tidy3d_wrapper.return_value = [mock_mode]
+        mock_normalize.return_value = (
+            jnp.ones((3, 2, 5, 1), dtype=jnp.complex64),
+            jnp.ones((3, 2, 5, 1), dtype=jnp.complex64),
+        )
+
+        compute_mode(
+            frequency=2e14,
+            inv_permittivities=jnp.ones((1, 2, 5, 1)),
+            inv_permeabilities=1.0,
+            resolution=1e-8,
+            direction="+",
+            transverse_coords=[
+                np.asarray([0.0, 1e-6, 2e-6]),  # Uniform spacing of 1um
+                np.asarray([0.0, 2e-6, 5e-6, 6e-6, 8e-6, 9e-6]),  # Non-uniform spacing
+            ],
+        )
+
+        wrapper_kwargs = mock_tidy3d_wrapper.call_args.kwargs
+
+        # since mode_2d triggers, the mode solver will called for the 1d mode
+        assert np.allclose(wrapper_kwargs["coords"][0], [0.0, 1.0])
+        assert np.allclose(wrapper_kwargs["coords"][1], [0.0, 2.0, 5.0, 6.0, 8.0, 9.0])
+
+        normalize_kwargs = mock_normalize.call_args.kwargs
+        assert normalize_kwargs["axis"] == 2
+
+        expected_area = jnp.asarray(
+            [
+                [[2e-12], [3e-12], [1e-12], [2e-12], [1e-12]],
+                [[2e-12], [3e-12], [1e-12], [2e-12], [1e-12]],
+            ],
+            dtype=jnp.float32,
+        )
+
         assert jnp.allclose(normalize_kwargs["area_weights"], expected_area)
 
 

--- a/tests/unit/core/physics/test_modes.py
+++ b/tests/unit/core/physics/test_modes.py
@@ -233,51 +233,6 @@ class TestComputeMode:
 
     @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
     @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
-    def test_transverse_coords_passed_to_tidy3d_and_normalization_321(self, mock_normalize, mock_tidy3d_wrapper):
-        """Non-uniform transverse coordinates are passed through and used for normalization weights."""
-        mock_mode = ModeTupleType(
-            neff=1.5 + 0.1j,
-            Ex=np.ones((3,), dtype=np.complex64),
-            Ey=np.ones((3,), dtype=np.complex64),
-            Ez=np.ones((3,), dtype=np.complex64),
-            Hx=np.ones((3,), dtype=np.complex64),
-            Hy=np.ones((3,), dtype=np.complex64),
-            Hz=np.ones((3,), dtype=np.complex64),
-        )
-        mock_tidy3d_wrapper.return_value = [mock_mode]
-        mock_normalize.return_value = (
-            jnp.ones((3, 3, 2, 1), dtype=jnp.complex64),
-            jnp.ones((3, 3, 2, 1), dtype=jnp.complex64),
-        )
-
-        compute_mode(
-            frequency=2e14,
-            inv_permittivities=jnp.ones((1, 3, 3, 1)),
-            inv_permeabilities=1.0,
-            resolution=1e-8,
-            direction="+",
-            transverse_coords=[np.asarray([0.0, 1e-6, 3e-6, 4e-6]), np.asarray([0.0, 2e-6, 5e-6, 6e-6])],
-        )
-
-        wrapper_kwargs = mock_tidy3d_wrapper.call_args.kwargs
-        assert np.allclose(wrapper_kwargs["coords"][0], [0.0, 1.0, 3.0, 4.0])
-        assert np.allclose(wrapper_kwargs["coords"][1], [0.0, 2.0, 5.0, 6.0])
-
-        normalize_kwargs = mock_normalize.call_args.kwargs
-        assert normalize_kwargs["axis"] == 2
-
-        expected_area = jnp.asarray(
-            [
-                [[2e-12], [3e-12], [1e-12]],
-                [[4e-12], [6e-12], [2e-12]],
-                [[2e-12], [3e-12], [1e-12]],
-            ],
-            dtype=jnp.float32,
-        )
-        assert jnp.allclose(normalize_kwargs["area_weights"], expected_area)
-
-    @patch("fdtdx.core.physics.modes.tidy3d_mode_computation_wrapper")
-    @patch("fdtdx.core.physics.modes.normalize_by_poynting_flux")
     def test_transverse_coords_passed_to_tidy3d_and_normalization_2d(self, mock_normalize, mock_tidy3d_wrapper):
         """Non-uniform transverse coordinates are passed through and used for normalization weights."""
 

--- a/tests/unit/fdtd/test_initialization.py
+++ b/tests/unit/fdtd/test_initialization.py
@@ -688,6 +688,7 @@ def _make_arrays_mock(shape=(10, 10, 10)):
     arrays.dispersive_c3 = None
     arrays.dispersive_P_curr = None
     arrays.dispersive_P_prev = None
+    arrays.initial_inv_permittivities = None
     at_accessor = MagicMock()
 
     def at_getitem(key):
@@ -721,6 +722,7 @@ def test_apply_params_continuous_type(mock_compute_perm):
     device.output_type = ParameterType.CONTINUOUS
     device.grid_slice = (slice(0, 10), slice(0, 10), slice(0, 10))
     device.materials = [Mock(), Mock()]
+    device.use_etching = False
     material_indices = jnp.ones((10, 10, 10)) * 0.5
     device.return_value = material_indices
     objects = Mock(spec=ObjectContainer)
@@ -746,6 +748,7 @@ def test_apply_params_discrete_type(mock_ste, mock_compute_perm):
     device.output_type = ParameterType.DISCRETE
     device.grid_slice = (slice(0, 10), slice(0, 10), slice(0, 10))
     device.materials = [Mock(), Mock()]
+    device.use_etching = False
     material_indices = jnp.zeros((10, 10, 10), dtype=jnp.int32)
     device.return_value = material_indices
     objects = Mock(spec=ObjectContainer)
@@ -785,6 +788,7 @@ def test_apply_params_isotropic_components(mock_compute_perm):
     device.output_type = ParameterType.CONTINUOUS
     device.grid_slice = (slice(0, 5), slice(0, 5), slice(0, 5))
     device.materials = [Mock(), Mock()]
+    device.use_etching = False
     material_indices = jnp.ones((5, 5, 5)) * 0.5
     device.return_value = material_indices
 
@@ -799,6 +803,7 @@ def test_apply_params_isotropic_components(mock_compute_perm):
     arrays.dispersive_c3 = None
     arrays.dispersive_P_curr = None
     arrays.dispersive_P_prev = None
+    arrays.initial_inv_permittivities = None
     at_accessor = MagicMock()
 
     def at_getitem(key):
@@ -842,6 +847,7 @@ def test_apply_params_fully_anisotropic_continuous(mock_compute_perm):
     device.output_type = ParameterType.CONTINUOUS
     device.grid_slice = (slice(0, 5), slice(0, 5), slice(0, 5))
     device.materials = [Mock(), Mock()]
+    device.use_etching = False
     material_indices = jnp.ones((5, 5, 5)) * 0.5
     device.return_value = material_indices
 
@@ -856,6 +862,7 @@ def test_apply_params_fully_anisotropic_continuous(mock_compute_perm):
     arrays.dispersive_c3 = None
     arrays.dispersive_P_curr = None
     arrays.dispersive_P_prev = None
+    arrays.initial_inv_permittivities = None
     at_accessor = MagicMock()
 
     def at_getitem(key):
@@ -901,6 +908,7 @@ def test_apply_params_fully_anisotropic_discrete(mock_ste, mock_compute_perm):
     device.output_type = ParameterType.DISCRETE
     device.grid_slice = (slice(0, 5), slice(0, 5), slice(0, 5))
     device.materials = [Mock(), Mock()]
+    device.use_etching = False
     material_indices = jnp.zeros((5, 5, 5), dtype=jnp.int32)
     device.return_value = material_indices
 
@@ -914,6 +922,7 @@ def test_apply_params_fully_anisotropic_discrete(mock_ste, mock_compute_perm):
     arrays.dispersive_c3 = None
     arrays.dispersive_P_curr = None
     arrays.dispersive_P_prev = None
+    arrays.initial_inv_permittivities = None
     at_accessor = MagicMock()
 
     def at_getitem(key):
@@ -944,6 +953,160 @@ def test_apply_params_fully_anisotropic_discrete(mock_ste, mock_compute_perm):
     _result_arrays, _result_objects, _info = apply_params(arrays, objects, {"device1": {}}, jax.random.PRNGKey(0))
     assert mock_ste.called
     assert mock_compute_perm.called
+
+
+@patch("fdtdx.fdtd.initialization.compute_allowed_permittivities")
+def test_apply_params_use_etching_continuous_isotropic(mock_compute_perm):
+    """Test apply_params etching path with continuous type and diagonally anisotropic components."""
+    # Etching interpolates between the old permittivity and perm_bc[0]
+    mock_compute_perm.return_value = [[4.0, 4.0, 4.0]] 
+    
+    device = Mock()
+    device.name = "device1"
+    device.output_type = ParameterType.CONTINUOUS
+    device.grid_slice = (slice(0, 5), slice(0, 5), slice(0, 5))
+    device.materials = [Mock()]
+    device.use_etching = True
+    
+    # 50% etching mix
+    material_indices = jnp.ones((5, 5, 5)) * 0.5
+    device.return_value = material_indices
+
+    shape = (10, 10, 10)
+    # Background inverse permittivity is 0.5 (so permittivity is 2.0)
+    init_inv_perm = jnp.full((3, *shape), 0.5)
+    inv_permeab = jnp.ones((3, *shape))
+
+    arrays = Mock(spec=ArrayContainer)
+    arrays.initial_inv_permittivities = init_inv_perm
+    arrays.inv_permittivities = init_inv_perm
+    arrays.inv_permeabilities = inv_permeab
+    arrays.dispersive_c1 = None
+    arrays.dispersive_c2 = None
+    arrays.dispersive_c3 = None
+    arrays.dispersive_P_curr = None
+    arrays.dispersive_P_prev = None
+
+    at_accessor = MagicMock()
+
+    def at_getitem(key):
+        at_result = Mock()
+        def set_side_effect(value):
+            result = Mock(spec=ArrayContainer)
+            result.inv_permittivities = value if key == "inv_permittivities" else arrays.inv_permittivities
+            result.initial_inv_permittivities = arrays.initial_inv_permittivities
+            result.inv_permeabilities = inv_permeab
+            result.dispersive_c1 = None
+            result.dispersive_c2 = None
+            result.dispersive_c3 = None
+            result.dispersive_P_curr = None
+            result.dispersive_P_prev = None
+            result.at = at_accessor
+            return result
+        at_result.set = set_side_effect
+        return at_result
+
+    at_accessor.__getitem__ = Mock(side_effect=at_getitem)
+    arrays.at = at_accessor
+
+    objects = Mock(spec=ObjectContainer)
+    objects.devices = [device]
+    mock_obj = Mock()
+    mock_obj.apply = Mock(return_value=mock_obj)
+    objects.object_list = [mock_obj]
+    objects.volume_idx = 0
+    device.apply = Mock(return_value=device)
+
+    _result_arrays, _result_objects, _info = apply_params(
+        arrays, objects, {"device1": {}}, jax.random.PRNGKey(0)
+    )
+
+    assert mock_compute_perm.called
+    assert device.call_count > 0
+    # Sanity check the math logic silently succeeded: 
+    # Old perm = 2.0. Etch material perm = 4.0. Mix = 0.5 * 2.0 + 0.5 * 4.0 = 3.0.
+    # Resulting inv_perm should be 1/3.0.
+    final_inv_perm = _result_arrays.inv_permittivities
+    assert jnp.allclose(final_inv_perm[:, 0, 0, 0], 1.0 / 3.0)
+
+
+@patch("fdtdx.fdtd.initialization.compute_allowed_permittivities")
+def test_apply_params_use_etching_continuous_fully_anisotropic(mock_compute_perm):
+    """Test apply_params etching path with fully anisotropic (9-component) permittivity."""
+    # Etching material: Identity matrix for permittivity
+    identity_flat = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+    mock_compute_perm.return_value = [identity_flat]
+
+    device = Mock()
+    device.name = "device1"
+    device.output_type = ParameterType.CONTINUOUS
+    device.grid_slice = (slice(0, 5), slice(0, 5), slice(0, 5))
+    device.materials = [Mock()]
+    device.use_etching = True
+    
+    # 50% etching mix
+    material_indices = jnp.ones((5, 5, 5)) * 0.5
+    device.return_value = material_indices
+
+    shape = (10, 10, 10)
+    # Background inverse permittivity diagonal is 0.5 -> original permittivity is 2.0
+    init_inv_perm_flat = jnp.array([0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5])
+    init_inv_perm = jnp.tile(init_inv_perm_flat[:, None, None, None], (1, *shape))
+    inv_permeab = jnp.ones((9, *shape))
+
+    arrays = Mock(spec=ArrayContainer)
+    arrays.initial_inv_permittivities = init_inv_perm
+    arrays.inv_permittivities = init_inv_perm
+    arrays.inv_permeabilities = inv_permeab
+    arrays.dispersive_c1 = None
+    arrays.dispersive_c2 = None
+    arrays.dispersive_c3 = None
+    arrays.dispersive_P_curr = None
+    arrays.dispersive_P_prev = None
+
+    at_accessor = MagicMock()
+
+    def at_getitem(key):
+        at_result = Mock()
+        def set_side_effect(value):
+            result = Mock(spec=ArrayContainer)
+            result.inv_permittivities = value if key == "inv_permittivities" else arrays.inv_permittivities
+            result.initial_inv_permittivities = arrays.initial_inv_permittivities
+            result.inv_permeabilities = inv_permeab
+            result.dispersive_c1 = None
+            result.dispersive_c2 = None
+            result.dispersive_c3 = None
+            result.dispersive_P_curr = None
+            result.dispersive_P_prev = None
+            result.at = at_accessor
+            return result
+        at_result.set = set_side_effect
+        return at_result
+
+    at_accessor.__getitem__ = Mock(side_effect=at_getitem)
+    arrays.at = at_accessor
+
+    objects = Mock(spec=ObjectContainer)
+    objects.devices = [device]
+    mock_obj = Mock()
+    mock_obj.apply = Mock(return_value=mock_obj)
+    objects.object_list = [mock_obj]
+    objects.volume_idx = 0
+    device.apply = Mock(return_value=device)
+
+    _result_arrays, _result_objects, _info = apply_params(
+        arrays, objects, {"device1": {}}, jax.random.PRNGKey(0)
+    )
+
+    assert mock_compute_perm.called
+    assert device.call_count > 0
+    
+    # Validation check: 
+    # Old perm = diag(2,2,2). Etch perm = diag(1,1,1). Mix = diag(1.5, 1.5, 1.5).
+    # Resulting inv_perm should be diag(1/1.5, 1/1.5, 1/1.5).
+    final_inv_perm = _result_arrays.inv_permittivities
+    assert jnp.allclose(final_inv_perm[0, 0, 0, 0], 1.0 / 1.5)  # xx component
+    assert jnp.allclose(final_inv_perm[1, 0, 0, 0], 0.0)        # xy component
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/fdtd/test_initialization.py
+++ b/tests/unit/fdtd/test_initialization.py
@@ -772,7 +772,7 @@ def test_apply_params_no_devices():
     arrays = _make_arrays_mock()
     key = jax.random.PRNGKey(0)
     _result_arrays, _result_objects, info = apply_params(arrays, objects, {}, key)
-    assert mock_obj.apply.called
+    assert not mock_obj.apply.called  # apply should have been called in place_objects
     assert isinstance(info, dict)
 
 

--- a/tests/unit/fdtd/test_initialization.py
+++ b/tests/unit/fdtd/test_initialization.py
@@ -973,15 +973,15 @@ def test_apply_params_fully_anisotropic_discrete(mock_ste, mock_compute_perm):
 def test_apply_params_use_etching_continuous_isotropic(mock_compute_perm):
     """Test apply_params etching path with continuous type and diagonally anisotropic components."""
     # Etching interpolates between the old permittivity and perm_bc[0]
-    mock_compute_perm.return_value = [[4.0, 4.0, 4.0]] 
-    
+    mock_compute_perm.return_value = [[4.0, 4.0, 4.0]]
+
     device = Mock()
     device.name = "device1"
     device.output_type = ParameterType.CONTINUOUS
     device.grid_slice = (slice(0, 5), slice(0, 5), slice(0, 5))
     device.materials = [Mock()]
     device.use_etching = True
-    
+
     # 50% etching mix
     material_indices = jnp.ones((5, 5, 5)) * 0.5
     device.return_value = material_indices
@@ -1005,6 +1005,7 @@ def test_apply_params_use_etching_continuous_isotropic(mock_compute_perm):
 
     def at_getitem(key):
         at_result = Mock()
+
         def set_side_effect(value):
             result = Mock(spec=ArrayContainer)
             result.inv_permittivities = value if key == "inv_permittivities" else arrays.inv_permittivities
@@ -1017,6 +1018,7 @@ def test_apply_params_use_etching_continuous_isotropic(mock_compute_perm):
             result.dispersive_P_prev = None
             result.at = at_accessor
             return result
+
         at_result.set = set_side_effect
         return at_result
 
@@ -1031,13 +1033,11 @@ def test_apply_params_use_etching_continuous_isotropic(mock_compute_perm):
     objects.volume_idx = 0
     device.apply = Mock(return_value=device)
 
-    _result_arrays, _result_objects, _info = apply_params(
-        arrays, objects, {"device1": {}}, jax.random.PRNGKey(0)
-    )
+    _result_arrays, _result_objects, _info = apply_params(arrays, objects, {"device1": {}}, jax.random.PRNGKey(0))
 
     assert mock_compute_perm.called
     assert device.call_count > 0
-    # Sanity check the math logic silently succeeded: 
+    # Sanity check the math logic silently succeeded:
     # Old perm = 2.0. Etch material perm = 4.0. Mix = 0.5 * 2.0 + 0.5 * 4.0 = 3.0.
     # Resulting inv_perm should be 1/3.0.
     final_inv_perm = _result_arrays.inv_permittivities
@@ -1057,7 +1057,7 @@ def test_apply_params_use_etching_continuous_fully_anisotropic(mock_compute_perm
     device.grid_slice = (slice(0, 5), slice(0, 5), slice(0, 5))
     device.materials = [Mock()]
     device.use_etching = True
-    
+
     # 50% etching mix
     material_indices = jnp.ones((5, 5, 5)) * 0.5
     device.return_value = material_indices
@@ -1082,6 +1082,7 @@ def test_apply_params_use_etching_continuous_fully_anisotropic(mock_compute_perm
 
     def at_getitem(key):
         at_result = Mock()
+
         def set_side_effect(value):
             result = Mock(spec=ArrayContainer)
             result.inv_permittivities = value if key == "inv_permittivities" else arrays.inv_permittivities
@@ -1094,6 +1095,7 @@ def test_apply_params_use_etching_continuous_fully_anisotropic(mock_compute_perm
             result.dispersive_P_prev = None
             result.at = at_accessor
             return result
+
         at_result.set = set_side_effect
         return at_result
 
@@ -1108,19 +1110,17 @@ def test_apply_params_use_etching_continuous_fully_anisotropic(mock_compute_perm
     objects.volume_idx = 0
     device.apply = Mock(return_value=device)
 
-    _result_arrays, _result_objects, _info = apply_params(
-        arrays, objects, {"device1": {}}, jax.random.PRNGKey(0)
-    )
+    _result_arrays, _result_objects, _info = apply_params(arrays, objects, {"device1": {}}, jax.random.PRNGKey(0))
 
     assert mock_compute_perm.called
     assert device.call_count > 0
-    
-    # Validation check: 
+
+    # Validation check:
     # Old perm = diag(2,2,2). Etch perm = diag(1,1,1). Mix = diag(1.5, 1.5, 1.5).
     # Resulting inv_perm should be diag(1/1.5, 1/1.5, 1/1.5).
     final_inv_perm = _result_arrays.inv_permittivities
     assert jnp.allclose(final_inv_perm[0, 0, 0, 0], 1.0 / 1.5)  # xx component
-    assert jnp.allclose(final_inv_perm[1, 0, 0, 0], 0.0)        # xy component
+    assert jnp.allclose(final_inv_perm[1, 0, 0, 0], 0.0)  # xy component
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR is an accumulation of several small(ish) changes.

## Pre-computing Modes

This change has the largest overall impact on fdtdx. Currently, the mode solver is queried when `.apply()` is called, which happens at every iteration inside `.apply_params()` during normal optimization loops. Recomputing the same 10+ modes every iteration is highly inefficient.

Instead, we now detect whether the `grid_slice` overlaps any device. If it doesn't, we can safely pre-compute the mode in `place_objects()`. *Note:* This slightly contradicts our naming scheme, as it means `.apply()` is no longer strictly called within `.apply_params()`, but sometimes earlier.

## Interpolating permittivities

When using continuous devices, or multi-material objects with a voxel_mask, we need to interpolate between two materials. This is currently done by linearly interpolating between inverse permittivities. I changed this to interpolate between raw permittivities (before inversion) instead. This sometimes results in additional inversion steps, which may be troublesome for full-tensor anisotropic materials. Neither interpolation method is perfectly accurate, but interpolating raw permittivities seems more intuitive.

## `ModePlaneSource` and `ModeOverlapDetector` in 2D FDTD Simulations

Currently, when setting up a 2D simulation (using a thickness of 2 grid cells with periodic boundaries), the resulting modes are nonsensical. While the current mode solver actually supports 1D modes, they aren't applied because our permittivity slice is 2 cells high.

To fix this, I temporarily cast these slices to 1 cell high for the solver, and then expand them back to 2 cells afterward. This edge case is detected implicitly, so no additional flags are needed in the source or detector. However, the user needs to use exactly 2 grid cells, not 3 or more.

## Support for Etched Devices

Many photonic devices are fabricated by etching away existing material. Our current setup only supports this use-case when a single material is etched away.

To support etching multiple materials with similar etch rates (e.g., across multiple layers), we now back up the pre-etch permittivities before applying the etch. This backup is necessary in case we want to run multiple simulations, and the backup permittivities (`initial_inv_permittivities`) are attached to the `arrays` container.

There is a known tradeoff here regarding memory space and efficiency. This approach can be inefficient if:

* We only call `.apply_params()` once (i.e., running a single simulation).
* The permittivity array is very large (e.g., full-tensor) while the etched device itself is small.

However, since this backup is only created when etching is actively used, I opted for this tradeoff to keep the implementation simple. I am happy to discuss alternatives!

## Subgrid
Working with rectilinear grids can complicate plotting. While `Detector.draw_plot()` currently manages this via several helper functions, custom plotting applications would benefit from directly utilizing smaller `RectilinearGrid` instances instead of manually handling `x_edges` and `y_edges`. To support this, I introduced the `.subgrid(grid_slice)` helper method to generate these smaller grids.

## Power
For better modularity and convenience, I extracted the power computation logic from `normalize_by_poynting_flux` into its own function, `compute_integrated_power`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new way to compute integrated power and made it available from the top-level package.
  * Added a grid subsetting helper for extracting smaller regions from an existing grid.
  * Added support for etched device placement and improved handling of 2D mode cross-sections.

* **Bug Fixes**
  * Improved normalization and mode calculations for more consistent results on edge cases.
  * Updated simulation initialization so etched setups and parameter updates behave more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->