### PR TITLE
enhancement: implements colormap defaults for signed and unsigned detector data (solves #396)

### DIFF
--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Literal, Self
+from typing import ClassVar, Literal, Self
 
 import jax
 import jax.numpy as jnp
@@ -61,6 +61,13 @@ class Detector(SimulationObject, ABC):
 
     #: DPI resolution for plots. Defaults to None.
     plot_dpi: int | None = frozen_field(default=None)
+
+    #: Whether this detector records signed, zero-centered data (e.g. field
+    #: components Ex/Ey/Ez/Hx/Hy/Hz) vs. strictly non-negative data (e.g. energy
+    #: density, |E|^2, Poynting magnitude). Controls the default colormap and
+    #: normalization used by draw_plot. Override in subclasses that record
+    #: non-negative quantities.
+    _signed_data: ClassVar[bool] = True
 
     _num_time_steps_on: int = frozen_private_field()
     _is_on_at_time_step_arr: jax.Array = private_field()
@@ -283,13 +290,13 @@ class Detector(SimulationObject, ABC):
         for time-varying data.
 
         Args:
-            state (dict[str, np.ndarray]): Dictionary containing recorded field data arrays.
-            progress (Progress | None, optional): Optional progress bar for video generation.
-            cmap: str = "default": Color map for the detector plots. "default" is a custom
-                                   red-blue seaborn color map.
+            state: dict[str, np.ndarray]: Dictionary containing recorded field data arrays.
+            progress: Progress | None, optional: Optional progress bar for video generation.
+            cmap: str = "default": Color map for the detector plots. "default" is inferno
+                for unsigned data and bwr for signed data.
             aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
-                    "equal" (default) uses the same scale for all axes.
-                    "auto" adjusts each axis's scale to fit the figure size.
+                "equal" (default) uses the same scale for all axes.
+                "auto" adjusts each axis's scale to fit the figure size.
 
         Returns:
             dict[str, Figure | str]: Dictionary mapping plot names to either
@@ -297,6 +304,16 @@ class Detector(SimulationObject, ABC):
         """
         squeezed_arrs = {}
         squeezed_ndim = None
+
+        # Resolve cmap
+        if cmap == "default":
+            if self._signed_data:
+                resolved_cmap = "bwr"
+            else:
+                resolved_cmap = "inferno"
+        else:
+            resolved_cmap = cmap
+
         for k, v in state.items():
             v_squeezed = v.squeeze()
             if self.inverse and self.if_inverse_plot_backwards and self.num_time_steps_recorded > 1:
@@ -375,7 +392,8 @@ class Detector(SimulationObject, ABC):
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
                     aspect=aspect,
-                    cmap=cmap,
+                    cmap=resolved_cmap,
+                    signed_data=self._signed_data,
                 )
                 figs["sliced_plot"] = fig
             else:
@@ -395,7 +413,8 @@ class Detector(SimulationObject, ABC):
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
                     aspect=aspect,
-                    cmap=cmap,
+                    cmap=resolved_cmap,
+                    signed_data=self._signed_data,
                 )
                 figs["sliced_video"] = path
             else:
@@ -418,7 +437,8 @@ class Detector(SimulationObject, ABC):
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
                     aspect=aspect,
-                    cmap=cmap,
+                    cmap=resolved_cmap,
+                    signed_data=self._signed_data,
                 )
                 figs[k] = fig
         elif squeezed_ndim == 4 and self.num_time_steps_recorded > 1:
@@ -439,7 +459,8 @@ class Detector(SimulationObject, ABC):
                     plot_dpi=self.plot_dpi,
                     plot_interpolation=self.plot_interpolation,
                     aspect=aspect,
-                    cmap=cmap,
+                    cmap=resolved_cmap,
+                    signed_data=self._signed_data,
                 )
                 figs[k] = path
         else:

--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -293,7 +293,7 @@ class Detector(SimulationObject, ABC):
             state: dict[str, np.ndarray]: Dictionary containing recorded field data arrays.
             progress: Progress | None, optional: Optional progress bar for video generation.
             cmap: str = "default": Color map for the detector plots. "default" is turbo
-                for unsigned data and bwr for signed data.
+                for unsigned data and RdBu_r for signed data.
             aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
                 "equal" (default) uses the same scale for all axes.
                 "auto" adjusts each axis's scale to fit the figure size.

--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -292,7 +292,7 @@ class Detector(SimulationObject, ABC):
         Args:
             state: dict[str, np.ndarray]: Dictionary containing recorded field data arrays.
             progress: Progress | None, optional: Optional progress bar for video generation.
-            cmap: str = "default": Color map for the detector plots. "default" is inferno
+            cmap: str = "default": Color map for the detector plots. "default" is turbo
                 for unsigned data and bwr for signed data.
             aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
                 "equal" (default) uses the same scale for all axes.
@@ -310,7 +310,7 @@ class Detector(SimulationObject, ABC):
             if self._signed_data:
                 resolved_cmap = "RdBu_r"
             else:
-                resolved_cmap = "inferno"
+                resolved_cmap = "turbo"
         else:
             resolved_cmap = cmap
 

--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -308,7 +308,7 @@ class Detector(SimulationObject, ABC):
         # Resolve cmap
         if cmap == "default":
             if self._signed_data:
-                resolved_cmap = "bwr"
+                resolved_cmap = "RdBu_r"
             else:
                 resolved_cmap = "inferno"
         else:

--- a/src/fdtdx/objects/detectors/energy.py
+++ b/src/fdtdx/objects/detectors/energy.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 import jax
 import jax.numpy as jnp
 
@@ -38,6 +40,9 @@ class EnergyDetector(Detector):
     #: If "mean", aggregates slices by averaging instead of using position.
     #: If None, mean is used. Defaults to None.
     aggregate: str | None = frozen_field(default=None)  # e.g., "mean"
+
+    # Electromagnetic energy is positive.
+    _signed_data: ClassVar[bool] = False
 
     def _slice_position_to_index(self, axis: int, real_pos: float | None, axis_len: int) -> int | jax.Array:
         """Map a requested physical slice position to a local energy index.

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -2,7 +2,6 @@ from typing import Literal
 
 import matplotlib.pyplot as plt
 import numpy as np
-import seaborn as sns
 from matplotlib.figure import Figure
 
 
@@ -18,6 +17,7 @@ def plot_2d_from_slices(
     plot_dpi: int | None = None,
     aspect: Literal["equal", "auto"] = "equal",
     cmap: str = "default",
+    signed_data: bool = True,
 ) -> Figure:
     """Plot orthogonal slices using either uniform spacing or rectilinear edges.
 
@@ -34,31 +34,38 @@ def plot_2d_from_slices(
         maxvals: Per-slice color maxima.
         plot_interpolation: Interpolation used by the legacy uniform imshow path.
         plot_dpi: Figure DPI.
-        cmap: str = "default": Color map for the detector plots. "default" is a custom
-            red-blue seaborn color map.
+        cmap: str = "default": Color map for the detector plots. "default" is inferno
+            for unsigned data and bwr for signed data.
         aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
             "equal" (default) uses the same scale for all axes.
             "auto" adjusts each axis's scale to fit the figure size.
+        signed_data: bool: Whether the data is signed (fields, phasors, mode_overlaps...)
+            or unsigned (energy, Poynting flux). Used to choose a colormap and scale its values.
 
     Returns:
         Matplotlib figure with XY, XZ, and YZ panels.
     """
     slices = [xy_slice, xz_slice, yz_slice]
     for a in range(3):
-        if minvals[a] is None:
-            min_list = list(minvals)
-            min_list[a] = slices[a].min()
-            minvals = min_list[0], min_list[1], min_list[2]
-        if maxvals[a] is None:
-            max_list = list(maxvals)
-            max_list[a] = slices[a].max()
-            maxvals = max_list[0], max_list[1], max_list[2]
+        if signed_data:
+            if minvals[a] is None or maxvals[a] is None:
+                abs_max = float(np.abs(slices[a]).max())
+                min_list, max_list = list(minvals), list(maxvals)
+                min_list[a] = -abs_max
+                max_list[a] = abs_max
+                minvals = (min_list[0], min_list[1], min_list[2])
+                maxvals = (max_list[0], max_list[1], max_list[2])
+        else:
+            if minvals[a] is None:
+                min_list = list(minvals)
+                min_list[a] = 0.0
+                minvals = (min_list[0], min_list[1], min_list[2])
+            if maxvals[a] is None:
+                max_list = list(maxvals)
+                max_list[a] = slices[a].max()
+                maxvals = (max_list[0], max_list[1], max_list[2])
 
     fig = plt.figure(figsize=(20, 10), dpi=plot_dpi)
-    if cmap == "default":
-        color_map = sns.diverging_palette(220, 20, as_cmap=True)
-    else:
-        color_map = cmap
     res_x = resolutions[0] / 1.0e-6  # Convert to µm
     res_y = resolutions[1] / 1.0e-6
     res_z = resolutions[2] / 1.0e-6
@@ -90,7 +97,7 @@ def plot_2d_from_slices(
         )
         cax1 = ax1.imshow(
             xy_slice.T,
-            cmap=color_map,
+            cmap=cmap,
             vmin=minvals[0],
             vmax=maxvals[0],
             extent=extent1,
@@ -104,7 +111,7 @@ def plot_2d_from_slices(
             x_edges_centered,
             y_edges_centered,
             xy_slice.T,
-            cmap=color_map,
+            cmap=cmap,
             vmin=minvals[0],
             vmax=maxvals[0],
             shading="auto",
@@ -128,7 +135,7 @@ def plot_2d_from_slices(
         )
         cax2 = ax2.imshow(
             xz_slice.T,
-            cmap=color_map,
+            cmap=cmap,
             vmin=minvals[1],
             vmax=maxvals[1],
             extent=extent2,
@@ -142,7 +149,7 @@ def plot_2d_from_slices(
             x_edges_centered,
             z_edges_centered,
             xz_slice.T,
-            cmap=color_map,
+            cmap=cmap,
             vmin=minvals[1],
             vmax=maxvals[1],
             shading="auto",
@@ -165,7 +172,7 @@ def plot_2d_from_slices(
         )
         cax3 = ax3.imshow(
             yz_slice.T,
-            cmap=color_map,
+            cmap=cmap,
             vmin=minvals[2],
             vmax=maxvals[2],
             extent=extent3,
@@ -179,7 +186,7 @@ def plot_2d_from_slices(
             y_edges_centered,
             z_edges_centered,
             yz_slice.T,
-            cmap=color_map,
+            cmap=cmap,
             vmin=minvals[2],
             vmax=maxvals[2],
             shading="auto",

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -65,6 +65,15 @@ def plot_2d_from_slices(
                 max_list[a] = slices[a].max()
                 maxvals = (max_list[0], max_list[1], max_list[2])
 
+    # Resolve cmap if not done before
+    if cmap == "default":
+        if signed_data:
+            resolved_cmap = "RdBu_r"
+        else:
+            resolved_cmap = "inferno"
+    else:
+        resolved_cmap = cmap
+
     fig = plt.figure(figsize=(20, 10), dpi=plot_dpi)
     res_x = resolutions[0] / 1.0e-6  # Convert to µm
     res_y = resolutions[1] / 1.0e-6
@@ -97,7 +106,7 @@ def plot_2d_from_slices(
         )
         cax1 = ax1.imshow(
             xy_slice.T,
-            cmap=cmap,
+            cmap=resolved_cmap,
             vmin=minvals[0],
             vmax=maxvals[0],
             extent=extent1,
@@ -111,7 +120,7 @@ def plot_2d_from_slices(
             x_edges_centered,
             y_edges_centered,
             xy_slice.T,
-            cmap=cmap,
+            cmap=resolved_cmap,
             vmin=minvals[0],
             vmax=maxvals[0],
             shading="auto",
@@ -135,7 +144,7 @@ def plot_2d_from_slices(
         )
         cax2 = ax2.imshow(
             xz_slice.T,
-            cmap=cmap,
+            cmap=resolved_cmap,
             vmin=minvals[1],
             vmax=maxvals[1],
             extent=extent2,
@@ -149,7 +158,7 @@ def plot_2d_from_slices(
             x_edges_centered,
             z_edges_centered,
             xz_slice.T,
-            cmap=cmap,
+            cmap=resolved_cmap,
             vmin=minvals[1],
             vmax=maxvals[1],
             shading="auto",
@@ -172,7 +181,7 @@ def plot_2d_from_slices(
         )
         cax3 = ax3.imshow(
             yz_slice.T,
-            cmap=cmap,
+            cmap=resolved_cmap,
             vmin=minvals[2],
             vmax=maxvals[2],
             extent=extent3,
@@ -186,7 +195,7 @@ def plot_2d_from_slices(
             y_edges_centered,
             z_edges_centered,
             yz_slice.T,
-            cmap=cmap,
+            cmap=resolved_cmap,
             vmin=minvals[2],
             vmax=maxvals[2],
             shading="auto",

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -46,24 +46,34 @@ def plot_2d_from_slices(
         Matplotlib figure with XY, XZ, and YZ panels.
     """
     slices = [xy_slice, xz_slice, yz_slice]
+    minlist = list(minvals)  # Convert to list for mutability
+    maxlist = list(maxvals)  # Convert to list for mutability
+    # Reset max and min color values
     for a in range(3):
         if signed_data:
             if minvals[a] is None or maxvals[a] is None:
-                abs_max = float(np.abs(slices[a]).max())
-                min_list, max_list = list(minvals), list(maxvals)
-                min_list[a] = -abs_max
-                max_list[a] = abs_max
-                minvals = (min_list[0], min_list[1], min_list[2])
-                maxvals = (max_list[0], max_list[1], max_list[2])
-        else:
-            if minvals[a] is None:
-                min_list = list(minvals)
-                min_list[a] = 0.0
-                minvals = (min_list[0], min_list[1], min_list[2])
-            if maxvals[a] is None:
-                max_list = list(maxvals)
-                max_list[a] = slices[a].max()
-                maxvals = (max_list[0], max_list[1], max_list[2])
+                if minlist[a] is None and maxlist[a] is None:
+                    # Set values symmetrically with absolute maximum
+                    abs_max = float(np.abs(slices[a]).max())
+                    minlist[a] = -abs_max
+                    maxlist[a] = abs_max
+                elif minlist[a] is not None:
+                    # Keep user input, set values symmetrically
+                    # minvals[a] is guaranteed to be not None here
+                    minlist[a] = -cast(float, maxlist[a])
+                elif maxlist[a] is not None:
+                    # Keep user input, set values symmetrically
+                    # maxvals[a] is guaranteed to be not None here
+                    minlist[a] = -cast(float, minlist[a])
+        else:  # Data is unsigned
+            if minlist[a] is None:
+                minlist[a] = 0.0
+            if maxlist[a] is None:
+                maxlist[a] = float(slices[a].max())
+
+    # Convert back to tuples
+    minvals = (minlist[0], minlist[1], minlist[2])
+    maxvals = (maxlist[0], maxlist[1], maxlist[2])
 
     # Resolve cmap if not done before
     if cmap == "default":

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -60,7 +60,7 @@ def plot_2d_from_slices(
                 elif minlist[a] is not None:
                     # Keep user input, set values symmetrically
                     # minvals[a] is guaranteed to be not None here
-                    minlist[a] = -cast(float, maxlist[a])
+                    maxlist[a] = -cast(float, minlist[a])
                 elif maxlist[a] is not None:
                     # Keep user input, set values symmetrically
                     # maxvals[a] is guaranteed to be not None here

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -64,7 +64,7 @@ def plot_2d_from_slices(
                 elif maxlist[a] is not None:
                     # Keep user input, set values symmetrically
                     # maxvals[a] is guaranteed to be not None here
-                    minlist[a] = -cast(float, minlist[a])
+                    minlist[a] = -cast(float, maxlist[a])
         else:  # Data is unsigned
             if minlist[a] is None:
                 minlist[a] = 0.0

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -35,7 +35,7 @@ def plot_2d_from_slices(
         plot_interpolation: Interpolation used by the legacy uniform imshow path.
         plot_dpi: Figure DPI.
         cmap: str = "default": Color map for the detector plots. "default" is turbo
-            for unsigned data and bwr for signed data.
+            for unsigned data and RdBu_r for signed data.
         aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
             "equal" (default) uses the same scale for all axes.
             "auto" adjusts each axis's scale to fit the figure size.

--- a/src/fdtdx/objects/detectors/plotting/plot2d.py
+++ b/src/fdtdx/objects/detectors/plotting/plot2d.py
@@ -34,7 +34,7 @@ def plot_2d_from_slices(
         maxvals: Per-slice color maxima.
         plot_interpolation: Interpolation used by the legacy uniform imshow path.
         plot_dpi: Figure DPI.
-        cmap: str = "default": Color map for the detector plots. "default" is inferno
+        cmap: str = "default": Color map for the detector plots. "default" is turbo
             for unsigned data and bwr for signed data.
         aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
             "equal" (default) uses the same scale for all axes.
@@ -70,7 +70,7 @@ def plot_2d_from_slices(
         if signed_data:
             resolved_cmap = "RdBu_r"
         else:
-            resolved_cmap = "inferno"
+            resolved_cmap = "turbo"
     else:
         resolved_cmap = cmap
 

--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -26,6 +26,7 @@ def plot_from_slices(
     coordinate_edges_um: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
     aspect: Literal["auto", "equal"] = "equal",
     cmap: str = "default",
+    signed_data: bool = True,
 ):
     xy_slice, xz_slice, yz_slice = slice_tuple
 
@@ -41,6 +42,7 @@ def plot_from_slices(
         plot_interpolation=plot_interpolation,
         aspect=aspect,
         cmap=cmap,
+        signed_data=signed_data,
     )
     # Convert matplotlib figure to a numpy array
     fig.canvas.draw()
@@ -86,6 +88,7 @@ def generate_video_from_slices(
     coordinate_edges_um: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
     aspect: Literal["auto", "equal"] = "equal",
     cmap: str = "default",
+    signed_data: bool = True,
 ) -> str:
     """Generates an MP4 video from time-series slice data using parallel processing.
 
@@ -109,25 +112,35 @@ def generate_video_from_slices(
             scaling. None values are auto-scaled. Defaults to (None, None, None)
         maxvals (tuple[float | None, float | None, float | None]): Tuple of maximum values for colormap scaling.
             None values are auto-scaled. Defaults to (None, None, None).
-        cmap: str = "default": Color map for the detector plots. "default" is a custom
-            red-blue seaborn color map.
+        resolved_cmap: str = "default": Color map for the detector plots.
         aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
             "equal" (default) uses the same scale for all axes.
             "auto" adjusts each axis's scale to fit the figure size.
+        signed_data: bool: Whether the data is signed (fields, phasors, mode_overlaps...)
+            or unsigned (energy, Poynting flux). Used to choose a colormap and scale its values.
 
     Returns:
         str: Path to the generated MP4 video file
     """
     slices = [xy_slice, xz_slice, yz_slice]
     for a in range(3):
-        if minvals[a] is None:
-            min_list = list(minvals)
-            min_list[a] = slices[a].min()
-            minvals = min_list[0], min_list[1], min_list[2]
-        if maxvals[a] is None:
-            max_list = list(maxvals)
-            max_list[a] = slices[a].max()
-            maxvals = max_list[0], max_list[1], max_list[2]
+        if signed_data:
+            if minvals[a] is None or maxvals[a] is None:
+                abs_max = float(np.abs(slices[a]).max())
+                min_list, max_list = list(minvals), list(maxvals)
+                min_list[a] = -abs_max
+                max_list[a] = abs_max
+                minvals = (min_list[0], min_list[1], min_list[2])
+                maxvals = (max_list[0], max_list[1], max_list[2])
+        else:
+            if minvals[a] is None:
+                min_list = list(minvals)
+                min_list[a] = 0.0
+                minvals = (min_list[0], min_list[1], min_list[2])
+            if maxvals[a] is None:
+                max_list = list(maxvals)
+                max_list[a] = slices[a].max()
+                maxvals = (max_list[0], max_list[1], max_list[2])
 
     _, path = tempfile.mkstemp(suffix=".mp4")
 
@@ -146,6 +159,7 @@ def generate_video_from_slices(
         coordinate_edges_um=coordinate_edges_um,
         aspect=aspect,
         cmap=cmap,
+        signed_data=signed_data,
     )
     slice_arr_list = [(xy_slice[t], xz_slice[t], yz_slice[t]) for t in range(time_steps)]
     if num_worker is None:

--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -142,7 +142,7 @@ def generate_video_from_slices(
                 elif maxlist[a] is not None:
                     # Keep user input, set values symmetrically
                     # maxvals[a] is guaranteed to be not None here
-                    minlist[a] = -cast(float, minlist[a])
+                    minlist[a] = -cast(float, maxlist[a])
         else:  # Data is unsigned
             if minlist[a] is None:
                 minlist[a] = 0.0

--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -112,7 +112,7 @@ def generate_video_from_slices(
             scaling. None values are auto-scaled. Defaults to (None, None, None)
         maxvals (tuple[float | None, float | None, float | None]): Tuple of maximum values for colormap scaling.
             None values are auto-scaled. Defaults to (None, None, None).
-        resolved_cmap: str = "default": Color map for the detector plots.
+        cmap: str = "default": Color map for the detector plots.
         aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
             "equal" (default) uses the same scale for all axes.
             "auto" adjusts each axis's scale to fit the figure size.

--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -112,7 +112,8 @@ def generate_video_from_slices(
             scaling. None values are auto-scaled. Defaults to (None, None, None)
         maxvals (tuple[float | None, float | None, float | None]): Tuple of maximum values for colormap scaling.
             None values are auto-scaled. Defaults to (None, None, None).
-        cmap: str = "default": Color map for the detector plots.
+        cmap: str = "default": Color map for the detector plots. "default" is turbo
+            for unsigned data and RdBu_r for signed data.
         aspect: Literal["auto", "equal"]: Size aspect of the detector plots.
             "equal" (default) uses the same scale for all axes.
             "auto" adjusts each axis's scale to fit the figure size.

--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -1,7 +1,7 @@
 import multiprocessing as mp
 import tempfile
 from functools import partial
-from typing import Callable, Literal
+from typing import Callable, Literal, cast
 
 import matplotlib
 
@@ -124,24 +124,30 @@ def generate_video_from_slices(
         str: Path to the generated MP4 video file
     """
     slices = [xy_slice, xz_slice, yz_slice]
+    minlist = list(minvals)  # Convert to list for mutability
+    maxlist = list(maxvals)  # Convert to list for mutability
+    # Reset max and min color values
     for a in range(3):
         if signed_data:
             if minvals[a] is None or maxvals[a] is None:
-                abs_max = float(np.abs(slices[a]).max())
-                min_list, max_list = list(minvals), list(maxvals)
-                min_list[a] = -abs_max
-                max_list[a] = abs_max
-                minvals = (min_list[0], min_list[1], min_list[2])
-                maxvals = (max_list[0], max_list[1], max_list[2])
-        else:
-            if minvals[a] is None:
-                min_list = list(minvals)
-                min_list[a] = 0.0
-                minvals = (min_list[0], min_list[1], min_list[2])
-            if maxvals[a] is None:
-                max_list = list(maxvals)
-                max_list[a] = slices[a].max()
-                maxvals = (max_list[0], max_list[1], max_list[2])
+                if minlist[a] is None and maxlist[a] is None:
+                    # Set values symmetrically with absolute maximum
+                    abs_max = float(np.abs(slices[a]).max())
+                    minlist[a] = -abs_max
+                    maxlist[a] = abs_max
+                elif minlist[a] is not None:
+                    # Keep user input, set values symmetrically
+                    # minvals[a] is guaranteed to be not None here
+                    maxlist[a] = -cast(float, minlist[a])
+                elif maxlist[a] is not None:
+                    # Keep user input, set values symmetrically
+                    # maxvals[a] is guaranteed to be not None here
+                    minlist[a] = -cast(float, minlist[a])
+        else:  # Data is unsigned
+            if minlist[a] is None:
+                minlist[a] = 0.0
+            if maxlist[a] is None:
+                maxlist[a] = float(slices[a].max())
 
     _, path = tempfile.mkstemp(suffix=".mp4")
 

--- a/src/fdtdx/objects/detectors/poynting_flux.py
+++ b/src/fdtdx/objects/detectors/poynting_flux.py
@@ -1,4 +1,4 @@
-from typing import Literal, Self
+from typing import ClassVar, Literal, Self
 
 import jax
 import jax.numpy as jnp
@@ -37,6 +37,9 @@ class PoyntingFluxDetector(Detector):
     keep_all_components: bool = frozen_field(default=False)
 
     _cached_face_area_weights: jax.Array = private_field()
+
+    # Poynting flux is positive.
+    _signed_data: ClassVar[bool] = False
 
     @property
     def propagation_axis(self) -> int:

--- a/src/fdtdx/utils/plot_field_slice.py
+++ b/src/fdtdx/utils/plot_field_slice.py
@@ -33,6 +33,15 @@ def plot_field_slice_component(
     if jnp.any(jnp.isinf(field)):
         raise ValueError(f"{component_name} contains infinite values")
 
+    # Min-max recenter-at-0 scheme: make vmin/vmax symmetric about zero so
+    # the diverging colormap's white midpoint always corresponds to 0,
+    # regardless of whether the field skews positive or negative.
+    max_abs = float(jnp.max(jnp.abs(field)))
+    if max_abs == 0:
+        # Avoid a degenerate (0, 0) color range for an all-zero field
+        max_abs = 1e-12
+    vmin, vmax = -max_abs, max_abs
+
     # Plot the field component
     h, w = field.T.shape
     im = ax.imshow(
@@ -42,6 +51,8 @@ def plot_field_slice_component(
         aspect="equal",
         cmap="RdBu_r",  # Red-blue colormap, centered at zero
         interpolation="nearest",
+        vmin=vmin,
+        vmax=vmax,
     )
 
     # Set labels and title
@@ -147,6 +158,7 @@ def plot_field_slice(
 
     # Plot E field components (top row)
     for i, comp_name in enumerate(E_components):
+        assert axs is not None
         plot_field_slice_component(
             field=E[i],
             component_name=comp_name,
@@ -156,6 +168,7 @@ def plot_field_slice(
 
     # Plot H field components (bottom row)
     for i, comp_name in enumerate(H_components):
+        assert axs is not None
         plot_field_slice_component(
             field=H[i],
             component_name=comp_name,


### PR DESCRIPTION
Solves #396.

A new boolean class variable, `_signed_data` is added to the `Detector` class and set as True by default.
Classes for unsigned data like energy and Poynting flux (please tell me if I forgot any), override the default value and set it as False.

Plotting colormaps are then assigned. Depending on its value, a red-white-blue color map (RdBl_r) is used when data is signed, and "turbo" is used if it is unsigned.
Max and minimum color values are set from the data: `vmin=0`, `vmax=data_max` in unsigned case and `vmin=-abs_max`, `vmax=abs_max` in signed case, where `abs_max = max(abs(data_min), abs(data_max))`. This way the zeroes points of the data are mapped to white, the 0 point of the colorbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **New Features**
  * Detector plot and video rendering now automatically adjust colormaps and min/max scaling based on whether outputs can be signed or are strictly non-negative.
  * Field component visualizations now render with zero-centered color scaling for improved contrast.

* **Bug Fixes**
  * Improved auto min/max behavior: signed data defaults to symmetric bounds around 0 when limits are missing; unsigned data defaults to non-negative bounds.
  * Increased plotting robustness by ensuring required axes are present before drawing component panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->