### PR TITLE
Spacing-weight the off-diagonal anisotropic average on non-uniform grids

### DIFF
--- a/src/fdtdx/fdtd/misc.py
+++ b/src/fdtdx/fdtd/misc.py
@@ -133,51 +133,81 @@ def avg_anisotropic_E_component(
     field: jax.Array,
     component: int,
     location: int,
+    aniso_widths: tuple[jax.Array, jax.Array, jax.Array] | None = None,
 ) -> jax.Array:
-    """Averages an E field component at a given location.
+    """Averages an E field component onto another component's Yee location.
+
+    On a uniform grid this is the four-point mean of the staggered samples. On a non-uniform
+    grid the center-to-edge half-step along the component axis is weighted by the local cell
+    widths; the location axis is already edge-aligned and keeps an unweighted midpoint.
 
     Args:
         field (jax.Array): E field to average (3, Nx, Ny, Nz)
         component (int): Component to average, 0 for Ex, 1 for Ey, 2 for Ez
         location (int): Location to calculate average, 0 for Ex, 1 for Ey, 2 for Ez
+        aniso_widths (tuple | None): Per-axis padded cell widths from
+            ``get_anisotropic_averaging_widths``, broadcast along their axis, or None on a
+            uniform grid. None (the default) selects the unweighted four-point mean.
 
     Returns:
         jax.Array: Averaged E field component
     """
 
-    return (
-        (
-            field[component]
-            + jnp.roll(field[component], -1, axis=location)
-            + jnp.roll(field[component], 1, axis=component)
-            + jnp.roll(field[component], (-1, 1), axis=(location, component))
-        )
-        / 4
-    )[1:-1, 1:-1, 1:-1]
+    samples = field[component]
+    if aniso_widths is None:
+        return (
+            (
+                samples
+                + jnp.roll(samples, -1, axis=location)
+                + jnp.roll(samples, 1, axis=component)
+                + jnp.roll(samples, (-1, 1), axis=(location, component))
+            )
+            / 4
+        )[1:-1, 1:-1, 1:-1]
+    centered = 0.5 * (samples + jnp.roll(samples, -1, axis=location))
+    width = aniso_widths[component]
+    previous_width = jnp.roll(width, 1, axis=component)
+    on_edge = (centered * previous_width + jnp.roll(centered, 1, axis=component) * width) / (width + previous_width)
+    return on_edge[1:-1, 1:-1, 1:-1]
 
 
 def avg_anisotropic_H_component(
     field: jax.Array,
     component: int,
     location: int,
+    aniso_widths: tuple[jax.Array, jax.Array, jax.Array] | None = None,
 ) -> jax.Array:
-    """Averages an H field component at a given location.
+    """Averages an H field component onto another component's Yee location.
+
+    On a uniform grid this is the four-point mean of the staggered samples. On a non-uniform
+    grid the center-to-edge half-step along the location axis is weighted by the local cell
+    widths; the component axis is already edge-aligned and keeps an unweighted midpoint.
 
     Args:
         field (jax.Array): H field to average (3, Nx, Ny, Nz)
         component (int): Component to average, 0 for Hx, 1 for Hy, 2 for Hz
         location (int): Location to calculate average, 0 for Hx, 1 for Hy, 2 for Hz
+        aniso_widths (tuple | None): Per-axis padded cell widths from
+            ``get_anisotropic_averaging_widths``, broadcast along their axis, or None on a
+            uniform grid. None (the default) selects the unweighted four-point mean.
 
     Returns:
         jax.Array: Averaged H field component
     """
 
-    return (
-        (
-            field[component]
-            + jnp.roll(field[component], 1, axis=location)
-            + jnp.roll(field[component], -1, axis=component)
-            + jnp.roll(field[component], (1, -1), axis=(location, component))
-        )
-        / 4
-    )[1:-1, 1:-1, 1:-1]
+    samples = field[component]
+    if aniso_widths is None:
+        return (
+            (
+                samples
+                + jnp.roll(samples, 1, axis=location)
+                + jnp.roll(samples, -1, axis=component)
+                + jnp.roll(samples, (1, -1), axis=(location, component))
+            )
+            / 4
+        )[1:-1, 1:-1, 1:-1]
+    width = aniso_widths[location]
+    previous_width = jnp.roll(width, 1, axis=location)
+    on_edge = (samples * previous_width + jnp.roll(samples, 1, axis=location) * width) / (width + previous_width)
+    centered = 0.5 * (on_edge + jnp.roll(on_edge, -1, axis=component))
+    return centered[1:-1, 1:-1, 1:-1]

