### PR TITLE
fix: serialize NumPy/JAX arrays in JSON export and allow roundtrip of polygon geometry

### DIFF
--- a/src/fdtdx/conversion/json.py
+++ b/src/fdtdx/conversion/json.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
 import jax
+import numpy as np
 
 from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import TreeClass
@@ -201,6 +202,20 @@ def _export_json(obj: Any) -> dict | float | int | str | bool | None:
     if isinstance(obj, float | int | str | bool):
         # basic data types
         return obj
+    # numpy arrays — must be checked before JAX_DTYPES to avoid ndarray.__eq__ TypeError
+    if isinstance(obj, np.ndarray):
+        return {
+            "__module__": "numpy",
+            "__name__": "array",
+            "__value__": obj.tolist(),
+        }
+    # JAX arrays — serialize as numpy arrays; RectilinearGrid.__post_init__ re-wraps via jnp.asarray
+    if isinstance(obj, jax.Array):
+        return {
+            "__module__": "numpy",
+            "__name__": "array",
+            "__value__": np.asarray(obj).tolist(),
+        }
     # jax data types
     if obj in JAX_DTYPES:
         str_name = str(obj).split("'")[1]
@@ -272,11 +287,13 @@ def export_json_str(obj: Any) -> str:
     return _json_dict_to_str(d)
 
 
-def _import_obj_from_json(obj: dict | float | int | str | bool | None) -> Any:
+def _import_obj_from_json(obj: dict | list | float | int | str | bool | None) -> Any:
     if obj is None:
         return None
     if isinstance(obj, int | float | str | bool):
         return obj
+    if isinstance(obj, list):
+        return [_import_obj_from_json(v) for v in obj]
     assert isinstance(obj, dict)
     # jax data types
     if "__dtype__" in obj:

--- a/src/fdtdx/conversion/json.py
+++ b/src/fdtdx/conversion/json.py
@@ -313,8 +313,11 @@ def _import_obj_from_json(obj: dict | list | float | int | str | bool | None) ->
             kwargs = {k: _import_obj_from_json(v) for k, v in vals.items()}
             return cls(**kwargs)
         # sequence
-        imported_vals = [_import_obj_from_json(v) for v in vals]
-        return cls(imported_vals)
+        if isinstance(vals, list):
+            imported_vals = [_import_obj_from_json(v) for v in vals]
+            return cls(imported_vals)
+        # 0-d numpy/jax array: ndarray.tolist() returns a bare scalar, not a list
+        return cls(_import_obj_from_json(vals))
     # dictionary
     if name == "dict":
         return {k: _import_obj_from_json(v) for k, v in obj.items() if k not in ["__module__", "__name__"]}

--- a/src/fdtdx/objects/static_material/polygon.py
+++ b/src/fdtdx/objects/static_material/polygon.py
@@ -41,7 +41,7 @@ class ExtrudedPolygon(StaticMultiMaterialObject):
         real_shape = list(self.partial_real_shape)
         grid_shape = list(self.partial_grid_shape)
         for ax, size in ((self.horizontal_axis, w), (self.vertical_axis, h)):
