### PR TITLE
enhancement: "auto" aspect plots and color map argument for detector videos

### DIFF
--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -289,7 +289,7 @@ class Detector(SimulationObject, ABC):
                                    red-blue seaborn color map.
             aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
                     "equal" (default) uses the same scale for all axes.
-                    "auto" ajusts each axis's scale to fit the figure size.
+                    "auto" adjusts each axis's scale to fit the figure size.
 
         Returns:
             dict[str, Figure | str]: Dictionary mapping plot names to either

--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Self
+from typing import Literal, Self
 
 import jax
 import jax.numpy as jnp
@@ -273,6 +273,7 @@ class Detector(SimulationObject, ABC):
         self,
         state: dict[str, np.ndarray],
         progress: Progress | None = None,
+        aspect: Literal["auto", "equal"] = "equal",
     ) -> dict[str, Figure | str]:
         """Generates plots or videos from recorded detector data.
 
@@ -367,6 +368,7 @@ class Detector(SimulationObject, ABC):
                     coordinate_edges_um=self._plot_coordinate_edges_um(),
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
+                    aspect=aspect,
                 )
                 figs["sliced_plot"] = fig
             else:
@@ -385,6 +387,7 @@ class Detector(SimulationObject, ABC):
                     coordinate_edges_um=self._plot_coordinate_edges_um(),
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
+                    aspect=aspect,
                 )
                 figs["sliced_video"] = path
             else:
@@ -406,6 +409,7 @@ class Detector(SimulationObject, ABC):
                     coordinate_edges_um=self._plot_coordinate_edges_um(),
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
+                    aspect=aspect,
                 )
                 figs[k] = fig
         elif squeezed_ndim == 4 and self.num_time_steps_recorded > 1:
@@ -425,6 +429,7 @@ class Detector(SimulationObject, ABC):
                     coordinate_edges_um=self._plot_coordinate_edges_um(),
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
+                    aspect=aspect,
                 )
                 figs[k] = path
         else:

--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -273,6 +273,7 @@ class Detector(SimulationObject, ABC):
         self,
         state: dict[str, np.ndarray],
         progress: Progress | None = None,
+        cmap: str = "default",
         aspect: Literal["auto", "equal"] = "equal",
     ) -> dict[str, Figure | str]:
         """Generates plots or videos from recorded detector data.
@@ -369,6 +370,7 @@ class Detector(SimulationObject, ABC):
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
                     aspect=aspect,
+                    cmap=cmap,
                 )
                 figs["sliced_plot"] = fig
             else:
@@ -388,6 +390,7 @@ class Detector(SimulationObject, ABC):
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
                     aspect=aspect,
+                    cmap=cmap,
                 )
                 figs["sliced_video"] = path
             else:
@@ -410,6 +413,7 @@ class Detector(SimulationObject, ABC):
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
                     aspect=aspect,
+                    cmap=cmap,
                 )
                 figs[k] = fig
         elif squeezed_ndim == 4 and self.num_time_steps_recorded > 1:
@@ -430,6 +434,7 @@ class Detector(SimulationObject, ABC):
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
                     aspect=aspect,
+                    cmap=cmap,
                 )
                 figs[k] = path
         else:

--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -285,6 +285,11 @@ class Detector(SimulationObject, ABC):
         Args:
             state (dict[str, np.ndarray]): Dictionary containing recorded field data arrays.
             progress (Progress | None, optional): Optional progress bar for video generation.
