### PR TITLE
Fix GDS layer masks on rectilinear grids

### DIFF
--- a/src/fdtdx/objects/static_material/gds_layer_stack.py
+++ b/src/fdtdx/objects/static_material/gds_layer_stack.py
@@ -156,9 +156,13 @@ class GDSLayerObject(StaticMultiMaterialObject):
             v_lower, v_upper = self.grid_slice_tuple[self.vertical_axis]
             h_edges = np.asarray(grid.edges(self.horizontal_axis))
             v_edges = np.asarray(grid.edges(self.vertical_axis))
-            # Compute cell centers relative to the origin at the center of the simulation volume
-            h_centers = 0.5 * (h_edges[h_lower:h_upper] + h_edges[h_lower + 1 : h_upper + 1])
-            v_centers = 0.5 * (v_edges[v_lower:v_upper] + v_edges[v_lower + 1 : v_upper + 1])
+            # local_polygons are in gds_center-relative space (poly - gds_center).
+            # gds_center maps to the object's physical centre in the simulation, so
+            # cell centres must be expressed relative to the object's slice centre too.
+            h_obj_center = 0.5 * (h_edges[h_lower] + h_edges[h_upper])
+            v_obj_center = 0.5 * (v_edges[v_lower] + v_edges[v_upper])
+            h_centers = 0.5 * (h_edges[h_lower:h_upper] + h_edges[h_lower + 1 : h_upper + 1]) - h_obj_center
+            v_centers = 0.5 * (v_edges[v_lower:v_upper] + v_edges[v_lower + 1 : v_upper + 1]) - v_obj_center
             if len(local_polygons) == 0:
                 mask_2d = np.zeros((n_h, n_v), dtype=bool)
             else:
@@ -217,7 +221,7 @@ def _load_gds_cell(
     return lib, cell
 
 
-def _gds_to_sim(gds_val: float, gds_center_val: float, vol_size: float) -> float:
+def _gds_to_sim(gds_val: float, gds_center_val: float) -> float:
     """Convert a GDS coordinate (metres) to a simulation real-space coordinate (metres).
 
     Simulation real-space coordinates are now measured from the center of the simulation volume.
@@ -279,7 +283,7 @@ def _iter_port_placements(
             name = f"{spec.name_prefix}_{i}"
 
             gds_prop_val = centroid[spec.propagation_axis]
-            sim_prop_pos = _gds_to_sim(gds_prop_val, gds_center[spec.propagation_axis], vol_size)
+            sim_prop_pos = _gds_to_sim(gds_prop_val, gds_center[spec.propagation_axis])
 
             # Transverse width from the actual marker polygon — avoids spanning
             # neighbouring waveguides and corrupting mode-overlap integrals.

--- a/src/fdtdx/objects/static_material/gds_layer_stack.py
+++ b/src/fdtdx/objects/static_material/gds_layer_stack.py
@@ -73,16 +73,17 @@ class GDSLayerObject(StaticMultiMaterialObject):
     Each instance represents one GDS layer (layer/datatype pair) extruded uniformly
     along ``axis``. The cross-sectional shape is described by ``polygons``, given in
     GDS coordinate space (metres). The mapping from GDS space to the local grid is
-    controlled by ``gds_center``, which gives the GDS coordinate that coincides with the x/y centre
-    of the simulation volume. For example, ``gds_center=(0.0, 0.0)`` maps the GDS origin to the
-    centre of the simulation volume, while ``gds_center=(500e-9, 0.0)`` shifts the layout 500 nm to the left.
+    controlled by ``gds_center``, which gives the GDS coordinate that coincides
+    with the x/y centre of the placed object. For example,
+    ``gds_center=(0.0, 0.0)`` maps the GDS origin to the object's centre, while
+    ``gds_center=(500e-9, 0.0)`` shifts the layout 500 nm to the left.
     """
 
     #: Sequence of (N, 2) vertex arrays for each polygon, in GDS metres.
     polygons: Sequence[np.ndarray] = frozen_field()
 
     #: GDS coordinate (horizontal, vertical) in metres that coincides with the x/y centre
-    #: of the simulation volume.
+    #: of the placed object.
     gds_center: tuple[float, float] = frozen_field()
 
     #: Key into the materials dictionary used for this object.

--- a/tests/unit/objects/static_material/test_gds_layer_stack.py
+++ b/tests/unit/objects/static_material/test_gds_layer_stack.py
@@ -77,6 +77,10 @@ def _square_polygon(half_side=100e-9):
     return np.array([[-h, -h], [h, -h], [h, h], [-h, h]])
 
 
+def _square_polygon_at(center, half_side=100e-9):
+    return _square_polygon(half_side=half_side) + np.asarray(center)
+
+
 def _make_layer_obj(materials, polygons=None, gds_center=(0.0, 0.0), axis=2, thickness=200e-9, material_name="si"):
     if polygons is None:
         polygons = [_square_polygon()]
@@ -92,6 +96,18 @@ def _make_layer_obj(materials, polygons=None, gds_center=(0.0, 0.0), axis=2, thi
 
 def _place(obj, config, key, slices=((0, 20), (0, 20), (0, 4))):
     return obj.place_on_grid(grid_slice_tuple=slices, config=config, key=key)
+
+
+def _rectilinear_config(x_edges, y_edges, z_edges=None):
+    if z_edges is None:
+        z_edges = jnp.linspace(0.0, 200e-9, 5)
+    grid = RectilinearGrid(x_edges=x_edges, y_edges=y_edges, z_edges=z_edges)
+    return SimulationConfig(time=100e-15, grid=grid, backend="cpu", dtype=jnp.float32, gradient_config=None)
+
+
+def _gds_mask_xy(materials, config, key, polygons, gds_center, slices=((0, 20), (0, 20), (0, 4))):
+    obj = _make_layer_obj(materials, polygons=polygons, gds_center=gds_center, axis=2)
+    return np.array(_place(obj, config, key, slices=slices).get_voxel_mask_for_shape()[:, :, 0])
 
 
 # ---------------------------------------------------------------------------
@@ -332,6 +348,56 @@ class TestGetVoxelMaskRectilinearGrid:
         mask_uniform = placed_uniform.get_voxel_mask_for_shape()
         mask_rect = placed_rect.get_voxel_mask_for_shape()
         assert jnp.array_equal(mask_uniform, mask_rect)
+
+    def test_polygon_position_with_nonzero_gds_center(self, key, two_materials):
+        """A shifted GDS center is evaluated relative to the placed object center."""
+        n, res = 20, 50e-9
+        edges_xy = jnp.linspace(0.0, n * res, n + 1)
+        cfg = _rectilinear_config(edges_xy, edges_xy)
+        gds_center = (400e-9, 500e-9)
+        mask_xy = _gds_mask_xy(
+            two_materials,
+            cfg,
+            key,
+            polygons=[_square_polygon_at(gds_center, half_side=100e-9)],
+            gds_center=gds_center,
+        )
+
+        expected = np.zeros((20, 20), dtype=bool)
+        expected[8:12, 8:12] = True
+        np.testing.assert_array_equal(mask_xy, expected)
+
+    def test_rectilinear_matches_uniform_for_nonzero_gds_center(self, config, key, two_materials):
+        """RectilinearGrid and UniformGrid paths produce the same mask for a nonzero gds_center."""
+        n, res = 20, 50e-9
+        edges_xy = jnp.linspace(0.0, n * res, n + 1)
+        rect_cfg = _rectilinear_config(edges_xy, edges_xy)
+        gds_center = (400e-9, 500e-9)
+        polygons = [_square_polygon_at(gds_center, half_side=100e-9)]
+        slices = ((0, 20), (0, 20), (0, 4))
+        mask_uniform = _gds_mask_xy(two_materials, config, key, polygons, gds_center, slices=slices)
+        mask_rect = _gds_mask_xy(two_materials, rect_cfg, key, polygons, gds_center, slices=slices)
+        np.testing.assert_array_equal(mask_rect, mask_uniform)
+
+    def test_polygon_position_on_nonuniform_grid(self, key, two_materials):
+        """Cell-center sampling uses real rectilinear coordinates, not a uniform index grid."""
+        coarse_edges = np.linspace(0.0, 800e-9, 11)
+        fine_edges = np.linspace(800e-9, 1000e-9, 11)[1:]
+        edges_x = jnp.asarray(np.concatenate([coarse_edges, fine_edges]))
+        edges_y = jnp.linspace(0.0, 20 * 50e-9, 21)
+        cfg = _rectilinear_config(edges_x, edges_y)
+        gds_center = (500e-9, 500e-9)
+        mask_xy = _gds_mask_xy(
+            two_materials,
+            cfg,
+            key,
+            polygons=[_square_polygon_at(gds_center, half_side=50e-9)],
+            gds_center=gds_center,
+        )
+
+        expected = np.zeros((20, 20), dtype=bool)
+        expected[6, 9:11] = True
+        np.testing.assert_array_equal(mask_xy, expected)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This is a small follow-up to #363, which moved grid coordinates toward a center-origin convention and added rectilinear/quasi-uniform grid support.

The GDS layer code already converts imported polygons into gds_center-relative coordinates:

local_polygon = polygon - gds_center

The uniform-grid path samples cell centers in that same center-relative frame, so it stayed consistent after #363. The rectilinear-grid path, however, was still passing absolute grid cell centers into
polygon_to_mask_at_points. That meant it could compare center-relative polygon coordinates against absolute rectilinear grid coordinates.

Example:

1. A rectilinear grid has edges from 0 nm to 1000 nm, so the object center is at 500 nm.
2. gds_center = 400 nm, meaning GDS 400 nm should map to the object center.
3. A GDS polygon from 300 nm to 500 nm becomes local coordinates from -100 nm to 100 nm.
4. Before this fix, the rectilinear path tested that local polygon against absolute cell centers around 400-600 nm.
5. After this fix, the rectilinear path subtracts the object slice center first, so those sample points become center-relative and match the polygon frame.

This keeps the intent of #363 while making the GDS rectilinear voxelization path consistent with the uniform-grid path and the documented gds_center behavior.

Regression coverage added for:

- nonzero gds_center placement on rectilinear grids
- uniform-grid vs rectilinear-grid parity
- nonuniform rectilinear cell-center sampling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voxel mask placement accuracy for GDS-derived shapes, including correct handling of per-slice offsets and non-uniform rectilinear grids.
  * Corrected coordinate conversion so port positions map consistently into simulation space.
  * Updated alignment behavior for `gds_center` to reflect placement relative to the object’s slice center.
* **Tests**
  * Added new unit tests for offset `gds_center` scenarios and verification against expected boolean masks on mixed-resolution rectilinear grids.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->