--- a/src/fdtdx/fdtd/update.py
+++ b/src/fdtdx/fdtd/update.py
@@ -115,6 +115,37 @@ def pad_fields_for_boundaries(
     return padded
 
 
+def get_anisotropic_averaging_widths(
+    config: SimulationConfig,
+) -> tuple[jax.Array, jax.Array, jax.Array] | None:
+    """Build the per-axis cell widths that spacing-weight the off-diagonal anisotropic average.
+
+    The result depends only on the run-fixed grid, so the averaging functions take it as a
+    precomputed input and operate on arrays alone; under JIT it folds to a constant with no
+    per-step cost. Each entry is the axis cell widths padded by replicating the edge cell (to
+    line up with the field halo) and reshaped to broadcast along that axis.
+
+    Args:
+        config (SimulationConfig): Simulation configuration providing the resolved grid.
+
+    Returns:
+        tuple[jax.Array, jax.Array, jax.Array] | None: Per-axis padded cell widths, or None on
+            a uniform grid (where the averaging keeps its unweighted four-point mean).
+    """
+    if not config.has_nonuniform_grid:
+        return None
+    grid = config.resolved_grid
+    assert grid is not None  # narrowed by has_nonuniform_grid
+    widths = []
+    for axis in range(3):
+        axis_widths = grid.cell_widths(axis)
+        padded = jnp.concatenate([axis_widths[:1], axis_widths, axis_widths[-1:]])
+        broadcast_shape = [1, 1, 1]
+        broadcast_shape[axis] = padded.shape[0]
+        widths.append(padded.reshape(broadcast_shape))
+    return (widths[0], widths[1], widths[2])
+
+
 def update_E(
     time_step: jax.Array,
     arrays: ArrayContainer,
@@ -211,19 +242,45 @@ def update_E(
         E_pad = pad_fields_for_boundaries(arrays.fields.E, objects, config)
         curl_pad = pad_fields_for_boundaries(curl, objects, config)
 
+        # Spacing weights for the off-diagonal average (None on a uniform grid).
+        aniso_widths = get_anisotropic_averaging_widths(config)
         # Compute the averages of the fields and curl
-        Ex_y_avg = avg_anisotropic_E_component(E_pad, component=0, location=1)  # calc Ex at location of Ey
-        Ex_z_avg = avg_anisotropic_E_component(E_pad, component=0, location=2)  # calc Ex at location of Ez
-        Ey_x_avg = avg_anisotropic_E_component(E_pad, component=1, location=0)  # calc Ey at location of Ex
-        Ey_z_avg = avg_anisotropic_E_component(E_pad, component=1, location=2)  # calc Ey at location of Ez
-        Ez_x_avg = avg_anisotropic_E_component(E_pad, component=2, location=0)  # calc Ez at location of Ex
-        Ez_y_avg = avg_anisotropic_E_component(E_pad, component=2, location=1)  # calc Ez at location of Ey
-        curlHx_y_avg = avg_anisotropic_E_component(curl_pad, component=0, location=1)  # calc curl(H)x at location of Ey
-        curlHx_z_avg = avg_anisotropic_E_component(curl_pad, component=0, location=2)  # calc curl(H)x at location of Ez
-        curlHy_x_avg = avg_anisotropic_E_component(curl_pad, component=1, location=0)  # calc curl(H)y at location of Ex
-        curlHy_z_avg = avg_anisotropic_E_component(curl_pad, component=1, location=2)  # calc curl(H)y at location of Ez
-        curlHz_x_avg = avg_anisotropic_E_component(curl_pad, component=2, location=0)  # calc curl(H)z at location of Ex
-        curlHz_y_avg = avg_anisotropic_E_component(curl_pad, component=2, location=1)  # calc curl(H)z at location of Ey
+        Ex_y_avg = avg_anisotropic_E_component(
+            E_pad, component=0, location=1, aniso_widths=aniso_widths
+        )  # calc Ex at location of Ey
+        Ex_z_avg = avg_anisotropic_E_component(
+            E_pad, component=0, location=2, aniso_widths=aniso_widths
+        )  # calc Ex at location of Ez
+        Ey_x_avg = avg_anisotropic_E_component(
+            E_pad, component=1, location=0, aniso_widths=aniso_widths
+        )  # calc Ey at location of Ex
+        Ey_z_avg = avg_anisotropic_E_component(
+            E_pad, component=1, location=2, aniso_widths=aniso_widths
+        )  # calc Ey at location of Ez
+        Ez_x_avg = avg_anisotropic_E_component(
+            E_pad, component=2, location=0, aniso_widths=aniso_widths
+        )  # calc Ez at location of Ex
+        Ez_y_avg = avg_anisotropic_E_component(
+            E_pad, component=2, location=1, aniso_widths=aniso_widths
+        )  # calc Ez at location of Ey
+        curlHx_y_avg = avg_anisotropic_E_component(
+            curl_pad, component=0, location=1, aniso_widths=aniso_widths
+        )  # calc curl(H)x at location of Ey
+        curlHx_z_avg = avg_anisotropic_E_component(
+            curl_pad, component=0, location=2, aniso_widths=aniso_widths
+        )  # calc curl(H)x at location of Ez
+        curlHy_x_avg = avg_anisotropic_E_component(
+            curl_pad, component=1, location=0, aniso_widths=aniso_widths
+        )  # calc curl(H)y at location of Ex
+        curlHy_z_avg = avg_anisotropic_E_component(
+            curl_pad, component=1, location=2, aniso_widths=aniso_widths
+        )  # calc curl(H)y at location of Ez
+        curlHz_x_avg = avg_anisotropic_E_component(
+            curl_pad, component=2, location=0, aniso_widths=aniso_widths
+        )  # calc curl(H)z at location of Ex
+        curlHz_y_avg = avg_anisotropic_E_component(
+            curl_pad, component=2, location=1, aniso_widths=aniso_widths
+        )  # calc curl(H)z at location of Ey
 
         # K = curl(H)
         # Ex <= (Axx * Ex + Axy * x_avg(Ey) + Axz * x_avg(Ez)) +
@@ -372,19 +429,45 @@ def update_E_reverse(
         E_pad = pad_fields_for_boundaries(E, objects, config)
         curl_pad = pad_fields_for_boundaries(curl, objects, config)
 
+        # Spacing weights for the off-diagonal average (None on a uniform grid).
+        aniso_widths = get_anisotropic_averaging_widths(config)
         # Compute the averages of the fields and curl
-        Ex_y_avg = avg_anisotropic_E_component(E_pad, component=0, location=1)  # calc Ex at location of Ey
-        Ex_z_avg = avg_anisotropic_E_component(E_pad, component=0, location=2)  # calc Ex at location of Ez
-        Ey_x_avg = avg_anisotropic_E_component(E_pad, component=1, location=0)  # calc Ey at location of Ex
-        Ey_z_avg = avg_anisotropic_E_component(E_pad, component=1, location=2)  # calc Ey at location of Ez
-        Ez_x_avg = avg_anisotropic_E_component(E_pad, component=2, location=0)  # calc Ez at location of Ex
-        Ez_y_avg = avg_anisotropic_E_component(E_pad, component=2, location=1)  # calc Ez at location of Ey
-        curlHx_y_avg = avg_anisotropic_E_component(curl_pad, component=0, location=1)  # calc curl(H)x at location of Ey
-        curlHx_z_avg = avg_anisotropic_E_component(curl_pad, component=0, location=2)  # calc curl(H)x at location of Ez
-        curlHy_x_avg = avg_anisotropic_E_component(curl_pad, component=1, location=0)  # calc curl(H)y at location of Ex
-        curlHy_z_avg = avg_anisotropic_E_component(curl_pad, component=1, location=2)  # calc curl(H)y at location of Ez
-        curlHz_x_avg = avg_anisotropic_E_component(curl_pad, component=2, location=0)  # calc curl(H)z at location of Ex
-        curlHz_y_avg = avg_anisotropic_E_component(curl_pad, component=2, location=1)  # calc curl(H)z at location of Ey
+        Ex_y_avg = avg_anisotropic_E_component(
+            E_pad, component=0, location=1, aniso_widths=aniso_widths
+        )  # calc Ex at location of Ey
+        Ex_z_avg = avg_anisotropic_E_component(
+            E_pad, component=0, location=2, aniso_widths=aniso_widths
+        )  # calc Ex at location of Ez
+        Ey_x_avg = avg_anisotropic_E_component(
+            E_pad, component=1, location=0, aniso_widths=aniso_widths
+        )  # calc Ey at location of Ex
+        Ey_z_avg = avg_anisotropic_E_component(
+            E_pad, component=1, location=2, aniso_widths=aniso_widths
+        )  # calc Ey at location of Ez
+        Ez_x_avg = avg_anisotropic_E_component(
+            E_pad, component=2, location=0, aniso_widths=aniso_widths
+        )  # calc Ez at location of Ex
+        Ez_y_avg = avg_anisotropic_E_component(
+            E_pad, component=2, location=1, aniso_widths=aniso_widths
+        )  # calc Ez at location of Ey
+        curlHx_y_avg = avg_anisotropic_E_component(
+            curl_pad, component=0, location=1, aniso_widths=aniso_widths
+        )  # calc curl(H)x at location of Ey
+        curlHx_z_avg = avg_anisotropic_E_component(
+            curl_pad, component=0, location=2, aniso_widths=aniso_widths
+        )  # calc curl(H)x at location of Ez
+        curlHy_x_avg = avg_anisotropic_E_component(
+            curl_pad, component=1, location=0, aniso_widths=aniso_widths
+        )  # calc curl(H)y at location of Ex
+        curlHy_z_avg = avg_anisotropic_E_component(
+            curl_pad, component=1, location=2, aniso_widths=aniso_widths
+        )  # calc curl(H)y at location of Ez
+        curlHz_x_avg = avg_anisotropic_E_component(
+            curl_pad, component=2, location=0, aniso_widths=aniso_widths
+        )  # calc curl(H)z at location of Ex
+        curlHz_y_avg = avg_anisotropic_E_component(
+            curl_pad, component=2, location=1, aniso_widths=aniso_widths
+        )  # calc curl(H)z at location of Ey
 
         # K = curl(H)
         # Ex <= (Axx * Ex + Axy * x_avg(Ey) + Axz * x_avg(Ez)) -
@@ -489,19 +572,45 @@ def update_H(
         H_pad = pad_fields_for_boundaries(arrays.fields.H, objects, config)
         curl_pad = pad_fields_for_boundaries(curl, objects, config)
 
+        # Spacing weights for the off-diagonal average (None on a uniform grid).
+        aniso_widths = get_anisotropic_averaging_widths(config)
         # Compute the averages of the fields and curl
-        Hx_y_avg = avg_anisotropic_H_component(H_pad, component=0, location=1)  # calc Hx at location of Hy
-        Hx_z_avg = avg_anisotropic_H_component(H_pad, component=0, location=2)  # calc Hx at location of Hz
-        Hy_x_avg = avg_anisotropic_H_component(H_pad, component=1, location=0)  # calc Hy at location of Hx
-        Hy_z_avg = avg_anisotropic_H_component(H_pad, component=1, location=2)  # calc Hy at location of Hz
-        Hz_x_avg = avg_anisotropic_H_component(H_pad, component=2, location=0)  # calc Hz at location of Hx
-        Hz_y_avg = avg_anisotropic_H_component(H_pad, component=2, location=1)  # calc Hz at location of Hy
-        curlEx_y_avg = avg_anisotropic_H_component(curl_pad, component=0, location=1)  # calc curl(E)x at location of Hy
-        curlEx_z_avg = avg_anisotropic_H_component(curl_pad, component=0, location=2)  # calc curl(E)x at location of Hz
-        curlEy_x_avg = avg_anisotropic_H_component(curl_pad, component=1, location=0)  # calc curl(E)y at location of Hx
-        curlEy_z_avg = avg_anisotropic_H_component(curl_pad, component=1, location=2)  # calc curl(E)y at location of Hz
-        curlEz_x_avg = avg_anisotropic_H_component(curl_pad, component=2, location=0)  # calc curl(E)z at location of Hx
-        curlEz_y_avg = avg_anisotropic_H_component(curl_pad, component=2, location=1)  # calc curl(E)z at location of Hy
+        Hx_y_avg = avg_anisotropic_H_component(
+            H_pad, component=0, location=1, aniso_widths=aniso_widths
+        )  # calc Hx at location of Hy
+        Hx_z_avg = avg_anisotropic_H_component(
+            H_pad, component=0, location=2, aniso_widths=aniso_widths
+        )  # calc Hx at location of Hz
+        Hy_x_avg = avg_anisotropic_H_component(
+            H_pad, component=1, location=0, aniso_widths=aniso_widths
+        )  # calc Hy at location of Hx
+        Hy_z_avg = avg_anisotropic_H_component(
+            H_pad, component=1, location=2, aniso_widths=aniso_widths
+        )  # calc Hy at location of Hz
+        Hz_x_avg = avg_anisotropic_H_component(
+            H_pad, component=2, location=0, aniso_widths=aniso_widths
+        )  # calc Hz at location of Hx
+        Hz_y_avg = avg_anisotropic_H_component(
+            H_pad, component=2, location=1, aniso_widths=aniso_widths
+        )  # calc Hz at location of Hy
+        curlEx_y_avg = avg_anisotropic_H_component(
+            curl_pad, component=0, location=1, aniso_widths=aniso_widths
+        )  # calc curl(E)x at location of Hy
+        curlEx_z_avg = avg_anisotropic_H_component(
+            curl_pad, component=0, location=2, aniso_widths=aniso_widths
+        )  # calc curl(E)x at location of Hz
+        curlEy_x_avg = avg_anisotropic_H_component(
+            curl_pad, component=1, location=0, aniso_widths=aniso_widths
+        )  # calc curl(E)y at location of Hx
+        curlEy_z_avg = avg_anisotropic_H_component(
+            curl_pad, component=1, location=2, aniso_widths=aniso_widths
+        )  # calc curl(E)y at location of Hz
+        curlEz_x_avg = avg_anisotropic_H_component(
+            curl_pad, component=2, location=0, aniso_widths=aniso_widths
+        )  # calc curl(E)z at location of Hx
+        curlEz_y_avg = avg_anisotropic_H_component(
+            curl_pad, component=2, location=1, aniso_widths=aniso_widths
+        )  # calc curl(E)z at location of Hy
 
         # K = curl(E)
         # Hx <= (Axx * Hx + Axy * x_avg(Hy) + Axz * x_avg(Hz)) -
@@ -627,19 +736,45 @@ def update_H_reverse(
         H_pad = pad_fields_for_boundaries(H, objects, config)
         curl_pad = pad_fields_for_boundaries(curl, objects, config)
 
+        # Spacing weights for the off-diagonal average (None on a uniform grid).
+        aniso_widths = get_anisotropic_averaging_widths(config)
         # Compute the averages of the fields and curl
-        Hx_y_avg = avg_anisotropic_H_component(H_pad, component=0, location=1)  # calc Hx at location of Hy
-        Hx_z_avg = avg_anisotropic_H_component(H_pad, component=0, location=2)  # calc Hx at location of Hz
-        Hy_x_avg = avg_anisotropic_H_component(H_pad, component=1, location=0)  # calc Hy at location of Hx
-        Hy_z_avg = avg_anisotropic_H_component(H_pad, component=1, location=2)  # calc Hy at location of Hz
-        Hz_x_avg = avg_anisotropic_H_component(H_pad, component=2, location=0)  # calc Hz at location of Hx
-        Hz_y_avg = avg_anisotropic_H_component(H_pad, component=2, location=1)  # calc Hz at location of Hy
-        curlEx_y_avg = avg_anisotropic_H_component(curl_pad, component=0, location=1)  # calc curl(E)x at location of Hy
-        curlEx_z_avg = avg_anisotropic_H_component(curl_pad, component=0, location=2)  # calc curl(E)x at location of Hz
-        curlEy_x_avg = avg_anisotropic_H_component(curl_pad, component=1, location=0)  # calc curl(E)y at location of Hx
-        curlEy_z_avg = avg_anisotropic_H_component(curl_pad, component=1, location=2)  # calc curl(E)y at location of Hz
-        curlEz_x_avg = avg_anisotropic_H_component(curl_pad, component=2, location=0)  # calc curl(E)z at location of Hx
-        curlEz_y_avg = avg_anisotropic_H_component(curl_pad, component=2, location=1)  # calc curl(E)z at location of Hy
+        Hx_y_avg = avg_anisotropic_H_component(
+            H_pad, component=0, location=1, aniso_widths=aniso_widths
+        )  # calc Hx at location of Hy
+        Hx_z_avg = avg_anisotropic_H_component(
+            H_pad, component=0, location=2, aniso_widths=aniso_widths
+        )  # calc Hx at location of Hz
+        Hy_x_avg = avg_anisotropic_H_component(
+            H_pad, component=1, location=0, aniso_widths=aniso_widths
+        )  # calc Hy at location of Hx
+        Hy_z_avg = avg_anisotropic_H_component(
+            H_pad, component=1, location=2, aniso_widths=aniso_widths
+        )  # calc Hy at location of Hz
+        Hz_x_avg = avg_anisotropic_H_component(
+            H_pad, component=2, location=0, aniso_widths=aniso_widths
+        )  # calc Hz at location of Hx
+        Hz_y_avg = avg_anisotropic_H_component(
+            H_pad, component=2, location=1, aniso_widths=aniso_widths
+        )  # calc Hz at location of Hy
+        curlEx_y_avg = avg_anisotropic_H_component(
+            curl_pad, component=0, location=1, aniso_widths=aniso_widths
+        )  # calc curl(E)x at location of Hy
+        curlEx_z_avg = avg_anisotropic_H_component(
+            curl_pad, component=0, location=2, aniso_widths=aniso_widths
+        )  # calc curl(E)x at location of Hz
+        curlEy_x_avg = avg_anisotropic_H_component(
+            curl_pad, component=1, location=0, aniso_widths=aniso_widths
+        )  # calc curl(E)y at location of Hx
+        curlEy_z_avg = avg_anisotropic_H_component(
+            curl_pad, component=1, location=2, aniso_widths=aniso_widths
+        )  # calc curl(E)y at location of Hz
+        curlEz_x_avg = avg_anisotropic_H_component(
+            curl_pad, component=2, location=0, aniso_widths=aniso_widths
+        )  # calc curl(E)z at location of Hx
+        curlEz_y_avg = avg_anisotropic_H_component(
+            curl_pad, component=2, location=1, aniso_widths=aniso_widths
+        )  # calc curl(E)z at location of Hy
 
         # K = curl(E)
         # Hx <= (Axx * Hx + Axy * x_avg(Hy) + Axz * x_avg(Hz)) +

--- a/tests/unit/fdtd/test_fdtd_misc.py
+++ b/tests/unit/fdtd/test_fdtd_misc.py
@@ -1,10 +1,16 @@
 # tests/unit/fdtd/test_misc.py
 
+import math
+
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 import fdtdx.fdtd.misc as misc
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.fdtd.container import ArrayContainer, FieldState
+from fdtdx.fdtd.update import get_anisotropic_averaging_widths
 
 
 class MockPML:
@@ -381,3 +387,68 @@ def test_avg_anisotropic_H_component_diagonal():
     assert jnp.allclose(Hx_avg_x, expected_Hx_avg_x)
     assert jnp.allclose(Hy_avg_y, expected_Hy_avg_y)
     assert jnp.allclose(Hz_avg_z, expected_Hz_avg_z)
+
+
+def test_avg_anisotropic_uniform_grid_matches_unweighted():
+    """A uniform grid yields no weights and the averaging is identical to the plain four-point mean."""
+    field = jnp.asarray(np.arange(3 * 5 * 5 * 5, dtype=float).reshape(3, 5, 5, 5))
+    config = SimulationConfig(grid=RectilinearGrid.uniform(shape=(3, 3, 3), spacing=1.0), time=10e-15)
+    aniso_widths = get_anisotropic_averaging_widths(config)
+    assert aniso_widths is None
+    for comp in range(3):
+        for loc in range(3):
+            if comp == loc:
+                continue
+            for fn in (misc.avg_anisotropic_E_component, misc.avg_anisotropic_H_component):
+                assert jnp.array_equal(fn(field, comp, loc, aniso_widths=aniso_widths), fn(field, comp, loc))
+
+
+def test_avg_anisotropic_spacing_weighting_is_second_order():
+    """On a graded mesh the weighted average converges at second order and the unweighted mean at first.
+
+    A smooth field sin(2 pi x) is interpolated from cell centers to cell faces on a strongly graded mesh
+    (alternating cell widths) refined over a fixed domain, so the relative grading does not vanish. The
+    averaging weights only the graded axis, so the field is held constant on the other axis; the off-axis
+    step is then exact and the measured error reflects the graded-axis interpolation alone.
+    """
+    resolutions = [16, 32, 64, 128]
+    # avg fn -> (component, location); the graded axis (x = 0) is the weighted one for each.
+    cases = {"E": (misc.avg_anisotropic_E_component, 0, 1), "H": (misc.avg_anisotropic_H_component, 1, 0)}
+    errors = {(name, kind): [] for name in cases for kind in ("weighted", "unweighted")}
+
+    for n in resolutions:
+        widths_x = np.tile([1.0, 3.0], n // 2)
+        widths_x /= widths_x.sum()  # cell widths on [0, 1], persistent 3:1 grading
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray(np.concatenate([[0.0], np.cumsum(widths_x)])),
+            y_edges=jnp.asarray([0.0, 1.0, 2.0]),
+            z_edges=jnp.asarray([0.0, 1.0, 2.0]),
+        )
+        aniso_widths = get_anisotropic_averaging_widths(SimulationConfig(grid=grid, time=10e-15))
+
+        # sin(2 pi x) at the padded cell centers (constant on y, z); exact value lives at the cell faces.
+        padded_widths = np.concatenate([widths_x[:1], widths_x, widths_x[-1:]])
+        padded_edges = np.concatenate([[0.0], np.cumsum(padded_widths)])
+        centers = 0.5 * (padded_edges[:-1] + padded_edges[1:])
+        field = jnp.asarray(
+            np.broadcast_to(np.sin(2 * math.pi * centers)[None, :, None, None], (3, centers.size, 3, 3)).copy()
+        )
+        exact = np.sin(2 * math.pi * padded_edges[1 : 1 + n])[:, None, None]
+
+        for name, (fn, component, location) in cases.items():
+            weighted = np.asarray(fn(field, component=component, location=location, aniso_widths=aniso_widths))
+            unweighted = np.asarray(fn(field, component=component, location=location))
+            errors[(name, "weighted")].append(float(np.abs(weighted - exact).max()))
+            errors[(name, "unweighted")].append(float(np.abs(unweighted - exact).max()))
+
+    # error ~ h^p and h halves as n doubles, so the order p is the log2 error ratio between refinements.
+    def order(series):
+        return math.log2(series[-2] / series[-1])
+
+    print("\nconvergence order on a graded mesh (refinement factor 2):")
+    for (name, kind), series in errors.items():
+        print(f"  {name} {kind:<10} order = {order(series):.2f}")
+
+    for name in cases:
+        assert order(errors[(name, "weighted")]) > 1.7, f"{name} weighted average should be ~2nd order"
+        assert order(errors[(name, "unweighted")]) < 1.3, f"{name} unweighted average should be ~1st order"

--- a/tests/unit/fdtd/test_update.py
+++ b/tests/unit/fdtd/test_update.py
@@ -75,6 +75,7 @@ def _make_config(c=0.5):
     cfg = Mock()
     cfg.courant_number = c
     cfg.uniform_spacing.return_value = 1.0
+    cfg.has_nonuniform_grid = False
     return cfg
 
 


### PR DESCRIPTION
• `avg_anisotropic_E/H_component` used to colocate the off-diagonal field and curl components of the full-tensor anisotropic update with a plain four-point mean. On a non-uniform grid, the unweighted mean is only first-order accurate. Weighting the center-to-edge half-step of each average by the local cell widths restores second order.

• `get_anisotropic_averaging_widths()` calculates the weights from the resolved grid. It is threaded into the forward and reverse E/H updates. They depend only on the static grid, so under JIT they constant-fold and add no per-step cost.

• Tests:
Uniform grids reproduce the unweighted mean exactly; a refinement study on a graded mesh shows the weighted average converging at second order versus first order for the unweighted mean.

• Scope: 
This is the off-diagonal field/curl averaging in the full-tensor anisotropic update (fdtd/misc.py), distinct from subpixel averaging (#368) and the material permittivity interpolation around #376, which blend materials at interfaces during setup. This PR doesn't touch material smoothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for anisotropic averaging on non-uniform grids, improving results when grid spacing varies.
  * Updated field update paths to use spacing-aware averaging automatically where applicable.

* **Bug Fixes**
  * Kept existing behavior unchanged for uniform grids, preserving the same averaging results as before.
  * Improved numerical accuracy on graded meshes with better convergence behavior.

* **Tests**
  * Added coverage for uniform-grid parity and weighted averaging accuracy on strongly graded meshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->