### PR TITLE
feat(gds): sub-pixel dielectric smoothing for GDS layer objects (closes #373)

### DIFF
--- a/src/fdtdx/fdtd/container.py
+++ b/src/fdtdx/fdtd/container.py
@@ -103,9 +103,10 @@ class ObjectContainer(TreeClass):
     def any_object_subpixel_smoothing(self) -> bool:
         """True if any static multi-material object requests sub-pixel dielectric smoothing.
 
-        When True the permittivity must be allocated as a full 9-component tensor (the smoothing
-        produces an anisotropic effective permittivity at interface cells), regardless of the fact that
-        every underlying material is isotropic.
+        When True the permittivity must be allocated as an anisotropic effective permittivity at
+        interface cells even though every underlying material is isotropic. The default (diagonal)
+        variant uses a 3-component allocation; a full 9-component tensor is only used when
+        ``any_object_subpixel_full_tensor`` is also True.
         """
         return any(getattr(o, "subpixel_smoothing", False) for o in self.static_material_objects)
 

--- a/src/fdtdx/fdtd/container.py
+++ b/src/fdtdx/fdtd/container.py
@@ -100,6 +100,29 @@ class ObjectContainer(TreeClass):
         return [o for o in self.objects if isinstance(o, BaseBoundary)]
 
     @property
+    def any_object_subpixel_smoothing(self) -> bool:
+        """True if any static multi-material object requests sub-pixel dielectric smoothing.
+
+        When True the permittivity must be allocated as a full 9-component tensor (the smoothing
+        produces an anisotropic effective permittivity at interface cells), regardless of the fact that
+        every underlying material is isotropic.
+        """
+        return any(getattr(o, "subpixel_smoothing", False) for o in self.static_material_objects)
+
+    @property
+    def any_object_subpixel_full_tensor(self) -> bool:
+        """True if any smoothed object requests the full 9-component tensor (vs the cheap 3-comp diagonal).
+
+        When True the permittivity is allocated as a full 9-component tensor and the anisotropic update
+        kernel is used; when False (all smoothed objects diagonal) a 3-component diagonal allocation runs on
+        the cheaper elementwise update, which is exact for axis-aligned interfaces.
+        """
+        return any(
+            getattr(o, "subpixel_smoothing", False) and getattr(o, "subpixel_full_tensor", False)
+            for o in self.static_material_objects
+        )
+
+    @property
     def all_objects_non_magnetic(self) -> bool:
         def _fn(m: Material):
             return not m.is_magnetic

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -586,6 +586,21 @@ def _init_arrays(
     # variant keeps the off-diagonal terms and forces a 9-component allocation (anisotropic kernel).
     subpixel_permittivity = objects.any_object_subpixel_smoothing
     subpixel_full_tensor = objects.any_object_subpixel_full_tensor
+    if subpixel_permittivity and not isotropic_permittivity:
+        # The eps_bar/eps_h blend below (isotropic-background assumption) only ever reads the xx
+        # component of the background and object material, so yy/zz/off-diagonal anisotropy on either
+        # side of a smoothed interface is silently dropped rather than rejected or routed through a
+        # dedicated anisotropic path. Not yet handled - see fdtdx#400.
+        warnings.warn(
+            "`subpixel_smoothing=True` is combined with an anisotropic material somewhere in the "
+            "simulation. Sub-pixel smoothing currently assumes locally isotropic permittivity at "
+            "interface cells (only the xx component of the background/material is used to compute the "
+            "smoothed value); any yy/zz or off-diagonal anisotropy is silently ignored there. Use "
+            "isotropic materials on and around sub-pixel-smoothed objects until this is properly "
+            "supported.",
+            UserWarning,
+            stacklevel=2,
+        )
     if subpixel_permittivity:
         isotropic_permittivity = False
         diagonally_anisotropic_permittivity = not subpixel_full_tensor

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -580,6 +580,16 @@ def _init_arrays(
     diagonally_anisotropic_electric_conductivity = objects.all_objects_diagonally_anisotropic_electric_conductivity
     diagonally_anisotropic_magnetic_conductivity = objects.all_objects_diagonally_anisotropic_magnetic_conductivity
 
+    # Sub-pixel smoothing produces an anisotropic effective permittivity at interface cells even when
+    # every material is isotropic. The DIAGONAL variant (default) keeps only eps_ii and allocates a
+    # 3-component array (cheap elementwise update, exact for axis-aligned interfaces); the FULL-TENSOR
+    # variant keeps the off-diagonal terms and forces a 9-component allocation (anisotropic kernel).
+    subpixel_permittivity = objects.any_object_subpixel_smoothing
+    subpixel_full_tensor = objects.any_object_subpixel_full_tensor
+    if subpixel_permittivity:
+        isotropic_permittivity = False
+        diagonally_anisotropic_permittivity = not subpixel_full_tensor
+
     # Get component counts for each property
     if isotropic_permittivity:
         num_perm_components = 1
@@ -846,7 +856,8 @@ def _init_arrays(
 
         elif isinstance(o, (StaticMultiMaterialObject)):
             indices = o.get_material_mapping()
-            mask = o.get_voxel_mask_for_shape()
+            use_subpixel = subpixel_permittivity and getattr(o, "subpixel_smoothing", False)
+            mask = o.get_fill_fraction_for_shape() if use_subpixel else o.get_voxel_mask_for_shape()
 
             # compute_allowed_permittivities returns list of tuples with length 1 (isotropic), 3 (diagonally anisotropic), or 9 (fully anisotropic)
             allowed_perms = jnp.asarray(
@@ -862,9 +873,34 @@ def _init_arrays(
             component_values = jnp.moveaxis(allowed_perms[indices], -1, 0)
             perm_slice = _invert_property(inv_permittivities[:, *o.grid_slice])
 
-            # Linearly interpolate in the forward domain
-            perm_slice = perm_slice + mask * (component_values - perm_slice)
-            inv_permittivities = inv_permittivities.at[:, *o.grid_slice].set(_invert_property(perm_slice))
+            if use_subpixel:
+                # Farjadpour et al. (Meep) sub-pixel smoothing. Blend the object material (eps2) with the
+                # current background (eps1, treated as locally isotropic) using the cell fill fraction:
+                #   eps_bar (tangential) = arithmetic mean, eps_h (normal) = harmonic mean,
+                #   eps_eff = eps_bar * I - (eps_bar - eps_h) * (n (x) n).
+                # Interior cells (mask in {0,1}, normal = 0) collapse to the bulk value, so the formula is
+                # applied uniformly across the object's slice with no interface masking.
+                normal = o.get_interface_normal_for_shape()  # (3, *grid_shape), unit / zero
+                eps1 = perm_slice[0]  # background xx (locally isotropic background assumption)
+                eps2 = component_values[0]  # object material xx (= its isotropic permittivity)
+                eps_bar = mask * eps2 + (1.0 - mask) * eps1
+                eps_h = 1.0 / (mask / eps2 + (1.0 - mask) / eps1)
+                delta = eps_bar - eps_h  # (*grid_shape)
+                if subpixel_full_tensor:
+                    # 9-component: eps_bar * I - delta * (n (x) n). The arithmetic (I) part reuses the same
+                    # forward-domain linear blend as the isotropic path.
+                    perm_arith = perm_slice + mask[None, ...] * (component_values - perm_slice)
+                    nn_outer = jnp.stack([normal[a] * normal[b] for a in range(3) for b in range(3)], axis=0)
+                    perm_smoothed = perm_arith - delta[None, ...] * nn_outer
+                else:
+                    # 3-component diagonal: eps_ii = eps_bar - delta * n_i**2 (the diagonal of the tensor
+                    # above). Exact for axis-aligned interfaces; runs on the cheap elementwise update.
+                    perm_smoothed = jnp.stack([eps_bar - delta * normal[i] ** 2 for i in range(3)], axis=0)
+                inv_permittivities = inv_permittivities.at[:, *o.grid_slice].set(_invert_property(perm_smoothed))
+            else:
+                # Linearly interpolate in the forward domain
+                perm_slice = perm_slice + mask * (component_values - perm_slice)
+                inv_permittivities = inv_permittivities.at[:, *o.grid_slice].set(_invert_property(perm_slice))
 
             if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
                 allowed_perms = jnp.asarray(

--- a/src/fdtdx/objects/static_material/gds_layer_stack.py
+++ b/src/fdtdx/objects/static_material/gds_layer_stack.py
@@ -75,6 +75,10 @@ class GDSLayerSpec:
     #: the default cheap 3-component diagonal. See
     #: :attr:`~fdtdx.objects.static_material.static.StaticMultiMaterialObject.subpixel_full_tensor`.
     subpixel_full_tensor: bool = False
+    #: Number of sub-samples per axis used to estimate the in-plane fill fraction when
+    #: ``subpixel_smoothing`` is on. See
+    #: :attr:`~fdtdx.objects.static_material.gds_layer_stack.GDSLayerObject.fill_supersample`.
+    fill_supersample: int = 8
     color: Color | None = XKCD_LIGHT_GREY
 
 
@@ -137,11 +141,18 @@ class GDSLayerObject(StaticMultiMaterialObject):
     #: Face that keeps the nominal footprint: ``"bottom"``, ``"middle"`` or ``"top"``.
     reference_plane: Literal["bottom", "middle", "top"] = frozen_field(default="bottom")
 
+    #: Number of sub-samples per axis used to estimate the in-plane fill fraction for sub-pixel
+    #: smoothing (see :meth:`get_fill_fraction_for_shape`). Higher values give a more accurate fill
+    #: fraction / interface normal at a quadratic cost in this (CPU-side, one-time) rasterization step.
+    fill_supersample: int = frozen_field(default=8)
+
     def __post_init__(self):
         if not 0.0 < self.sidewall_angle < 180.0:
             raise ValueError(f"sidewall_angle must lie in (0, 180) degrees (90 = vertical), got {self.sidewall_angle}.")
         if self.reference_plane not in ("bottom", "middle", "top"):
             raise ValueError(f"reference_plane must be one of 'bottom', 'middle', 'top'; got {self.reference_plane!r}.")
+        if self.fill_supersample < 1:
+            raise ValueError(f"fill_supersample must be >= 1, got {self.fill_supersample}.")
 
     @property
     def horizontal_axis(self) -> int:
@@ -304,9 +315,6 @@ class GDSLayerObject(StaticMultiMaterialObject):
         idx = all_names.index(self.material_name)
         return jnp.ones(self.grid_shape, dtype=jnp.int32) * idx
 
-    #: Number of sub-samples per axis used to estimate the in-plane fill fraction.
-    _FILL_SUPERSAMPLE: int = 8
-
     def get_fill_fraction_for_shape(self) -> jax.Array:
         """Analytic per-cell fill fraction of the extruded (optionally trapezoidal) polygon, in ``[0, 1]``.
 
@@ -358,14 +366,14 @@ class GDSLayerObject(StaticMultiMaterialObject):
 
         if self.sidewall_angle == 90.0 or max_offset < 0.5 * pitch or n_z == 0:
             # Vertical wall (or sub-cell taper): separable fast path on the nominal footprint.
-            f_xy = self._fill_fraction_2d(self._FILL_SUPERSAMPLE)  # (n_h, n_v)
+            f_xy = self._fill_fraction_2d(self.fill_supersample)  # (n_h, n_v)
             frac = f_xy[:, :, None] * f_z[None, None, :]
         else:
             # Tilted wall: the footprint fraction varies with height -> per z-slice offset footprint.
             frac = np.zeros((n_h, n_v, n_z), dtype=float)
             for k in range(n_z):
                 offset = (float(z_centers[k]) - z_ref) * tan  # >0 erodes (angle<90), <0 dilates
-                frac[:, :, k] = self._fill_fraction_2d(self._FILL_SUPERSAMPLE, offset=offset) * f_z[k]
+                frac[:, :, k] = self._fill_fraction_2d(self.fill_supersample, offset=offset) * f_z[k]
         return jnp.asarray(frac, dtype=float)
 
     def _fill_fraction_2d(self, supersample: int, offset: float = 0.0) -> np.ndarray:
@@ -694,6 +702,7 @@ def gds_layer_stack(
             reference_plane=spec.reference_plane,
             subpixel_smoothing=spec.subpixel_smoothing,
             subpixel_full_tensor=spec.subpixel_full_tensor,
+            fill_supersample=spec.fill_supersample,
             partial_real_shape=(None, None, spec.thickness),
         )
 

--- a/src/fdtdx/objects/static_material/gds_layer_stack.py
+++ b/src/fdtdx/objects/static_material/gds_layer_stack.py
@@ -453,7 +453,9 @@ def _offset_polygons(polygons: list[np.ndarray], offset: float) -> list[np.ndarr
     Returns the possibly-empty list of resulting polygon vertex arrays (erosion can remove a shape entirely
     or split it; dilation can merge shapes — handled downstream by OR-ing the rasterized masks).
     """
-    gpolys = [gdstk.Polygon(np.asarray(p)) for p in polygons]
+    # gdstk.Polygon's type stub declares a ``Sequence[tuple[float, float]]``; feed it explicit vertex
+    # tuples (an ndarray works at runtime but trips the static type checker).
+    gpolys = [gdstk.Polygon([(float(x), float(y)) for x, y in np.asarray(p)]) for p in polygons]
     # gdstk.offset snaps to an internal integer grid of size ``precision``; its 1e-3 default assumes
     # micron-scale layout coordinates, but here coordinates are in METRES (~1e-6), so a coarse precision
     # would collapse the shape. Scale precision to the coordinate magnitude (~7 significant digits).

--- a/src/fdtdx/objects/static_material/gds_layer_stack.py
+++ b/src/fdtdx/objects/static_material/gds_layer_stack.py
@@ -50,17 +50,31 @@ class GDSLayerSpec:
     #: convention: ``polyslab_angle_rad = deg2rad(90 - sidewall_angle)``.)
     #:
     #: .. note::
-    #:    For ``sidewall_angle != 90`` the trapezoidal profile is **staircased** on the z-grid: each
-    #:    z-slice is eroded/dilated to a whole number of cells, so the wall is approximated by discrete
-    #:    steps rather than a continuous slope.  This is therefore less accurate than Tidy3D's analytic
-    #:    ``PolySlab`` (which represents the slanted face exactly).  A sub-cell fill-fraction treatment
-    #:    that would remove the staircasing is tracked as a follow-up in issue #373.
+    #:    For ``sidewall_angle != 90`` the *binary* voxelization (:meth:`GDSLayerObject.get_voxel_mask_for_shape`)
+    #:    **staircases** the trapezoidal profile on the z-grid: each z-slice is eroded/dilated to a whole
+    #:    number of cells, so the wall is approximated by discrete steps rather than a continuous slope.
+    #:    Enabling ``subpixel_smoothing`` removes this staircasing: the fill fraction is then computed per
+    #:    z-slice on the laterally offset footprint, giving a sub-cell-accurate slanted face whose interface
+    #:    normal tilts with the wall (issue #373).
     sidewall_angle: float = 90.0
     #: Which face keeps the nominal polygon footprint when ``sidewall_angle != 90``.
     #: ``"bottom"`` (default) keeps the base footprint and tapers the top inward for an angle ``< 90``;
     #: ``"top"`` keeps the top footprint; ``"middle"`` keeps the mid-height footprint and splits the
     #: taper symmetrically. Mirrors ``PolySlab.reference_plane``.
     reference_plane: Literal["bottom", "middle", "top"] = "bottom"
+    #: Enable sub-pixel dielectric smoothing for this layer (see
+    #: :attr:`~fdtdx.objects.static_material.static.StaticMultiMaterialObject.subpixel_smoothing`).
+    #: When ``True`` the layer is voxelised with an analytic fill fraction (supersampled footprint x
+    #: fractional z-coverage of the top/bottom faces) and the assembler builds a 2nd-order-accurate
+    #: anisotropic effective permittivity at the interface cells. Removes the staircasing of both the
+    #: in-plane polygon edges and the horizontal layer faces on the Yee grid. Defaults to a cheap
+    #: 3-component diagonal tensor (exact for axis-aligned interfaces); set ``subpixel_full_tensor`` for
+    #: the full 9-component tensor.
+    subpixel_smoothing: bool = False
+    #: Keep the full 9-component smoothing tensor (accurate for tilted sidewalls, ~3x heavier) instead of
+    #: the default cheap 3-component diagonal. See
+    #: :attr:`~fdtdx.objects.static_material.static.StaticMultiMaterialObject.subpixel_full_tensor`.
+    subpixel_full_tensor: bool = False
     color: Color | None = XKCD_LIGHT_GREY
 
 
@@ -290,10 +304,164 @@ class GDSLayerObject(StaticMultiMaterialObject):
         idx = all_names.index(self.material_name)
         return jnp.ones(self.grid_shape, dtype=jnp.int32) * idx
 
+    #: Number of sub-samples per axis used to estimate the in-plane fill fraction.
+    _FILL_SUPERSAMPLE: int = 8
+
+    def get_fill_fraction_for_shape(self) -> jax.Array:
+        """Analytic per-cell fill fraction of the extruded (optionally trapezoidal) polygon, in ``[0, 1]``.
+
+        The fraction is the product of an in-plane footprint coverage and the z-extent coverage:
+
+        * ``f_xy`` — the in-plane fraction of each cell covered by the polygon footprint, estimated by
+          super-sampling :meth:`polygon_to_mask_at_points` on an ``N x N`` grid inside every cell; and
+        * ``f_z`` — the fraction of each z-cell overlapped by the layer's physical z-extent
+          ``[z_base, z_base + thickness]`` (partial coverage at the top and bottom faces).
+
+        When ``sidewall_angle != 90`` the footprint shrinks/grows with height, so ``f_xy`` is recomputed
+        per z-slice on the laterally offset polygon (``offset(z) = (z - z_ref) * tan(90deg - angle)``,
+        matching :meth:`_extrude_with_sidewall`), giving a sub-cell-accurate trapezoidal profile whose
+        interface normal (recovered from the fill gradient) tilts with the wall. For a vertical wall, or
+        when the total lateral taper stays below half a cell (the common sub-cell case), the cheaper
+        separable ``f_xy(x, y) * f_z(z)`` form on the nominal footprint is used — it is identical there.
+
+        Returns:
+            jax.Array: Float array of shape ``self.grid_shape`` with values in ``[0, 1]``.
+        """
+        if self.axis != 2:
+            raise ValueError(
+                f"GDSLayerObject.get_fill_fraction_for_shape only supports axis=2 (z-extrusion); got axis={self.axis}."
+            )
+        n_h = self.grid_shape[self.horizontal_axis]
+        n_v = self.grid_shape[self.vertical_axis]
+        n_z = self.grid_shape[self.axis]
+        f_z = self._z_fill_fraction()  # (n_z,)
+
+        z_centers = self._z_centers(n_z)  # relative to layer base
+        tan = float(np.tan(np.deg2rad(90.0 - self.sidewall_angle)))
+        grid = self._config.resolved_grid
+        if grid is None:
+            pitch = float(self._config.uniform_spacing())
+        else:
+            pitch = min(
+                float(np.min(grid.cell_widths(self.horizontal_axis))),
+                float(np.min(grid.cell_widths(self.vertical_axis))),
+            )
+        if z_centers.size == 0:
+            z_ref = 0.0
+        elif self.reference_plane == "bottom":
+            z_ref = float(z_centers[0])
+        elif self.reference_plane == "top":
+            z_ref = float(z_centers[-1])
+        else:
+            z_ref = 0.5 * (float(z_centers[0]) + float(z_centers[-1]))
+        max_offset = abs(tan) * float(np.max(np.abs(z_centers - z_ref))) if z_centers.size else 0.0
+
+        if self.sidewall_angle == 90.0 or max_offset < 0.5 * pitch or n_z == 0:
+            # Vertical wall (or sub-cell taper): separable fast path on the nominal footprint.
+            f_xy = self._fill_fraction_2d(self._FILL_SUPERSAMPLE)  # (n_h, n_v)
+            frac = f_xy[:, :, None] * f_z[None, None, :]
+        else:
+            # Tilted wall: the footprint fraction varies with height -> per z-slice offset footprint.
+            frac = np.zeros((n_h, n_v, n_z), dtype=float)
+            for k in range(n_z):
+                offset = (float(z_centers[k]) - z_ref) * tan  # >0 erodes (angle<90), <0 dilates
+                frac[:, :, k] = self._fill_fraction_2d(self._FILL_SUPERSAMPLE, offset=offset) * f_z[k]
+        return jnp.asarray(frac, dtype=float)
+
+    def _fill_fraction_2d(self, supersample: int, offset: float = 0.0) -> np.ndarray:
+        """Super-sampled in-plane area fraction of the polygon footprint, shape ``(n_h, n_v)``.
+
+        ``offset`` (metres) laterally erodes (``offset > 0``) or dilates (``offset < 0``) the footprint
+        before rasterizing — the fractional analogue of :func:`_offset_mask`, used for the trapezoidal
+        sidewall profile.
+        """
+        n_h = self.grid_shape[self.horizontal_axis]
+        n_v = self.grid_shape[self.vertical_axis]
+
+        origin_h = self.gds_center[0]
+        origin_v = self.gds_center[1]
+        local_polygons = [poly - np.array([origin_h, origin_v]) for poly in self.polygons]
+        if abs(offset) > 1e-15 and len(local_polygons) > 0:
+            local_polygons = _offset_polygons(local_polygons, offset)
+        if len(local_polygons) == 0:
+            return np.zeros((n_h, n_v), dtype=float)
+
+        grid = self._config.resolved_grid
+        if grid is None:
+            res = self._config.uniform_spacing()
+            real_h = self.real_shape[self.horizontal_axis]
+            real_v = self.real_shape[self.vertical_axis]
+            h_edges = -real_h / 2.0 + np.arange(n_h + 1) * res
+            v_edges = -real_v / 2.0 + np.arange(n_v + 1) * res
+            h_obj_center = 0.0
+            v_obj_center = 0.0
+        else:
+            h_lower, h_upper = self.grid_slice_tuple[self.horizontal_axis]
+            v_lower, v_upper = self.grid_slice_tuple[self.vertical_axis]
+            h_edges_all = np.asarray(grid.edges(self.horizontal_axis))
+            v_edges_all = np.asarray(grid.edges(self.vertical_axis))
+            h_edges = h_edges_all[h_lower : h_upper + 1]
+            v_edges = v_edges_all[v_lower : v_upper + 1]
+            h_obj_center = 0.5 * (h_edges_all[h_lower] + h_edges_all[h_upper])
+            v_obj_center = 0.5 * (v_edges_all[v_lower] + v_edges_all[v_upper])
+
+        # Sub-sample centres inside every cell: cell [edge_lo, edge_hi] -> edge_lo + (s+0.5)/S * width.
+        s = (np.arange(supersample) + 0.5) / supersample
+        h_lo = h_edges[:-1]
+        h_hi = h_edges[1:]
+        v_lo = v_edges[:-1]
+        v_hi = v_edges[1:]
+        h_sub = (h_lo[:, None] + s[None, :] * (h_hi - h_lo)[:, None]).ravel() - h_obj_center
+        v_sub = (v_lo[:, None] + s[None, :] * (v_hi - v_lo)[:, None]).ravel() - v_obj_center
+
+        inside = np.zeros((n_h * supersample, n_v * supersample), dtype=bool)
+        for poly in local_polygons:
+            inside |= polygon_to_mask_at_points(x_coords=h_sub, y_coords=v_sub, polygon_vertices=poly)
+        frac = inside.reshape(n_h, supersample, n_v, supersample).mean(axis=(1, 3))
+        return np.asarray(frac, dtype=float)
+
+    def _z_fill_fraction(self) -> np.ndarray:
+        """Fraction of each z-cell overlapped by the layer extent ``[0, thickness]``, shape ``(n_z,)``."""
+        n_z = self.grid_shape[self.axis]
+        grid = self._config.resolved_grid
+        if grid is None:
+            res = self._config.uniform_spacing()
+            z_lo = np.arange(n_z) * res
+            z_hi = z_lo + res
+        else:
+            z_l, z_u = self.grid_slice_tuple[self.axis]
+            z_edges = np.asarray(grid.edges(self.axis))
+            base = z_edges[z_l]
+            z_lo = z_edges[z_l:z_u] - base
+            z_hi = z_edges[z_l + 1 : z_u + 1] - base
+        lo = np.maximum(z_lo, 0.0)
+        hi = np.minimum(z_hi, self.thickness)
+        overlap = np.clip(hi - lo, 0.0, None)
+        width = z_hi - z_lo
+        return np.where(width > 0, overlap / width, 0.0)
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _offset_polygons(polygons: list[np.ndarray], offset: float) -> list[np.ndarray]:
+    """Erode (``offset > 0``) or dilate (``offset < 0``) polygons by a physical distance (metres).
+
+    Uses :func:`gdstk.offset` (exact polygon inset/outset), the continuous analogue of :func:`_offset_mask`.
+    Returns the possibly-empty list of resulting polygon vertex arrays (erosion can remove a shape entirely
+    or split it; dilation can merge shapes — handled downstream by OR-ing the rasterized masks).
+    """
+    gpolys = [gdstk.Polygon(np.asarray(p)) for p in polygons]
+    # gdstk.offset snaps to an internal integer grid of size ``precision``; its 1e-3 default assumes
+    # micron-scale layout coordinates, but here coordinates are in METRES (~1e-6), so a coarse precision
+    # would collapse the shape. Scale precision to the coordinate magnitude (~7 significant digits).
+    scale = max((float(np.max(np.abs(p))) for p in polygons if len(p)), default=1.0)
+    precision = max(scale, abs(offset)) * 1e-7
+    # gdstk.offset: positive distance grows the shape, so negate to make offset>0 erode (shrink).
+    result = gdstk.offset(gpolys, -offset, use_union=True, precision=precision)
+    return [np.asarray(p.points) for p in result]
 
 
 def _offset_mask(mask_2d: np.ndarray, offset: float, pitch_h: float, pitch_v: float) -> np.ndarray:
@@ -522,6 +690,8 @@ def gds_layer_stack(
             thickness=spec.thickness,
             sidewall_angle=spec.sidewall_angle,
             reference_plane=spec.reference_plane,
+            subpixel_smoothing=spec.subpixel_smoothing,
+            subpixel_full_tensor=spec.subpixel_full_tensor,
             partial_real_shape=(None, None, spec.thickness),
         )
 

--- a/src/fdtdx/objects/static_material/static.py
+++ b/src/fdtdx/objects/static_material/static.py
@@ -33,7 +33,8 @@ class StaticMultiMaterialObject(OrderableObject, ABC):
     #: al. (Meep): arithmetic mean of ``eps`` for the field components tangential to the interface and
     #: harmonic mean of ``eps`` for the component normal to it. This removes the first-order staircasing
     #: error of the Yee grid at strong dielectric jumps (2nd-order accuracy). Forces the whole
-    #: simulation to allocate a 9-component permittivity tensor. Requires the object to provide a
+    #: simulation to allocate an anisotropic permittivity tensor (3-component diagonal by default, or a
+    #: full 9-component tensor when ``subpixel_full_tensor`` is set). Requires the object to provide a
     #: fractional ``get_fill_fraction_for_shape`` (the default falls back to the binary mask, which
     #: still yields a valid but only cell-wide normal). See issue #373.
     subpixel_smoothing: bool = frozen_field(default=False)

--- a/src/fdtdx/objects/static_material/static.py
+++ b/src/fdtdx/objects/static_material/static.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 
 import jax
+import jax.numpy as jnp
+import numpy as np
 
 from fdtdx.colors import XKCD_LIGHT_GREY, Color
 from fdtdx.core.jax.pytrees import autoinit, field, frozen_field
@@ -25,6 +27,27 @@ class StaticMultiMaterialObject(OrderableObject, ABC):
     #: the color of the material
     color: Color | None = frozen_field(default=XKCD_LIGHT_GREY)
 
+    #: Enable sub-pixel (sub-cell) dielectric smoothing for this object. When ``True`` the assembler
+    #: replaces the binary voxel occupancy with an analytic fill-fraction and builds a smoothed,
+    #: anisotropic (full 3x3 tensor) effective permittivity at interface cells following Farjadpour et
+    #: al. (Meep): arithmetic mean of ``eps`` for the field components tangential to the interface and
+    #: harmonic mean of ``eps`` for the component normal to it. This removes the first-order staircasing
+    #: error of the Yee grid at strong dielectric jumps (2nd-order accuracy). Forces the whole
+    #: simulation to allocate a 9-component permittivity tensor. Requires the object to provide a
+    #: fractional ``get_fill_fraction_for_shape`` (the default falls back to the binary mask, which
+    #: still yields a valid but only cell-wide normal). See issue #373.
+    subpixel_smoothing: bool = frozen_field(default=False)
+
+    #: Selects the smoothing tensor representation when ``subpixel_smoothing`` is on. ``False`` (default)
+    #: keeps only the DIAGONAL of the Farjadpour tensor (``eps_ii = eps_bar - (eps_bar - eps_h)*n_i**2``),
+    #: allocating a cheap 3-component array that runs on the elementwise Yee update. This is EXACT for
+    #: axis-aligned interfaces (their normal lies on one axis, so the off-diagonal terms vanish) and is the
+    #: recommended production path for Manhattan geometries. ``True`` allocates the full 9-component tensor
+    #: (keeps the off-diagonal ``-(eps_bar - eps_h)*n_i*n_j`` terms), which is more accurate for tilted
+    #: interfaces (slanted sidewalls, diagonal edges) but ~3x heavier per step and forces the anisotropic
+    #: update kernel. Ignored when ``subpixel_smoothing`` is False.
+    subpixel_full_tensor: bool = frozen_field(default=False)
+
     @abstractmethod
     def get_voxel_mask_for_shape(self) -> jax.Array:
         """Get a binary mask of the objects shape. Everything voxel not in the mask, will not be updated by
@@ -47,6 +70,52 @@ class StaticMultiMaterialObject(OrderableObject, ABC):
             jax.Array: Index array
         """
         raise NotImplementedError()
+
+    def get_fill_fraction_for_shape(self) -> jax.Array:
+        """Return the per-cell fill fraction of the object's material, in ``[0, 1]``.
+
+        This is the sub-pixel generalisation of :meth:`get_voxel_mask_for_shape`: interior cells return
+        ``1.0``, exterior cells ``0.0`` and interface cells the fraction of the cell volume covered by
+        the object. The default implementation falls back to the binary mask cast to float, so a subclass
+        that does not compute a genuine fill fraction still behaves correctly (albeit without the
+        sub-pixel accuracy gain). Subclasses that can rasterise fractionally should override this.
+
+        Returns:
+            jax.Array: Float array of shape ``self.grid_shape`` with values in ``[0, 1]``.
+        """
+        return self.get_voxel_mask_for_shape().astype(float)
+
+    def get_interface_normal_for_shape(self) -> jax.Array:
+        """Return a per-cell unit interface normal derived from the fill-fraction gradient.
+
+        The normal is ``n = -grad(fill) / |grad(fill)|`` (the sign is irrelevant downstream because only
+        the symmetric outer product ``n ⊗ n`` is used). The gradient is taken with the object's physical
+        cell pitch on each axis, so the direction is geometrically correct on anisotropic grids. Cells
+        away from an interface (``|grad(fill)| ~ 0``) get a zero normal, which makes the smoothed tensor
+        collapse back to the isotropic bulk value. Computed in NumPy at initialisation (static geometry,
+        not a traced quantity).
+
+        Returns:
+            jax.Array: Float array of shape ``(3, *self.grid_shape)`` with the per-cell unit normal.
+        """
+        frac = np.asarray(self.get_fill_fraction_for_shape(), dtype=float)
+        grid_shape = self.grid_shape
+        real_shape = self.real_shape
+        # Average physical pitch per axis (exact on uniform grids, a good local approximation on
+        # quasi-uniform grids; only the gradient *direction* matters after normalisation).
+        pitch = [(real_shape[i] / grid_shape[i]) if grid_shape[i] > 0 else 1.0 for i in range(3)]
+        grad = np.zeros((3, *frac.shape), dtype=float)
+        for ax in range(3):
+            if frac.shape[ax] > 1 and pitch[ax] > 0:
+                grad[ax] = np.gradient(frac, pitch[ax], axis=ax)
+        # n points from high fill (material) to low fill (background); sign is immaterial for n⊗n.
+        grad = -grad
+        norm = np.sqrt(np.sum(grad**2, axis=0))
+        safe = norm > 1e-12
+        normal = np.zeros_like(grad)
+        for ax in range(3):
+            normal[ax] = np.where(safe, grad[ax] / np.where(safe, norm, 1.0), 0.0)
+        return jnp.asarray(normal)
 
 
 @autoinit

--- a/tests/integration/fdtd/test_subpixel_smoothing.py
+++ b/tests/integration/fdtd/test_subpixel_smoothing.py
@@ -1,0 +1,224 @@
+"""Integration tests for sub-pixel (sub-cell) dielectric smoothing on StaticMultiMaterialObject.
+
+Sub-pixel smoothing replaces the binary (staircased) voxel permittivity at material interfaces with an
+anisotropic effective permittivity following Farjadpour et al. (Meep): the arithmetic mean of eps for the
+field components tangential to the interface and the harmonic mean for the component normal to it. This
+removes the first-order Yee staircasing error at strong dielectric jumps.
+
+The scene here is a SiN half-plane in vacuum: the material footprint fills x < x_edge (with x_edge placed
+at a sub-cell position) and spans the full y and z extent, so the only interface is the vertical x-normal
+face at x_edge -- the in-plane fill-fraction case that GDS sidewall smoothing (issue #373) targets. For a
+cell on that face with fill fraction f and normal n = x_hat the effective tensor is diag(eps_h, eps_bar,
+eps_bar) with
+
+    eps_bar = f * eps_SiN + (1 - f) * eps_vac        (arithmetic, tangential y and z)
+    eps_h   = 1 / (f / eps_SiN + (1 - f) / eps_vac)  (harmonic, normal x)
+
+The tests assert this relation exactly, plus the allocation logic (3-component diagonal vs 9-component full
+tensor) and that disabling smoothing is a no-op.
+"""
+
+import gdstk
+import jax
+import numpy as np
+
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
+from fdtdx.fdtd.initialization import place_objects
+from fdtdx.materials import Material
+from fdtdx.objects.static_material.gds_layer_stack import GDSLayerSpec, gds_layer_stack
+from fdtdx.objects.static_material.static import SimulationVolume
+
+EPS_SIN = 4.0
+EPS_VAC = 1.0
+SPACING = 1e-6  # 1 um cells
+N = 8  # 8 x 8 x 8 um domain
+X_EDGE = 0.3e-6  # material footprint boundary at a deliberately sub-cell x position
+
+
+def _build_halfplane_arrays(*, subpixel: bool, full_tensor: bool = False):
+    """Place a SiN half-plane (x < X_EDGE) spanning the full y/z extent and return the ArrayContainer.
+
+    The footprint's only interior boundary is the vertical x-normal face at X_EDGE; the layer fills the
+    whole z-extent (no internal horizontal face) and the footprint runs far past the domain in y (no
+    internal y face), so every smoothed cell has a clean n = x_hat interface normal.
+    """
+    volume = SimulationVolume(name="vol", partial_grid_shape=(N, N, N), material=Material(permittivity=EPS_VAC))
+
+    lib = gdstk.Library(unit=1e-6, precision=1e-9)
+    cell = lib.new_cell("HALF")
+    big = 1e3  # um; runs far past the domain in -x and +/-y so only the +x edge falls inside
+    cell.add(gdstk.Polygon([(-big, -big), (X_EDGE * 1e6, -big), (X_EDGE * 1e6, big), (-big, big)], layer=1, datatype=0))
+
+    layers = [
+        GDSLayerSpec(
+            gds_layer=1,
+            material_name="SiN",
+            thickness=N * SPACING,  # full z-extent -> no internal horizontal face
+            z_base=0.0,
+            sidewall_angle=90.0,
+            subpixel_smoothing=subpixel,
+            subpixel_full_tensor=full_tensor,
+        )
+    ]
+    materials = {"SiN": Material(permittivity=EPS_SIN), "vac": Material(permittivity=EPS_VAC)}
+    objs, constraints = gds_layer_stack(lib, "HALF", layers, materials, volume, gds_center=(0.0, 0.0))
+
+    config = SimulationConfig(grid=UniformGrid(spacing=SPACING), time=100e-15, backend="cpu")
+    _obj, arrays, _params, _cfg, _info = place_objects([volume, *objs], config, constraints, jax.random.PRNGKey(0))
+    return arrays
+
+
+def _forward_diag(ip):
+    """Return (eps_xx, eps_yy, eps_zz) from an inv-permittivity array of 3 or 9 components."""
+    if ip.shape[0] == 3:
+        return 1.0 / ip[0], 1.0 / ip[1], 1.0 / ip[2]
+    eps = np.linalg.inv(np.moveaxis(ip, 0, -1).reshape(*ip.shape[1:], 3, 3))
+    return eps[..., 0, 0], eps[..., 1, 1], eps[..., 2, 2]
+
+
+def test_subpixel_off_is_isotropic_and_unchanged():
+    """Without smoothing the permittivity stays a 1-component isotropic array (binary staircase)."""
+    ip = np.asarray(_build_halfplane_arrays(subpixel=False).inv_permittivities)
+    assert ip.shape[0] == 1  # isotropic scalar allocation
+    eps = 1.0 / ip[0]
+    # every cell is either pure SiN or pure vacuum -- no intermediate (smoothed) values
+    assert np.all(np.isclose(eps, EPS_SIN) | np.isclose(eps, EPS_VAC))
+
+
+def test_diagonal_subpixel_allocation_and_bulk():
+    """Diagonal smoothing (default) allocates a 3-component array and preserves the bulk material values."""
+    ip = np.asarray(_build_halfplane_arrays(subpixel=True, full_tensor=False).inv_permittivities)
+    assert ip.shape[0] == 3  # diagonal anisotropic allocation
+    exx, eyy, ezz = _forward_diag(ip)
+    for e in (exx, eyy, ezz):
+        assert np.isclose(e.max(), EPS_SIN)  # a fully-SiN cell exists
+        assert np.isclose(e.min(), EPS_VAC)  # a fully-vacuum cell exists
+
+
+def test_diagonal_subpixel_farjadpour_relation_on_x_face():
+    """The x-normal interface cell must obey the exact Farjadpour arithmetic/harmonic split.
+
+    For a cell with fill fraction f and normal n = x_hat: eps_yy = eps_zz = arithmetic mean (tangential),
+    eps_xx = harmonic mean (normal). We recover f from the tangential component and assert the normal one
+    matches the harmonic mean -- a check that is exact and independent of the exact fill the mesh produced.
+    """
+    ip = np.asarray(_build_halfplane_arrays(subpixel=True, full_tensor=False).inv_permittivities)
+    exx, eyy, ezz = _forward_diag(ip)
+
+    aniso = np.abs(exx - eyy)
+    idx = np.unravel_index(int(np.argmax(aniso)), aniso.shape)
+    assert aniso[idx] > 1e-6, "expected at least one anisotropic (smoothed) interface cell"
+
+    # x-normal interface: the two tangential components (y, z) are equal; the normal (x) is smaller.
+    assert np.isclose(eyy[idx], ezz[idx], rtol=1e-6), "tangential components must match for an x-normal interface"
+    assert exx[idx] < eyy[idx] - 1e-6, "normal (harmonic) component must be below the tangential (arithmetic) one"
+
+    # recover the fill fraction from the arithmetic (tangential) component and verify the harmonic (normal) one
+    f = (eyy[idx] - EPS_VAC) / (EPS_SIN - EPS_VAC)
+    assert 0.0 < f < 1.0
+    eps_h_expected = 1.0 / (f / EPS_SIN + (1.0 - f) / EPS_VAC)
+    assert np.isclose(exx[idx], eps_h_expected, rtol=1e-6), (
+        f"harmonic mean mismatch: eps_xx={exx[idx]:.6f} expected={eps_h_expected:.6f} (f={f:.4f})"
+    )
+
+
+def test_full_tensor_subpixel_allocation_and_diagonal_on_axis_aligned_face():
+    """The full-tensor variant allocates 9 components; for an x-normal face it stays diagonal (no off-diag)."""
+    ip = np.asarray(_build_halfplane_arrays(subpixel=True, full_tensor=True).inv_permittivities)
+    assert ip.shape[0] == 9  # full tensor allocation
+
+    eps = np.linalg.inv(np.moveaxis(ip, 0, -1).reshape(*ip.shape[1:], 3, 3))
+    exx, eyy, ezz = eps[..., 0, 0], eps[..., 1, 1], eps[..., 2, 2]
+    offdiag = np.abs(eps[..., 0, 1]) + np.abs(eps[..., 0, 2]) + np.abs(eps[..., 1, 2])
+
+    idx = np.unravel_index(int(np.argmax(np.abs(exx - eyy))), exx.shape)
+    assert np.isclose(eyy[idx], ezz[idx], rtol=1e-6)
+    assert exx[idx] < eyy[idx] - 1e-6
+    assert offdiag[idx] < 1e-6, "axis-aligned interface must have zero off-diagonal terms"
+    f = (eyy[idx] - EPS_VAC) / (EPS_SIN - EPS_VAC)
+    assert np.isclose(exx[idx], 1.0 / (f / EPS_SIN + (1.0 - f) / EPS_VAC), rtol=1e-6)
+
+
+def test_diagonal_and_full_tensor_agree_on_diagonal():
+    """For an axis-aligned interface the cheap diagonal path equals the diagonal of the full tensor."""
+    diag = np.asarray(_build_halfplane_arrays(subpixel=True, full_tensor=False).inv_permittivities)
+    full = np.asarray(_build_halfplane_arrays(subpixel=True, full_tensor=True).inv_permittivities)
+    # diagonal components of the full 9-tensor (indices 0, 4, 8) must match the 3-component diagonal array
+    assert np.allclose(diag[0], full[0], rtol=1e-6)  # xx
+    assert np.allclose(diag[1], full[4], rtol=1e-6)  # yy
+    assert np.allclose(diag[2], full[8], rtol=1e-6)  # zz
+
+
+# ---------------------------------------------------------------------------
+# Tilted sidewall (issue #373): the trapezoidal wall produces a non-axis-aligned
+# interface normal in the x-z plane -> genuine off-diagonal (eps_xz) tensor terms.
+# ---------------------------------------------------------------------------
+
+
+def _build_wedge_arrays(*, full_tensor: bool, sidewall_angle: float = 50.0):
+    """SiN half-plane with a steep sidewall: the x-edge slants across z (a wall in the x-z plane).
+
+    z_base=1 um, thickness=6 um, 50 deg wall -> the footprint boundary sweeps ~5 um in x over the 6 um of
+    height, i.e. a slanted interface whose normal lies in the x-z plane. The lateral taper is far above one
+    cell, so the per-z-slice trapezoidal fill path engages. The edge x (2.7 um) and angle are chosen so the
+    boundary lands mid-cell at each height (a sub-cell fractional fill, not a cell-aligned staircase).
+    """
+    volume = SimulationVolume(name="vol", partial_grid_shape=(N, N, N), material=Material(permittivity=EPS_VAC))
+    lib = gdstk.Library(unit=1e-6, precision=1e-9)
+    cell = lib.new_cell("WEDGE")
+    big = 1e3
+    x_edge_um = 2.7  # bottom edge at x = 2.7 um; erodes upward over the ~5 um wall (mid-cell at each z)
+    cell.add(gdstk.Polygon([(-big, -big), (x_edge_um, -big), (x_edge_um, big), (-big, big)], layer=1, datatype=0))
+    layers = [
+        GDSLayerSpec(
+            gds_layer=1,
+            material_name="SiN",
+            thickness=6e-6,
+            z_base=1e-6,
+            sidewall_angle=sidewall_angle,
+            reference_plane="bottom",
+            subpixel_smoothing=True,
+            subpixel_full_tensor=full_tensor,
+        )
+    ]
+    materials = {"SiN": Material(permittivity=EPS_SIN), "vac": Material(permittivity=EPS_VAC)}
+    objs, constraints = gds_layer_stack(lib, "WEDGE", layers, materials, volume, gds_center=(0.0, 0.0))
+    config = SimulationConfig(grid=UniformGrid(spacing=SPACING), time=100e-15, backend="cpu")
+    _obj, arrays, _params, _cfg, _info = place_objects([volume, *objs], config, constraints, jax.random.PRNGKey(0))
+    return arrays
+
+
+def test_tilted_sidewall_produces_offdiagonal_tensor():
+    """A slanted (non-axis-aligned) sidewall must yield genuine off-diagonal eps_xz terms (issue #373).
+
+    This is the payoff of the full-tensor path: for an interface normal in the x-z plane the Farjadpour
+    tensor has eps_xz = -(eps_bar - eps_h) * n_x * n_z != 0, which the diagonal path cannot represent.
+    """
+    ip = np.asarray(_build_wedge_arrays(full_tensor=True).inv_permittivities)
+    assert ip.shape[0] == 9
+    eps = np.linalg.inv(np.moveaxis(ip, 0, -1).reshape(*ip.shape[1:], 3, 3))
+    exz = eps[..., 0, 2]
+    # the slanted wall spans x and z -> a substantial x-z coupling must appear somewhere
+    assert np.max(np.abs(exz)) > 0.1, (
+        f"expected off-diagonal eps_xz from the tilted wall, got {np.max(np.abs(exz)):.3e}"
+    )
+    # the y-z and x-y couplings stay ~zero (the wall is invariant in y)
+    assert np.max(np.abs(eps[..., 0, 1])) < 1e-6  # eps_xy
+    assert np.max(np.abs(eps[..., 1, 2])) < 1e-6  # eps_yz
+
+
+def test_tilted_sidewall_smoothing_tracks_the_wall_across_z():
+    """The smoothed (interface) cells should follow the slanted wall: their x-position shifts with z."""
+    ip = np.asarray(_build_wedge_arrays(full_tensor=False).inv_permittivities)
+    exx, eyy, _ezz = _forward_diag(ip)
+    smoothed = np.abs(exx - eyy) > 1e-3  # cells with tangential/normal contrast (on the interface)
+    # for the lowest and highest interior z-slices, the mean x-index of smoothed cells must differ
+    # (the wall moved in x) -- a direct check that the fill fraction is z-dependent, not separable.
+    zs = np.where(smoothed.any(axis=(0, 1)))[0]
+    assert zs.size >= 2, "expected smoothed cells across multiple z-slices"
+    xs_low = np.where(smoothed[:, :, zs[0]].any(axis=1))[0].mean()
+    xs_high = np.where(smoothed[:, :, zs[-1]].any(axis=1))[0].mean()
+    assert abs(xs_high - xs_low) > 1.0, (
+        f"interface x-position should shift with z for a tilted wall (low={xs_low:.1f}, high={xs_high:.1f})"
+    )


### PR DESCRIPTION
## What

Adds opt-in **sub-pixel (sub-cell) dielectric smoothing** for `StaticMultiMaterialObject` /
`GDSLayerObject`, replacing the binary staircased permittivity at material interfaces with a smoothed,
anisotropic effective permittivity following Farjadpour et al.¹ (the method Meep and Tidy3D use). This
removes the first-order Yee staircasing error at strong dielectric jumps and, in particular, resolves the
tilted-sidewall staircasing tracked in #373.

Opt in per layer:

```python
GDSLayerSpec(..., sidewall_angle=80.0, subpixel_smoothing=True)          # cheap 3-comp diagonal (default)
GDSLayerSpec(..., sidewall_angle=80.0, subpixel_smoothing=True,
            subpixel_full_tensor=True)                                    # full 9-comp tensor
```

## How

- **Fill fraction** (`get_fill_fraction_for_shape`): analytic per-cell coverage — the footprint is
  super-sampled in-plane and combined with the fractional z-extent of the layer. For a **tilted sidewall**
  the footprint is laterally offset per z-slice (`gdstk.offset`), so the slanted face is resolved sub-cell
  rather than staircased. A guard keeps the cheap separable path when the wall is vertical or the total
  lateral taper stays below half a cell (identical result, no per-slice cost).
- **Interface normal** from the gradient of the fill fraction — this tilts with the wall automatically.
- **Effective tensor**: `eps_eff = eps_bar * I - (eps_bar - eps_h) * (n ⊗ n)`, with `eps_bar` the arithmetic
  mean (tangential components) and `eps_h` the harmonic mean (normal component).
- **Two representations** via `subpixel_full_tensor`:
  - *diagonal* (default) — a 3-component array `diag(eps_ii)` that runs on the existing elementwise Yee
    update; **exact for axis-aligned interfaces** (their normal lies on one axis, so off-diagonal terms
    vanish) and the recommended path for Manhattan geometries.
  - *full tensor* — the 9-component tensor, keeping the off-diagonal `-(eps_bar - eps_h) * n_i * n_j` terms
    for genuinely tilted interfaces (slanted sidewalls, diagonal edges).
- Allocation is bumped to 3/9 components only when smoothing is on; the existing anisotropic update path is
  reused, so **no changes to the field-update kernels**.

## Tests

`tests/integration/fdtd/test_subpixel_smoothing.py` (7 tests):
- 3-/9-component allocation and bulk-value preservation;
- the exact arithmetic/harmonic split on an axis-aligned face (recovered fill fraction → harmonic mean);
- **tilted sidewall → genuine off-diagonal `eps_xz`** and the smoothed cells tracking the slanted wall
  across z (the #373 case);
- a no-op regression (smoothing off ⇒ unchanged 1-component isotropic array).

All existing `test_initialization.py` tests still pass.

## Why it matters (real-world motivation)

In a multilayer interlayer-coupling problem (two stacked waveguides coupling evanescently across a thin
oxide gap), the binary staircasing scattered a large, unphysical fraction of the fundamental mode into a
spurious higher-order mode, and the error *grew* with resolution (a classic 1st-order artifact). Enabling
this smoothing brought the transmission from a badly wrong value to within a few percent of a reference
commercial subpixel-FDTD solver, and made the result resolution-robust (≈1% between two grids vs a factor
of ~2 without smoothing) — the expected 2nd-order behavior.

## Notes / scope

- The per-z-slice tilted path costs one polygon-offset + rasterization per z-cell; the sub-cell guard keeps
  the common (vertical / weakly-tapered) case on the fast separable path.
- Isotropic-background assumption: the harmonic term uses the local background as isotropic, which is exact
  except in the rare cell straddling two smoothed interfaces at once.
- Dispersive materials combined with the full 9-tensor remain unsupported (existing limitation); the diagonal
  path is unaffected.

¹ A. Farjadpour et al., "Improving accuracy by subpixel smoothing in the finite-difference time domain,"
Opt. Lett. 31, 2972 (2006).

---

## MRE (self-contained, no external assets)

```python
import gdstk, jax, numpy as np
from fdtdx.config import SimulationConfig
from fdtdx.core.grid import UniformGrid
from fdtdx.fdtd.initialization import place_objects
from fdtdx.materials import Material
from fdtdx.objects.static_material.gds_layer_stack import GDSLayerSpec, gds_layer_stack
from fdtdx.objects.static_material.static import SimulationVolume

# SiN half-plane (x < 2.7 um) in vacuum, 8x8x8 um at 1 um cells, with a 50-degree sidewall
vol = SimulationVolume(name="vol", partial_grid_shape=(8, 8, 8), material=Material(permittivity=1.0))
lib = gdstk.Library(unit=1e-6, precision=1e-9); cell = lib.new_cell("W")
cell.add(gdstk.Polygon([(-1e3, -1e3), (2.7, -1e3), (2.7, 1e3), (-1e3, 1e3)], layer=1))
layers = [GDSLayerSpec(gds_layer=1, material_name="SiN", thickness=6e-6, z_base=1e-6,
                       sidewall_angle=50.0, subpixel_smoothing=True, subpixel_full_tensor=True)]
mats = {"SiN": Material(permittivity=4.0), "vac": Material(permittivity=1.0)}
objs, cons = gds_layer_stack(lib, "W", layers, mats, vol, gds_center=(0.0, 0.0))
cfg = SimulationConfig(grid=UniformGrid(spacing=1e-6), time=100e-15, backend="cpu")
_, arr, _, _, _ = place_objects([vol, *objs], cfg, cons, jax.random.PRNGKey(0))

ip = np.asarray(arr.inv_permittivities)                       # (9, 8, 8, 8)
eps = np.linalg.inv(np.moveaxis(ip, 0, -1).reshape(8, 8, 8, 3, 3))
print("max |eps_xz| =", np.abs(eps[..., 0, 2]).max())         # > 0 : slanted wall -> off-diagonal coupling
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sub-pixel dielectric smoothing for static materials, including optional diagonal-only vs full-tensor permittivity at interfaces.
  * Introduced analytic per-cell fill fractions and interface-normal handling to improve partial-cell material transitions.
  * Extended GDS layer configuration with sub-pixel smoothing, full-tensor selection, and super-sampling controls.

* **Bug Fixes**
  * Improved handling of tilted sidewalls so smoothed material interfaces follow geometry consistently across z-slices.

* **Tests**
  * Added integration tests covering allocation modes, interface smoothing relations, and off-diagonal tensor behavior for tilted structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->