+            cmap: str = "default": Color map for the detector plots. "default" is a custom
+                                   red-blue seaborn color map.
+            aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
+                    "equal" (default) uses the same scale for all axes.
+                    "auto" ajusts each axis's scale to fit the figure size.
 
         Returns:
             dict[str, Figure | str]: Dictionary mapping plot names to either

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -71,7 +71,7 @@ def plot_2d_from_slices(
         extent1 = (
             -xy_slice.shape[0] * res_x / 2,
             xy_slice.shape[0] * res_x / 2,
-            -xy_slice.shape[0] * res_x / 2,
+            -xy_slice.shape[1] * res_x / 2,
             xy_slice.shape[1] * res_y / 2,
         )
         cax1 = ax1.imshow(
@@ -108,7 +108,7 @@ def plot_2d_from_slices(
         extent2 = (
             -xz_slice.shape[0] * res_x / 2,
             xz_slice.shape[0] * res_x / 2,
-            -xz_slice.shape[0] * res_x / 2,
+            -xz_slice.shape[1] * res_x / 2,
             xz_slice.shape[1] * res_z / 2,
         )
         cax2 = ax2.imshow(
@@ -144,8 +144,8 @@ def plot_2d_from_slices(
         extent3 = (
             -yz_slice.shape[0] * res_y / 2,
             yz_slice.shape[0] * res_y / 2,
-            -yz_slice.shape[0] * res_y / 2,
-            yz_slice.shape[0] * res_y / 2,
+            -yz_slice.shape[1] * res_y / 2,
+            yz_slice.shape[1] * res_y / 2,
         )
         cax3 = ax3.imshow(
             yz_slice.T,

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -71,7 +71,7 @@ def plot_2d_from_slices(
         extent1 = (
             -xy_slice.shape[0] * res_x / 2,
             xy_slice.shape[0] * res_x / 2,
-            -xy_slice.shape[1] * res_x / 2,
+            -xy_slice.shape[1] * res_y / 2,
             xy_slice.shape[1] * res_y / 2,
         )
         cax1 = ax1.imshow(
@@ -108,7 +108,7 @@ def plot_2d_from_slices(
         extent2 = (
             -xz_slice.shape[0] * res_x / 2,
             xz_slice.shape[0] * res_x / 2,
-            -xz_slice.shape[1] * res_x / 2,
+            -xz_slice.shape[1] * res_z / 2,
             xz_slice.shape[1] * res_z / 2,
         )
         cax2 = ax2.imshow(
@@ -144,8 +144,8 @@ def plot_2d_from_slices(
         extent3 = (
             -yz_slice.shape[0] * res_y / 2,
             yz_slice.shape[0] * res_y / 2,
-            -yz_slice.shape[1] * res_y / 2,
-            yz_slice.shape[1] * res_y / 2,
+            -yz_slice.shape[1] * res_z / 2,
+            yz_slice.shape[1] * res_z / 2,
         )
         cax3 = ax3.imshow(
             yz_slice.T,

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -69,10 +69,10 @@ def plot_2d_from_slices(
     assert minvals[0] is not None and maxvals[0] is not None
     if coordinate_edges_um is None:
         extent1 = (
-            0,
-            xy_slice.shape[0] * res_x,
-            0,
-            xy_slice.shape[1] * res_y,
+            -xy_slice.shape[0] * res_x / 2,
+            xy_slice.shape[0] * res_x / 2,
+            -xy_slice.shape[0] * res_x / 2,
+            xy_slice.shape[1] * res_y / 2,
         )
         cax1 = ax1.imshow(
             xy_slice.T,
@@ -106,10 +106,10 @@ def plot_2d_from_slices(
     assert minvals[1] is not None and maxvals[1] is not None
     if coordinate_edges_um is None:
         extent2 = (
-            0,
-            xz_slice.shape[0] * res_x,
-            0,
-            xz_slice.shape[1] * res_z,
+            -xz_slice.shape[0] * res_x / 2,
+            xz_slice.shape[0] * res_x / 2,
+            -xz_slice.shape[0] * res_x / 2,
+            xz_slice.shape[1] * res_z / 2,
         )
         cax2 = ax2.imshow(
             xz_slice.T,
@@ -142,10 +142,10 @@ def plot_2d_from_slices(
     assert minvals[2] is not None and maxvals[2] is not None
     if coordinate_edges_um is None:
         extent3 = (
-            0,
-            yz_slice.shape[0] * res_y,
-            0,
-            yz_slice.shape[1] * res_z,
+            -yz_slice.shape[0] * res_y / 2,
+            yz_slice.shape[0] * res_y / 2,
+            -yz_slice.shape[0] * res_y / 2,
+            yz_slice.shape[0] * res_y / 2,
         )
         cax3 = ax3.imshow(
             yz_slice.T,

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -64,6 +64,20 @@ def plot_2d_from_slices(
     res_z = resolutions[2] / 1.0e-6
     colorbar_shrink = 0.5
 
+    # Center rectilinear coordinates for plotting
+    if coordinate_edges_um is not None:
+        # Center the x, y and z coordinate edges
+        center_x = (coordinate_edges_um[0][0] + coordinate_edges_um[0][-1]) / 2
+        center_y = (coordinate_edges_um[1][0] + coordinate_edges_um[1][-1]) / 2
+        center_z = (coordinate_edges_um[2][0] + coordinate_edges_um[2][-1]) / 2
+
+        # Subtract the center from all edges
+        x_edges_centered = coordinate_edges_um[0] - center_x
+        y_edges_centered = coordinate_edges_um[1] - center_y
+        z_edges_centered = coordinate_edges_um[2] - center_z
+    else:
+        x_edges_centered = y_edges_centered = z_edges_centered = None
+
     # Create XY plane plot
     ax1 = fig.add_subplot(131)
     assert minvals[0] is not None and maxvals[0] is not None
@@ -85,9 +99,10 @@ def plot_2d_from_slices(
             origin="lower",
         )
     else:
+        assert x_edges_centered is not None and y_edges_centered is not None
         cax1 = ax1.pcolormesh(
-            coordinate_edges_um[0],
-            coordinate_edges_um[1],
+            x_edges_centered,
+            y_edges_centered,
             xy_slice.T,
             cmap=color_map,
             vmin=minvals[0],
@@ -122,9 +137,10 @@ def plot_2d_from_slices(
             origin="lower",
         )
     else:
+        assert x_edges_centered is not None and z_edges_centered is not None
         cax2 = ax2.pcolormesh(
-            coordinate_edges_um[0],
-            coordinate_edges_um[2],
+            x_edges_centered,
+            z_edges_centered,
             xz_slice.T,
             cmap=color_map,
             vmin=minvals[1],
@@ -158,9 +174,10 @@ def plot_2d_from_slices(
             origin="lower",
         )
     else:
+        assert y_edges_centered is not None and z_edges_centered is not None
         cax3 = ax3.pcolormesh(
-            coordinate_edges_um[1],
-            coordinate_edges_um[2],
+            y_edges_centered,
+            z_edges_centered,
             yz_slice.T,
             cmap=color_map,
             vmin=minvals[2],

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -103,6 +103,7 @@ def plot_2d_from_slices(
     # Create XZ plane plot
 
     ax2 = fig.add_subplot(132)
+    assert minvals[1] is not None and maxvals[1] is not None
     if coordinate_edges_um is None:
         extent2 = (
             0,
@@ -110,7 +111,6 @@ def plot_2d_from_slices(
             0,
             xz_slice.shape[1] * res_z,
         )
-        assert minvals[1] is not None and maxvals[1] is not None
         cax2 = ax2.imshow(
             xz_slice.T,
             cmap=color_map,
@@ -139,6 +139,7 @@ def plot_2d_from_slices(
 
     # # Create YZ plane plot
     ax3 = fig.add_subplot(133)
+    assert minvals[2] is not None and maxvals[2] is not None
     if coordinate_edges_um is None:
         extent3 = (
             0,
@@ -146,7 +147,6 @@ def plot_2d_from_slices(
             0,
             yz_slice.shape[1] * res_z,
         )
-        assert minvals[2] is not None and maxvals[2] is not None
         cax3 = ax3.imshow(
             yz_slice.T,
             cmap=color_map,

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -34,6 +34,11 @@ def plot_2d_from_slices(
         maxvals: Per-slice color maxima.
         plot_interpolation: Interpolation used by the legacy uniform imshow path.
         plot_dpi: Figure DPI.
+        cmap: str = "default": Color map for the detector plots. "default" is a custom
+            red-blue seaborn color map.
+        aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
+            "equal" (default) uses the same scale for all axes.
+            "auto" ajusts each axis's scale to fit the figure size.
 
     Returns:
         Matplotlib figure with XY, XZ, and YZ panels.

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
@@ -14,6 +16,7 @@ def plot_2d_from_slices(
     maxvals: tuple[float | None, float | None, float | None] = (None, None, None),
     plot_interpolation: str = "gaussian",
     plot_dpi: int | None = None,
+    aspect: float | Literal["equal", "auto"] = "equal",
 ) -> Figure:
     """Plot orthogonal slices using either uniform spacing or rectilinear edges.
 
@@ -61,6 +64,7 @@ def plot_2d_from_slices(
             0,
             xy_slice.shape[1] * res_y,
         )
+        assert minvals[0] is not None and maxvals[0] is not None
         cax1 = ax1.imshow(
             xy_slice.T,
             cmap=cmap,
@@ -68,7 +72,7 @@ def plot_2d_from_slices(
             vmax=maxvals[0],
             extent=extent1,
             interpolation=plot_interpolation,
-            aspect="equal",
+            aspect=aspect,
             origin="lower",
         )
     else:
@@ -81,7 +85,7 @@ def plot_2d_from_slices(
             vmax=maxvals[0],
             shading="auto",
         )
-        ax1.set_aspect("equal")
+        ax1.set_aspect(aspect)
     ax1.set_xlabel("X axis (µm)")
     ax1.set_ylabel("Y axis (µm)")
 
@@ -97,6 +101,7 @@ def plot_2d_from_slices(
             0,
             xz_slice.shape[1] * res_z,
         )
+        assert minvals[1] is not None and maxvals[1] is not None
         cax2 = ax2.imshow(
             xz_slice.T,
             cmap=cmap,
@@ -104,7 +109,7 @@ def plot_2d_from_slices(
             vmax=maxvals[1],
             extent=extent2,
             interpolation=plot_interpolation,
-            aspect="equal",
+            aspect=aspect,
             origin="lower",
         )
     else:
@@ -117,7 +122,7 @@ def plot_2d_from_slices(
             vmax=maxvals[1],
             shading="auto",
         )
-        ax2.set_aspect("equal")
+        ax2.set_aspect(aspect)
     ax2.set_xlabel("X axis (µm)")
     ax2.set_ylabel("Z axis (µm)")
 
@@ -132,6 +137,7 @@ def plot_2d_from_slices(
             0,
             yz_slice.shape[1] * res_z,
         )
+        assert minvals[2] is not None and maxvals[2] is not None
         cax3 = ax3.imshow(
             yz_slice.T,
             cmap=cmap,
@@ -139,7 +145,7 @@ def plot_2d_from_slices(
             vmax=maxvals[2],
             extent=extent3,
             interpolation=plot_interpolation,
-            aspect="equal",
+            aspect=aspect,
             origin="lower",
         )
     else:
@@ -152,7 +158,7 @@ def plot_2d_from_slices(
             vmax=maxvals[2],
             shading="auto",
         )
-        ax3.set_aspect("equal")
+        ax3.set_aspect(aspect)
     ax3.set_xlabel("Y axis (µm)")
     ax3.set_ylabel("Z axis (µm)")
 

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -16,7 +16,7 @@ def plot_2d_from_slices(
     maxvals: tuple[float | None, float | None, float | None] = (None, None, None),
     plot_interpolation: str = "gaussian",
     plot_dpi: int | None = None,
-    aspect: float | Literal["equal", "auto"] = "equal",
+    aspect: Literal["equal", "auto"] = "equal",
     cmap: str = "default",
 ) -> Figure:
     """Plot orthogonal slices using either uniform spacing or rectilinear edges.
@@ -38,7 +38,7 @@ def plot_2d_from_slices(
             red-blue seaborn color map.
         aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
             "equal" (default) uses the same scale for all axes.
-            "auto" ajusts each axis's scale to fit the figure size.
+            "auto" adjusts each axis's scale to fit the figure size.
 
     Returns:
         Matplotlib figure with XY, XZ, and YZ panels.
@@ -66,6 +66,7 @@ def plot_2d_from_slices(
 
     # Create XY plane plot
     ax1 = fig.add_subplot(131)
+    assert minvals[0] is not None and maxvals[0] is not None
     if coordinate_edges_um is None:
         extent1 = (
             0,
@@ -73,7 +74,6 @@ def plot_2d_from_slices(
             0,
             xy_slice.shape[1] * res_y,
         )
-        assert minvals[0] is not None and maxvals[0] is not None
         cax1 = ax1.imshow(
             xy_slice.T,
             cmap=color_map,

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -17,6 +17,7 @@ def plot_2d_from_slices(
     plot_interpolation: str = "gaussian",
     plot_dpi: int | None = None,
     aspect: float | Literal["equal", "auto"] = "equal",
+    cmap: str = "default",
 ) -> Figure:
     """Plot orthogonal slices using either uniform spacing or rectilinear edges.
 
@@ -49,7 +50,10 @@ def plot_2d_from_slices(
             maxvals = max_list[0], max_list[1], max_list[2]
 
     fig = plt.figure(figsize=(20, 10), dpi=plot_dpi)
-    cmap = sns.diverging_palette(220, 20, as_cmap=True)
+    if cmap == "default":
+        color_map = sns.diverging_palette(220, 20, as_cmap=True)
+    else:
+        color_map = cmap
     res_x = resolutions[0] / 1.0e-6  # Convert to µm
     res_y = resolutions[1] / 1.0e-6
     res_z = resolutions[2] / 1.0e-6
@@ -67,7 +71,7 @@ def plot_2d_from_slices(
         assert minvals[0] is not None and maxvals[0] is not None
         cax1 = ax1.imshow(
             xy_slice.T,
-            cmap=cmap,
+            cmap=color_map,
             vmin=minvals[0],
             vmax=maxvals[0],
             extent=extent1,
@@ -80,7 +84,7 @@ def plot_2d_from_slices(
             coordinate_edges_um[0],
             coordinate_edges_um[1],
             xy_slice.T,
-            cmap=cmap,
+            cmap=color_map,
             vmin=minvals[0],
             vmax=maxvals[0],
             shading="auto",
@@ -104,7 +108,7 @@ def plot_2d_from_slices(
         assert minvals[1] is not None and maxvals[1] is not None
         cax2 = ax2.imshow(
             xz_slice.T,
-            cmap=cmap,
+            cmap=color_map,
             vmin=minvals[1],
             vmax=maxvals[1],
             extent=extent2,
@@ -117,7 +121,7 @@ def plot_2d_from_slices(
             coordinate_edges_um[0],
             coordinate_edges_um[2],
             xz_slice.T,
-            cmap=cmap,
+            cmap=color_map,
             vmin=minvals[1],
             vmax=maxvals[1],
             shading="auto",
@@ -140,7 +144,7 @@ def plot_2d_from_slices(
         assert minvals[2] is not None and maxvals[2] is not None
         cax3 = ax3.imshow(
             yz_slice.T,
-            cmap=cmap,
+            cmap=color_map,
             vmin=minvals[2],
             vmax=maxvals[2],
             extent=extent3,
@@ -153,7 +157,7 @@ def plot_2d_from_slices(
             coordinate_edges_um[1],
             coordinate_edges_um[2],
             yz_slice.T,
-            cmap=cmap,
+            cmap=color_map,
             vmin=minvals[2],
             vmax=maxvals[2],
             shading="auto",

--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -109,6 +109,11 @@ def generate_video_from_slices(
             scaling. None values are auto-scaled. Defaults to (None, None, None)
         maxvals (tuple[float | None, float | None, float | None]): Tuple of maximum values for colormap scaling.
             None values are auto-scaled. Defaults to (None, None, None).
+        cmap: str = "default": Color map for the detector plots. "default" is a custom
+            red-blue seaborn color map.
+        aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
+            "equal" (default) uses the same scale for all axes.
+            "auto" ajusts each axis's scale to fit the figure size.
 
     Returns:
         str: Path to the generated MP4 video file

--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -113,7 +113,7 @@ def generate_video_from_slices(
             red-blue seaborn color map.
         aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
             "equal" (default) uses the same scale for all axes.
-            "auto" ajusts each axis's scale to fit the figure size.
+            "auto" adjusts each axis's scale to fit the figure size.
 
     Returns:
         str: Path to the generated MP4 video file

--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -1,7 +1,7 @@
 import multiprocessing as mp
 import tempfile
 from functools import partial
-from typing import Callable
+from typing import Callable, Literal
 
 import matplotlib
 
@@ -80,6 +80,7 @@ def generate_video_from_slices(
     minvals: tuple[float | None, float | None, float | None] = (None, None, None),
     maxvals: tuple[float | None, float | None, float | None] = (None, None, None),
     coordinate_edges_um: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
+    aspect: Literal["auto", "equal"] = "equal",
 ) -> str:
     """Generates an MP4 video from time-series slice data using parallel processing.
 
@@ -133,6 +134,7 @@ def generate_video_from_slices(
         plot_dpi=plot_dpi,
         plot_interpolation=plot_interpolation,
         coordinate_edges_um=coordinate_edges_um,
+        aspect=aspect,
     )
     slice_arr_list = [(xy_slice[t], xz_slice[t], yz_slice[t]) for t in range(time_steps)]
     if num_worker is None:

--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -24,6 +24,8 @@ def plot_from_slices(
     plot_dpi: int | None,
     plot_interpolation: str,
     coordinate_edges_um: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
+    aspect: Literal["auto", "equal"] = "equal",
+    cmap: str = "default",
 ):
     xy_slice, xz_slice, yz_slice = slice_tuple
 
@@ -37,6 +39,8 @@ def plot_from_slices(
         maxvals=maxvals,
         plot_dpi=plot_dpi,
         plot_interpolation=plot_interpolation,
+        aspect=aspect,
+        cmap=cmap,
     )
     # Convert matplotlib figure to a numpy array
     fig.canvas.draw()
@@ -81,6 +85,7 @@ def generate_video_from_slices(
     maxvals: tuple[float | None, float | None, float | None] = (None, None, None),
     coordinate_edges_um: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
     aspect: Literal["auto", "equal"] = "equal",
+    cmap: str = "default",
 ) -> str:
     """Generates an MP4 video from time-series slice data using parallel processing.
 
@@ -135,6 +140,7 @@ def generate_video_from_slices(
         plot_interpolation=plot_interpolation,
         coordinate_edges_um=coordinate_edges_um,
         aspect=aspect,
+        cmap=cmap,
     )
     slice_arr_list = [(xy_slice[t], xz_slice[t], yz_slice[t]) for t in range(time_steps)]
     if num_worker is None:

--- a/tests/unit/objects/detectors/test_detector.py
+++ b/tests/unit/objects/detectors/test_detector.py
@@ -150,8 +150,10 @@ class TestDrawPlotWaterfallAndSlices:
 
         assert "sliced_plot" in figs
         assert isinstance(figs["sliced_plot"], Figure)
-        assert figs["sliced_plot"].axes[0].get_xlim() == pytest.approx((0.0, 4.0))
-        assert figs["sliced_plot"].axes[0].get_ylim() == pytest.approx((0.0, 5.0))
+        assert figs["sliced_plot"].axes[0].get_xlim() == pytest.approx(
+            (-2.0, 2.0)
+        )  # plots use origin-at-center coordinates
+        assert figs["sliced_plot"].axes[0].get_ylim() == pytest.approx((-2.5, 2.5))
         plt.close(figs["sliced_plot"])
 
     def test_2d_single_timestep_wrong_keys_raises(self, simulation_config, small_grid_slice, random_key, single_switch):

--- a/tests/unit/utils/test_plot_setup.py
+++ b/tests/unit/utils/test_plot_setup.py
@@ -10,6 +10,7 @@ import pytest
 matplotlib.use("Agg")
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle
 
 from fdtdx.core.grid import RectilinearGrid
 from fdtdx.utils.plot_setup import plot_setup, plot_setup_from_side
@@ -96,7 +97,7 @@ class TestPlotSetupFromSide:
         container = _make_container()
         _fig, ax = plt.subplots()
         with pytest.raises(ValueError, match="Invalid viewing_side"):
-            plot_setup_from_side(config=config, objects=container, viewing_side="w", ax=ax)
+            plot_setup_from_side(config=config, objects=container, viewing_side="w", ax=ax)  # type: ignore
         plt.close("all")
 
     def test_nonuniform_grid_uses_physical_extents(self):
@@ -107,17 +108,12 @@ class TestPlotSetupFromSide:
             y_edges=jnp.asarray([-2.5e-6, -0.5e-6, 2.5e-6]),  # centered: total 5µm
             z_edges=jnp.asarray([-0.5e-6, 0.5e-6]),  # centered: total 1µm
         )
-        config.grid = RectilinearGrid(
-            x_edges=jnp.asarray([-2.0e-6, -1.0e-6, 2.0e-6]),  # centered: total 4µm
-            y_edges=jnp.asarray([-2.5e-6, -0.5e-6, 2.5e-6]),  # centered: total 5µm
-            z_edges=jnp.asarray([-0.5e-6, 0.5e-6]),  # centered: total 1µm
-        )
         obj = _MockObj("box", "blue", ((1, 2), (0, 2), (0, 1)))
         container = _make_container(objects=[obj], volume_grid_shape=(2, 2, 1))
         _fig, ax = plt.subplots()
         plot_setup_from_side(config=config, objects=container, viewing_side="z", ax=ax, plot_legend=False)
 
-        patch = ax.patches[0]
+        patch: Rectangle = ax.patches[0]  # type: ignore
         assert patch.get_x() == pytest.approx(-1.0)
         assert patch.get_width() == pytest.approx(3.0)
         assert patch.get_y() == pytest.approx(-2.5)
@@ -203,7 +199,7 @@ class TestPlotSetupFromSide:
             viewing_side="z",
             ax=ax,
             plot_legend=False,
-            exclude_object_list=[obj_b],
+            exclude_object_list=[obj_b],  # type: ignore
         )
         assert len(ax.patches) == 1
         plt.close("all")
@@ -302,7 +298,7 @@ class TestPlotSetup:
             objects=container,
             axs=axs,
             plot_legend=False,
-            exclude_object_list=[obj_b],
+            exclude_object_list=[obj_b],  # type: ignore
         )
         # Each of the 3 axes should show only obj_a (1 patch each)
         for ax in axs:

--- a/tests/unit/utils/test_plot_setup.py
+++ b/tests/unit/utils/test_plot_setup.py
@@ -107,6 +107,11 @@ class TestPlotSetupFromSide:
             y_edges=jnp.asarray([-2.5e-6, -0.5e-6, 2.5e-6]),  # centered: total 5µm
             z_edges=jnp.asarray([-0.5e-6, 0.5e-6]),  # centered: total 1µm
         )
+        config.grid = RectilinearGrid(
+            x_edges=jnp.asarray([-2.0e-6, -1.0e-6, 2.0e-6]),  # centered: total 4µm
+            y_edges=jnp.asarray([-2.5e-6, -0.5e-6, 2.5e-6]),  # centered: total 5µm
+            z_edges=jnp.asarray([-0.5e-6, 0.5e-6]),  # centered: total 1µm
+        )
         obj = _MockObj("box", "blue", ((1, 2), (0, 2), (0, 1)))
         container = _make_container(objects=[obj], volume_grid_shape=(2, 2, 1))
         _fig, ax = plt.subplots()


### PR DESCRIPTION
This small PR adds two arguments to detector states plotting functions:

- `aspect` that can be either `auto` or `equal`. The legacy behavior, `equal`, sets equal scales to all axes when plotting figures. It is kept as default. The other behavior, `auto` sets custom scales to all axes so that the plots fill the most space available.
- `cmap` is a matplotlib colormap. The legacy behavior is a custom red-blue colormap that is kept as "default".

Below is an example of plot obtained with `aspect="auto"` and `cmap="turbo"`.


<img width="1521" height="829" alt="Screenshot 2026-07-06 160557" src="https://github.com/user-attachments/assets/066de522-4154-4143-a022-af6f41338683" />

And here below, an example with `aspect="equal"` and `cmap="default"`.

<img width="985" height="296" alt="Screenshot 2026-07-06 165117" src="https://github.com/user-attachments/assets/b90650c0-f687-4916-93be-e82e5fc383be" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detector 2D slice plots and video frames now support customizable `cmap` (default `default`) and `aspect` (`auto`/`equal`, default `equal`), applied consistently across plot panels and rendering modes.
* **Bug Fixes**
  * Improved plot robustness by validating required per-slice min/max values before rendering.
  * Aspect handling is now honored for both image and mesh-based views, and centered micrometer extents are used when coordinate edges aren’t provided.
* **Tests**
  * Updated unit tests for compatibility with the expanded plotting interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->