-            if real_shape[ax] is not None:
+            if real_shape[ax] is not None and real_shape[ax] != size:
                 raise Exception(
                     f"ExtrudedPolygon {self.name}: partial_real_shape for axis {ax} is derived from the "
                     f"vertex bounding box ({size:.3e} m). Do not specify it explicitly."

--- a/tests/integration/conversion/test_json.py
+++ b/tests/integration/conversion/test_json.py
@@ -344,14 +344,17 @@ def test_run_simulation_with_jsonsetup(setup_simulation_inputs, tmp_path):
 def test_extruded_polygon_json():
     """Test JSON serialization and deserialization of ExtrudedPolygon."""
     import numpy as np
+
     from fdtdx.objects.static_material.polygon import ExtrudedPolygon
 
-    verts = np.array([
-        [-0.5e-6, -0.5e-6],
-        [0.5e-6, -0.5e-6],
-        [0.5e-6, 0.5e-6],
-        [-0.5e-6, 0.5e-6],
-    ])
+    verts = np.array(
+        [
+            [-0.5e-6, -0.5e-6],
+            [0.5e-6, -0.5e-6],
+            [0.5e-6, 0.5e-6],
+            [-0.5e-6, 0.5e-6],
+        ]
+    )
     materials = {"si": Material(permittivity=12.0)}
     poly = ExtrudedPolygon(
         name="test_poly",
@@ -376,11 +379,10 @@ def test_extruded_polygon_json():
 def test_gds_layer_object_json():
     """Test JSON serialization and deserialization of GDSLayerObject."""
     import numpy as np
+
     from fdtdx.objects.static_material.gds_layer_stack import GDSLayerObject
 
-    polygons = [
-        np.array([[-0.5e-6, -0.5e-6], [0.5e-6, -0.5e-6], [0.5e-6, 0.5e-6], [-0.5e-6, 0.5e-6]])
-    ]
+    polygons = [np.array([[-0.5e-6, -0.5e-6], [0.5e-6, -0.5e-6], [0.5e-6, 0.5e-6], [-0.5e-6, 0.5e-6]])]
     materials = {"si": Material(permittivity=12.0)}
     obj = GDSLayerObject(
         name="gds_layer",
@@ -404,4 +406,3 @@ def test_gds_layer_object_json():
     assert rec.gds_center == (0.0, 0.0)
     assert len(rec.polygons) == 1
     np.testing.assert_array_equal(rec.polygons[0], polygons[0])
-

--- a/tests/integration/conversion/test_json.py
+++ b/tests/integration/conversion/test_json.py
@@ -339,3 +339,69 @@ def test_run_simulation_with_jsonsetup(setup_simulation_inputs, tmp_path):
     compiled = jax.jit(sim_fn).lower(params, arrays, key).compile()
     out = compiled(params, arrays, subkey)
     assert out is not None
+
+
+def test_extruded_polygon_json():
+    """Test JSON serialization and deserialization of ExtrudedPolygon."""
+    import numpy as np
+    from fdtdx.objects.static_material.polygon import ExtrudedPolygon
+
+    verts = np.array([
+        [-0.5e-6, -0.5e-6],
+        [0.5e-6, -0.5e-6],
+        [0.5e-6, 0.5e-6],
+        [-0.5e-6, 0.5e-6],
+    ])
+    materials = {"si": Material(permittivity=12.0)}
+    poly = ExtrudedPolygon(
+        name="test_poly",
+        axis=2,
+        material_name="si",
+        materials=materials,
+        vertices=verts,
+        partial_real_shape=(None, None, 220e-9),
+    )
+
+    s = export_json_str(poly)
+    rec = import_from_json(s)
+
+    assert isinstance(rec, ExtrudedPolygon)
+    assert rec.name == "test_poly"
+    assert rec.axis == 2
+    assert rec.material_name == "si"
+    assert rec.partial_real_shape == (1e-6, 1e-6, 220e-9)
+    np.testing.assert_array_equal(rec.vertices, verts)
+
+
+def test_gds_layer_object_json():
+    """Test JSON serialization and deserialization of GDSLayerObject."""
+    import numpy as np
+    from fdtdx.objects.static_material.gds_layer_stack import GDSLayerObject
+
+    polygons = [
+        np.array([[-0.5e-6, -0.5e-6], [0.5e-6, -0.5e-6], [0.5e-6, 0.5e-6], [-0.5e-6, 0.5e-6]])
+    ]
+    materials = {"si": Material(permittivity=12.0)}
+    obj = GDSLayerObject(
+        name="gds_layer",
+        materials=materials,
+        polygons=polygons,
+        gds_center=(0.0, 0.0),
+        material_name="si",
+        axis=2,
+        thickness=220e-9,
+        partial_real_shape=(None, None, 220e-9),
+    )
+
+    s = export_json_str(obj)
+    rec = import_from_json(s)
+
+    assert isinstance(rec, GDSLayerObject)
+    assert rec.name == "gds_layer"
+    assert rec.axis == 2
+    assert rec.material_name == "si"
+    assert rec.thickness == 220e-9
+    assert rec.gds_center == (0.0, 0.0)
+    assert len(rec.polygons) == 1
+    np.testing.assert_array_equal(rec.polygons[0], polygons[0])
+

--- a/tests/unit/conversion/test_json.py
+++ b/tests/unit/conversion/test_json.py
@@ -263,6 +263,7 @@ class TestJsonRoundtrip:
     def test_roundtrip_numpy_array(self):
         """Test roundtrip of a numpy array."""
         import numpy as np
+
         original = np.array([[1.0, 2.0], [3.0, 4.0]])
         restored = import_from_json(export_json_str(original))
         assert isinstance(restored, np.ndarray)
@@ -271,8 +272,8 @@ class TestJsonRoundtrip:
     def test_roundtrip_jax_array(self):
         """Test roundtrip of a JAX array."""
         import numpy as np
+
         original = jnp.array([[1.0, 2.0], [3.0, 4.0]])
         restored = import_from_json(export_json_str(original))
         assert isinstance(restored, np.ndarray)
         np.testing.assert_array_equal(restored, np.asarray(original))
-

--- a/tests/unit/conversion/test_json.py
+++ b/tests/unit/conversion/test_json.py
@@ -259,3 +259,20 @@ class TestJsonRoundtrip:
         restored = import_from_json(export_json_str(original))
         assert restored["items"] == [1, 2, 3]
         assert restored["value"] == 42
+
+    def test_roundtrip_numpy_array(self):
+        """Test roundtrip of a numpy array."""
+        import numpy as np
+        original = np.array([[1.0, 2.0], [3.0, 4.0]])
+        restored = import_from_json(export_json_str(original))
+        assert isinstance(restored, np.ndarray)
+        np.testing.assert_array_equal(restored, original)
+
+    def test_roundtrip_jax_array(self):
+        """Test roundtrip of a JAX array."""
+        import numpy as np
+        original = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+        restored = import_from_json(export_json_str(original))
+        assert isinstance(restored, np.ndarray)
+        np.testing.assert_array_equal(restored, np.asarray(original))
+

--- a/tests/unit/conversion/test_json.py
+++ b/tests/unit/conversion/test_json.py
@@ -277,3 +277,23 @@ class TestJsonRoundtrip:
         restored = import_from_json(export_json_str(original))
         assert isinstance(restored, np.ndarray)
         np.testing.assert_array_equal(restored, np.asarray(original))
+
+    def test_roundtrip_0d_numpy_array(self):
+        """Test roundtrip of a 0-d numpy array (scalar array)."""
+        import numpy as np
+
+        original = np.array(3.14)
+        restored = import_from_json(export_json_str(original))
+        assert isinstance(restored, np.ndarray)
+        assert restored.shape == ()
+        np.testing.assert_array_equal(restored, original)
+
+    def test_roundtrip_0d_jax_array(self):
+        """Test roundtrip of a 0-d JAX array (scalar array)."""
+        import numpy as np
+
+        original = jnp.array(3.14)
+        restored = import_from_json(export_json_str(original))
+        assert isinstance(restored, np.ndarray)
+        assert restored.shape == ()
+        np.testing.assert_array_equal(restored, np.asarray(original))


### PR DESCRIPTION
Problem
The JSON export/import pipeline (export_json_str / import_from_json) was broken for any simulation setup involving GDS-imported geometry (GDSLayerObject) or custom polygon geometry (ExtrudedPolygon). Two distinct bugs caused failures:

1. Array serialization crash (conversion/json.py)
GDSLayerObject.polygons and ExtrudedPolygon.vertices are stored as numpy.ndarrays. The JSON exporter reached the if obj in JAX_DTYPES type-check before handling arrays, which internally triggers an element-wise == comparison, resulting in:

TypeError: descriptor '__array_wrap__' for 'numpy.generic' objects doesn't apply to a 'numpy.ndarray' object

2. Deserialization shape validation error (polygon.py)
When a serialized ExtrudedPolygon is reloaded, the constructor is called with the auto-derived partial_real_shape values (e.g. (1e-6, 1e-6, 220e-9)). The __post_init__ guard was too strict and raised an error for any non-None shape, even when the value matched the vertex bounding box exactly:

Exception: ExtrudedPolygon test_poly: partial_real_shape for axis 0 is derived from the vertex bounding box. Do not specify it explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved JSON import/export for array data, including reliable round-tripping of NumPy and JAX arrays (with correct reconstruction of list-based and scalar payloads).

* **Bug Fixes**
  * Fixed JSON deserialization issues involving nested list payloads and boolean values.
  * Relaxed polygon shape validation so partial 3D real-shape inputs are only rejected when they conflict with the derived geometry.

* **Tests**
  * Added integration and unit coverage for JSON round-trip behavior of polygon materials and array inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->