### PR TITLE
Fix inconsistent mode scaling between source and detector

### DIFF
--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -104,6 +104,7 @@ class ModeOverlapDetector(PhasorDetector):
         else:
             spacing = self._config.uniform_spacing()
             weights = jnp.ones(self.grid_shape, dtype=jnp.float32) * spacing * spacing
+        weights = weights / weights.mean()  # consistent with scaling in compute_mode
         self = self.aset("_cached_face_area_weights", weights, create_new_ok=True)
         return self
 

--- a/tests/unit/objects/detectors/test_mode.py
+++ b/tests/unit/objects/detectors/test_mode.py
@@ -333,8 +333,8 @@ class TestModeOverlapDetectorComputeOverlap:
 
         assert jnp.isclose(overlap, expected)
 
-    def test_compute_overlap_integrates_nonuniform_face_area(self, random_key, single_frequency):
-        """A constant overlap integrand integrates to the detector face area."""
+    def test_compute_overlap_invariant_to_absolute_face_area(self, random_key, single_frequency):
+        """A constant overlap integrand only considers the relative detector face area."""
         grid = RectilinearGrid(
             x_edges=jnp.asarray([0.0, 1.0, 3.0]),
             y_edges=jnp.asarray([0.0, 3.0, 7.0]),
@@ -352,7 +352,7 @@ class TestModeOverlapDetectorComputeOverlap:
 
         overlap = det.compute_overlap_to_mode(state=state, mode_E=mode_E, mode_H=mode_H)
 
-        assert jnp.allclose(overlap, jnp.asarray(21.0 / 4.0, dtype=jnp.complex64))
+        assert jnp.allclose(overlap, jnp.asarray(1.0, dtype=jnp.complex64))
 
     def test_transverse_edge_coordinates_follow_detector_slice(self, random_key, single_frequency):
         """Mode solving receives the physical edge arrays for the transverse detector axes."""


### PR DESCRIPTION
The recent PR #388 reverted the mode normalization, so that the fields produced by a mode source are suitable for checkpointing in smaller dtypes. However, this introduced an inconsistency between mode source and mode detector.

This PR makes the behaviour consistent, so that a mode detector placed on the same waveguide as a mode source measures a mode overlap of 1, by applying the same scaling to the mode overlap computation in the mode detector that is also applied in `compute_mode`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mode-overlap calculations by normalizing detector face-area weighting, making results consistent with the scaling used during mode computation.
  * Overlap outputs are now invariant to the absolute detector face area when the overlap integrand is constant.
* **Tests**
  * Updated unit tests to reflect the corrected weighting behavior and adjusted expected scaling accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->