### PR TITLE
Fix: re-scale area weights to prevent dtype overflow

### DIFF
--- a/src/fdtdx/core/physics/metrics.py
+++ b/src/fdtdx/core/physics/metrics.py
@@ -140,7 +140,9 @@ def compute_integrated_power(
     S_real = 0.5 * jnp.real(S_complex[axis])  # power flow in desired direction
 
     if area_weights is not None:
-        S_real = S_real * area_weights
+        # normalize area weights for numerical stability and consistency with the None case
+        relative_weights = area_weights / jnp.mean(area_weights)
+        S_real = S_real * relative_weights
 
     # Integrate over transverse plane (axis orthogonal to `axis`)
     power = jnp.abs(jnp.sum(S_real))


### PR DESCRIPTION
Resolves #387 

To respect the different cell sizes for non-uniform grids in the poynting flux computation, PR #344 scaled the cell values by their metric area. However, this is outside the operating range of the smaller data types like float8 which is commonly used for saving the fields for the backward simulation when computing gradients.

This PR fixes this issue by normalizing the area weights.

In the future, we should look into using a method that explicitly optimizes for numerical stability.