### PR TITLE
Perf: optimize FDTD update hot paths

### DIFF
--- a/src/fdtdx/core/grid.py
+++ b/src/fdtdx/core/grid.py
@@ -5,7 +5,7 @@ from matplotlib.path import Path
 
 from fdtdx import constants
 from fdtdx.core.axis import get_transverse_axes
-from fdtdx.core.jax.pytrees import TreeClass, autoinit, field, frozen_field, frozen_private_field
+from fdtdx.core.jax.pytrees import TreeClass, autoinit, field, frozen_field, frozen_private_field, private_field
 from fdtdx.core.misc import validate_symmetric_axis_cells
 
 
@@ -312,6 +312,7 @@ class RectilinearGrid(TreeClass):
     _min_spacings: tuple[float, float, float] = frozen_private_field()
     _is_uniform: bool = frozen_private_field()
     _uniform_spacing: float | None = frozen_private_field()
+    _cell_widths: tuple[jax.Array, jax.Array, jax.Array] = private_field(repr=False)
 
     def __post_init__(self):
         object.__setattr__(self, "x_edges", jnp.asarray(self.x_edges))
@@ -326,6 +327,7 @@ class RectilinearGrid(TreeClass):
                 raise ValueError(f"Grid edge coordinates for axis {axis} must be strictly increasing.")
         edge_arrays_np = tuple(np.asarray(edges) for edges in (self.x_edges, self.y_edges, self.z_edges))
         width_arrays = tuple(np.diff(edges) for edges in edge_arrays_np)
+        object.__setattr__(self, "_cell_widths", tuple(jnp.asarray(widths) for widths in width_arrays))
         min_spacings = tuple(float(np.min(widths)) for widths in width_arrays)
         spacing = float(width_arrays[0][0])
         # Uniformity is a *relative* property. The absolute width jitter of a perfectly uniform
@@ -463,17 +465,17 @@ class RectilinearGrid(TreeClass):
     @property
     def dx(self) -> jax.Array:
         """Cell widths along x in metres."""
-        return jnp.diff(self.x_edges)
+        return self._cell_widths[0]
 
     @property
     def dy(self) -> jax.Array:
         """Cell widths along y in metres."""
-        return jnp.diff(self.y_edges)
+        return self._cell_widths[1]
 
     @property
     def dz(self) -> jax.Array:
         """Cell widths along z in metres."""
-        return jnp.diff(self.z_edges)
+        return self._cell_widths[2]
 
     @property
     def min_spacing(self) -> float:

--- a/src/fdtdx/core/physics/curl.py
+++ b/src/fdtdx/core/physics/curl.py
@@ -229,17 +229,22 @@ def curl_E(
     dy_scale = _metric_scale(config, axis=1, shape=shape, stencil="forward")
     dz_scale = _metric_scale(config, axis=2, shape=shape, stencil="forward")
 
-    dyEz = (jnp.roll(E_pad[2], -1, axis=1) - E_pad[2])[1:-1, 1:-1, 1:-1] * dy_scale
-    dzEy = (jnp.roll(E_pad[1], -1, axis=2) - E_pad[1])[1:-1, 1:-1, 1:-1] * dz_scale
-    dzEx = (jnp.roll(E_pad[0], -1, axis=2) - E_pad[0])[1:-1, 1:-1, 1:-1] * dz_scale
-    dxEz = (jnp.roll(E_pad[2], -1, axis=0) - E_pad[2])[1:-1, 1:-1, 1:-1] * dx_scale
-    dxEy = (jnp.roll(E_pad[1], -1, axis=0) - E_pad[1])[1:-1, 1:-1, 1:-1] * dx_scale
-    dyEx = (jnp.roll(E_pad[0], -1, axis=1) - E_pad[0])[1:-1, 1:-1, 1:-1] * dy_scale
+    Ex = E_pad[0]
+    Ey = E_pad[1]
+    Ez = E_pad[2]
+    center = (slice(1, -1), slice(1, -1), slice(1, -1))
+
+    dyEz = (Ez[1:-1, 2:, 1:-1] - Ez[center]) * dy_scale
+    dzEy = (Ey[1:-1, 1:-1, 2:] - Ey[center]) * dz_scale
+    dzEx = (Ex[1:-1, 1:-1, 2:] - Ex[center]) * dz_scale
+    dxEz = (Ez[2:, 1:-1, 1:-1] - Ez[center]) * dx_scale
+    dxEy = (Ey[2:, 1:-1, 1:-1] - Ey[center]) * dx_scale
+    dyEx = (Ex[1:-1, 2:, 1:-1] - Ex[center]) * dy_scale
 
     curl_x = dyEz - dzEy
     curl_y = dzEx - dxEz
     curl_z = dxEy - dyEx
-    curl = jnp.stack((curl_x, curl_y, curl_z), axis=0)
+    curl_components = [curl_x, curl_y, curl_z]
 
     psi_H_updated = {}
 
@@ -264,11 +269,12 @@ def curl_E(
             d_field_1, d_field_2, psi_1, psi_2, is_curl_E=True, simulate_boundaries=simulate_boundaries
         )
 
-        curl = curl.at[i, *pml.grid_slice].add(-corr_1)
-        curl = curl.at[j, *pml.grid_slice].add(corr_2)
+        curl_components[i] = curl_components[i].at[pml.grid_slice].add(-corr_1)
+        curl_components[j] = curl_components[j].at[pml.grid_slice].add(corr_2)
 
         psi_H_updated[pml.name] = (psi_1_new, psi_2_new)
 
+    curl = jnp.stack(curl_components, axis=0)
     return curl, psi_H_updated
 
 
@@ -310,17 +316,22 @@ def curl_H(
     dy_scale = _metric_scale(config, axis=1, shape=shape, stencil="backward")
     dz_scale = _metric_scale(config, axis=2, shape=shape, stencil="backward")
 
-    dyHz = (H_pad[2] - jnp.roll(H_pad[2], 1, axis=1))[1:-1, 1:-1, 1:-1] * dy_scale
-    dzHy = (H_pad[1] - jnp.roll(H_pad[1], 1, axis=2))[1:-1, 1:-1, 1:-1] * dz_scale
-    dzHx = (H_pad[0] - jnp.roll(H_pad[0], 1, axis=2))[1:-1, 1:-1, 1:-1] * dz_scale
-    dxHz = (H_pad[2] - jnp.roll(H_pad[2], 1, axis=0))[1:-1, 1:-1, 1:-1] * dx_scale
-    dxHy = (H_pad[1] - jnp.roll(H_pad[1], 1, axis=0))[1:-1, 1:-1, 1:-1] * dx_scale
-    dyHx = (H_pad[0] - jnp.roll(H_pad[0], 1, axis=1))[1:-1, 1:-1, 1:-1] * dy_scale
+    Hx = H_pad[0]
+    Hy = H_pad[1]
+    Hz = H_pad[2]
+    center = (slice(1, -1), slice(1, -1), slice(1, -1))
+
+    dyHz = (Hz[center] - Hz[1:-1, :-2, 1:-1]) * dy_scale
+    dzHy = (Hy[center] - Hy[1:-1, 1:-1, :-2]) * dz_scale
+    dzHx = (Hx[center] - Hx[1:-1, 1:-1, :-2]) * dz_scale
+    dxHz = (Hz[center] - Hz[:-2, 1:-1, 1:-1]) * dx_scale
+    dxHy = (Hy[center] - Hy[:-2, 1:-1, 1:-1]) * dx_scale
+    dyHx = (Hx[center] - Hx[1:-1, :-2, 1:-1]) * dy_scale
 
     curl_x = dyHz - dzHy
     curl_y = dzHx - dxHz
     curl_z = dxHy - dyHx
-    curl = jnp.stack((curl_x, curl_y, curl_z), axis=0)
+    curl_components = [curl_x, curl_y, curl_z]
 
     psi_E_updated = {}
 
@@ -344,9 +355,10 @@ def curl_H(
             d_field_1, d_field_2, psi_1, psi_2, is_curl_E=False, simulate_boundaries=simulate_boundaries
         )
 
-        curl = curl.at[i, *pml.grid_slice].add(-corr_1)
-        curl = curl.at[j, *pml.grid_slice].add(corr_2)
+        curl_components[i] = curl_components[i].at[pml.grid_slice].add(-corr_1)
+        curl_components[j] = curl_components[j].at[pml.grid_slice].add(corr_2)
 
         psi_E_updated[pml.name] = (psi_1_new, psi_2_new)
 
+    curl = jnp.stack(curl_components, axis=0)
     return curl, psi_E_updated

--- a/src/fdtdx/core/switch.py
+++ b/src/fdtdx/core/switch.py
@@ -35,6 +35,22 @@ class OnOffSwitch(TreeClass):
     #: interval of the switch
     interval: int = frozen_field(default=1)
 
+    @property
+    def is_default_always_on(self) -> bool:
+        """Return whether the switch is the default all-steps-on switch."""
+        return (
+            not self.is_always_off
+            and self.fixed_on_time_steps is None
+            and self.interval == 1
+            and self.start_time is None
+            and self.start_after_periods is None
+            and self.end_time is None
+            and self.end_after_periods is None
+            and self.on_for_time is None
+            and self.on_for_periods is None
+            and self.period is None
+        )
+
     def calculate_on_list(
         self,
         num_total_time_steps: int,

--- a/src/fdtdx/fdtd/update.py
+++ b/src/fdtdx/fdtd/update.py
@@ -5,6 +5,7 @@ from fdtdx.config import SimulationConfig
 from fdtdx.constants import eta0
 from fdtdx.core.misc import expand_to_3x3, pad_fields
 from fdtdx.core.physics.curl import curl_E, curl_H, interpolate_fields
+from fdtdx.core.switch import OnOffSwitch
 from fdtdx.fdtd.container import ArrayContainer, ObjectContainer
 from fdtdx.fdtd.misc import (
     add_boundary_interfaces,
@@ -15,6 +16,11 @@ from fdtdx.fdtd.misc import (
     compute_anisotropic_update_matrices_reverse,
 )
 from fdtdx.objects.detectors.detector import Detector
+
+
+def _source_uses_default_always_on_switch(source) -> bool:
+    switch = getattr(source, "switch", None)
+    return isinstance(switch, OnOffSwitch) and switch.is_default_always_on
 
 
 def get_wrap_padding_axes(objects: ObjectContainer) -> tuple[bool, bool, bool]:
@@ -317,6 +323,15 @@ def update_E(
         E = jnp.stack((Ex, Ey, Ez), axis=0)
 
     for source in objects.sources:
+        if _source_uses_default_always_on_switch(source):
+            E = source.update_E(
+                E=E,
+                inv_permittivities=arrays.inv_permittivities,
+                inv_permeabilities=arrays.inv_permeabilities,
+                time_step=time_step,
+                inverse=False,
+            )
+            continue
 
         def _update():
             adj_time_step = source.adjust_time_step_by_on_off(time_step)
@@ -362,6 +377,15 @@ def update_E_reverse(
     """
     E = arrays.fields.E
     for source in objects.sources:
+        if _source_uses_default_always_on_switch(source):
+            E = source.update_E(
+                E,
+                inv_permittivities=arrays.inv_permittivities,
+                inv_permeabilities=arrays.inv_permeabilities,
+                time_step=time_step,
+                inverse=True,
+            )
+            continue
 
         def _update():
             adj_time_step = source.adjust_time_step_by_on_off(time_step)
@@ -653,6 +677,15 @@ def update_H(
         H = jnp.stack((Hx, Hy, Hz), axis=0)
 
     for source in objects.sources:
+        if _source_uses_default_always_on_switch(source):
+            H = source.update_H(
+                H=H,
+                inv_permittivities=arrays.inv_permittivities,
+                inv_permeabilities=arrays.inv_permeabilities,
+                time_step=time_step + 0.5,
+                inverse=False,
+            )
+            continue
 
         def _update():
             adj_time_step = source.adjust_time_step_by_on_off(time_step)
@@ -698,6 +731,15 @@ def update_H_reverse(
     """
     H = arrays.fields.H
     for source in objects.sources:
+        if _source_uses_default_always_on_switch(source):
+            H = source.update_H(
+                H,
+                inv_permittivities=arrays.inv_permittivities,
+                inv_permeabilities=arrays.inv_permeabilities,
+                time_step=time_step + 0.5,
+                inverse=True,
+            )
+            continue
 
         def _update():
             adj_time_step = source.adjust_time_step_by_on_off(time_step)

--- a/src/fdtdx/objects/boundaries/perfectly_matched_layer.py
+++ b/src/fdtdx/objects/boundaries/perfectly_matched_layer.py
@@ -181,8 +181,11 @@ class PerfectlyMatchedLayer(BaseBoundary):
         else:
             psi_1_new, psi_2_new = psi_1, psi_2
 
-        corr_1 = (inv_kappa - 1.0) * d_field_1 + psi_1_new
-        corr_2 = (inv_kappa - 1.0) * d_field_2 + psi_2_new
+        if self.kappa_start == 1.0 and self.kappa_end == 1.0:
+            corr_1, corr_2 = psi_1_new, psi_2_new
+        else:
+            corr_1 = (inv_kappa - 1.0) * d_field_1 + psi_1_new
+            corr_2 = (inv_kappa - 1.0) * d_field_2 + psi_2_new
 
         return corr_1, corr_2, psi_1_new, psi_2_new
 
@@ -241,7 +244,7 @@ class PerfectlyMatchedLayer(BaseBoundary):
             dtype: Data type for the array
 
         Returns:
-            jax.Array: Graded profile array with shape self.grid_shape
+            Broadcast-shaped E/H profile arrays with grading along only the PML axis.
         """
         L = self.thickness  # Total thickness of PML
 
@@ -269,11 +272,7 @@ class PerfectlyMatchedLayer(BaseBoundary):
         shape[self.axis] = L
         profileE_reshaped = profileE_1d.reshape(shape)
         profileH_reshaped = profileH_1d.reshape(shape)
-        # Broadcast to full grid_shape
-        profileE = jnp.broadcast_to(profileE_reshaped, self.grid_shape)
-        profileH = jnp.broadcast_to(profileH_reshaped, self.grid_shape)
-
-        return profileE, profileH
+        return profileE_reshaped, profileH_reshaped
 
     def _compute_nonuniform_pml_depths(self, dtype) -> tuple[jax.Array, jax.Array, float]:
         """Return E/H physical depths into a non-uniform PML.

--- a/src/fdtdx/objects/sources/dipole.py
+++ b/src/fdtdx/objects/sources/dipole.py
@@ -37,6 +37,17 @@ def _contract_orientation(
     return inv_material * orient
 
 
+def _axis_aligned_diagonal_injection(
+    inv_material: jax.Array | float, azimuth_angle: float, elevation_angle: float
+) -> bool:
+    """Return whether an axis-aligned dipole can update only one field component."""
+    if azimuth_angle != 0.0 or elevation_angle != 0.0:
+        return False
+    if not isinstance(inv_material, jax.Array) or inv_material.ndim == 0:
+        return True
+    return inv_material.shape[0] in (1, 3)
+
+
 @autoinit
 class PointDipoleSource(Source):
     """Soft point dipole source (electric or magnetic).
@@ -185,15 +196,20 @@ class PointDipoleSource(Source):
         sign = -1.0 if not inverse else 1.0
 
         if isinstance(self._inv_eps_oriented, Null):
-            inv_eps_slice = inv_permittivities[:, *self.grid_slice]
-            inv_eps_oriented = _contract_orientation(inv_eps_slice, self._orientation)
+            inv_eps_source = inv_permittivities[:, *self.grid_slice]
+            inv_eps_oriented = _contract_orientation(inv_eps_source, self._orientation)
         else:
+            inv_eps_source = self._inv_eps_local
             inv_eps_oriented = self._inv_eps_oriented
 
         scale = c * self.amplitude * self.static_amplitude_factor * amplitude
-        for axis in range(3):
-            injection = scale * inv_eps_oriented[axis]
-            E = E.at[axis, *self.grid_slice].add(sign * injection.astype(E.dtype))
+        if _axis_aligned_diagonal_injection(inv_eps_source, self.azimuth_angle, self.elevation_angle):
+            injection = scale * inv_eps_oriented[self.polarization]
+            E = E.at[self.polarization, *self.grid_slice].add(sign * injection.astype(E.dtype))
+        else:
+            for axis in range(3):
+                injection = scale * inv_eps_oriented[axis]
+                E = E.at[axis, *self.grid_slice].add(sign * injection.astype(E.dtype))
 
         return E
 
@@ -226,11 +242,16 @@ class PointDipoleSource(Source):
                 inv_mu_source = inv_permeabilities[:, *self.grid_slice]
             inv_mu_oriented = _contract_orientation(inv_mu_source, self._orientation)
         else:
+            inv_mu_source = self._inv_mu_local
             inv_mu_oriented = self._inv_mu_oriented
 
         scale = c * self.amplitude * self.static_amplitude_factor * amplitude
-        for axis in range(3):
-            injection = scale * inv_mu_oriented[axis]
-            H = H.at[axis, *self.grid_slice].add(sign * injection.astype(H.dtype))
+        if _axis_aligned_diagonal_injection(inv_mu_source, self.azimuth_angle, self.elevation_angle):
+            injection = scale * inv_mu_oriented[self.polarization]
+            H = H.at[self.polarization, *self.grid_slice].add(sign * injection.astype(H.dtype))
+        else:
+            for axis in range(3):
+                injection = scale * inv_mu_oriented[axis]
+                H = H.at[axis, *self.grid_slice].add(sign * injection.astype(H.dtype))
 
         return H

--- a/tests/unit/core/test_switch.py
+++ b/tests/unit/core/test_switch.py
@@ -127,6 +127,14 @@ class TestOnOffSwitch:
         result = switch.calculate_on_list(num_total_time_steps=5, time_step_duration=1.0)
         assert result == [True, True, True, True, True]
 
+    def test_default_switch_is_default_always_on(self):
+        assert OnOffSwitch().is_default_always_on
+        assert not OnOffSwitch(interval=2).is_default_always_on
+        assert not OnOffSwitch(start_time=0.0).is_default_always_on
+        assert not OnOffSwitch(end_time=1.0).is_default_always_on
+        assert not OnOffSwitch(fixed_on_time_steps=[0]).is_default_always_on
+        assert not OnOffSwitch(is_always_off=True).is_default_always_on
+
     def test_calculate_on_list_with_interval(self):
         switch = OnOffSwitch(interval=3)
         result = switch.calculate_on_list(num_total_time_steps=7, time_step_duration=1.0)

--- a/tests/unit/objects/boundaries/test_perfectly_matched_layer.py
+++ b/tests/unit/objects/boundaries/test_perfectly_matched_layer.py
@@ -190,12 +190,14 @@ class TestPMLThickness:
 class TestPMLComputeProfile:
     """Tests for PerfectlyMatchedLayer._compute_pml_profile."""
 
-    def test_profile_shape_matches_grid_shape(self, micro_config, jax_key):
+    def test_profile_shape_is_broadcastable_to_grid_shape(self, micro_config, jax_key):
         pml = make_pml(axis=0, direction="-", thickness=10)
         placed = place_pml(pml, micro_config, jax_key, volume_shape=(30, 20, 20))
         profileE, profileH = placed._compute_pml_profile(0.0, 1.0, 3.0, jnp.float32)
-        assert profileE.shape == (10, 20, 20)
-        assert profileH.shape == (10, 20, 20)
+        assert profileE.shape == (10, 1, 1)
+        assert profileH.shape == (10, 1, 1)
+        assert jnp.broadcast_to(profileE, placed.grid_shape).shape == (10, 20, 20)
+        assert jnp.broadcast_to(profileH, placed.grid_shape).shape == (10, 20, 20)
 
     def test_profile_dtype(self, micro_config, jax_key):
         pml = make_pml(axis=0, direction="-", thickness=10)
@@ -232,13 +234,15 @@ class TestPMLComputeProfile:
         pml = make_pml(axis=1, direction="+", thickness=6)
         placed = place_pml(pml, micro_config, jax_key, volume_shape=(15, 20, 10))
         profileE, _profileH = placed._compute_pml_profile(0.0, 1.0, 1.0, jnp.float32)
-        assert profileE.shape == (15, 6, 10)
+        assert profileE.shape == (1, 6, 1)
+        assert jnp.broadcast_to(profileE, placed.grid_shape).shape == (15, 6, 10)
 
     def test_profile_axis2_shape(self, micro_config, jax_key):
         pml = make_pml(axis=2, direction="-", thickness=5)
         placed = place_pml(pml, micro_config, jax_key, volume_shape=(10, 10, 20))
         profileE, _profileH = placed._compute_pml_profile(0.0, 1.0, 1.0, jnp.float32)
-        assert profileE.shape == (10, 10, 5)
+        assert profileE.shape == (1, 1, 5)
+        assert jnp.broadcast_to(profileE, placed.grid_shape).shape == (10, 10, 5)
 
     def test_nonuniform_profile_uses_physical_depth_min_side(self, jax_key):
         """Stretched PML profiles are graded by physical distance into the boundary."""

--- a/tests/unit/objects/sources/test_dipole.py
+++ b/tests/unit/objects/sources/test_dipole.py
@@ -175,6 +175,23 @@ class TestPointDipoleSourceUpdateE:
         E_check = E_updated.at[2, 4, 4, 4].set(0.0)
         assert jnp.allclose(E_check, 0.0)
 
+    def test_axis_aligned_full_tensor_material_keeps_coupled_components(self, micro_config, jax_key):
+        placed = self._make_placed(micro_config, jax_key, polarization=0)
+        inv_perm = jnp.zeros((9, 8, 8, 8), dtype=jnp.float32)
+        inv_perm = inv_perm.at[0].set(1.0)
+        inv_perm = inv_perm.at[3].set(2.0)
+        inv_perm = inv_perm.at[6].set(3.0)
+        applied = placed.apply(jax_key, inv_perm, 1.0)
+
+        E = jnp.zeros((3, 8, 8, 8), dtype=jnp.float32)
+        time_step = jnp.array(10)
+
+        E_updated = applied.update_E(E, inv_perm, 1.0, time_step, inverse=False)
+        source_values = E_updated[:, 4, 4, 4]
+        assert not jnp.allclose(source_values[0], 0.0)
+        assert jnp.allclose(source_values[1], 2.0 * source_values[0], atol=1e-6)
+        assert jnp.allclose(source_values[2], 3.0 * source_values[0], atol=1e-6)
+
 
 class TestPointDipoleSourceUpdateH:
     """Tests for magnetic dipole update_H behavior."""


### PR DESCRIPTION
## Summary

Improves several FDTD update hot paths without changing the intended numerical behavior.

Changes include four parts:

- Curl update: replaces full-array `jnp.roll` curl stencils with direct neighbor slicing, and applies PML curl corrections component-wise before stacking the final curl array.
- PML update: keeps PML profiles in broadcast-shaped form instead of materializing full face arrays, and skips the zero-valued `kappa` correction when `kappa_start == kappa_end == 1`.
- Source update: adds a fast path for default always-on source updates, and updates axis-aligned point dipoles in scalar / diagonal media through only the active field component while keeping the full coupled path for rotated dipoles and full tensor media.
- Rectilinear grid: caches rectilinear-grid cell widths instead of recomputing `jnp.diff(edges)` on repeated access.

By reducing per-step dispatch overhead and unnecessary array materialization, especially for small and medium grids where GPU utilization was previously low, local GPU benchmarks on the same layered test case gave approximately:

- `0.8M` grid cells: `4.9x` faster
- `3.3M` grid cells: `2.7x` faster
- `7.4M` grid cells: `2.2x` faster

## Tests

Added / updated:

- Unit test coverage for the default always-on source-switch fast path.
- Unit test coverage for broadcast-shaped PML profiles.
- Unit test coverage ensuring full tensor point-dipole injection still keeps coupled field components.

Passed:

- `UV_CACHE_DIR=/tmp/uv-cache JAX_PLATFORMS=cpu uv run python -m pytest tests --cov --cov-branch --cov-config=pyproject.toml --cov-report=xml`
- Full local pytest coverage:
  - `2573 passed`
  - `1 skipped`
  - `1 xfailed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved source handling for common “always on” configurations, reducing unnecessary overhead during field updates.
  * Added a faster path for axis-aligned dipole sources in compatible media, while preserving existing behavior for other cases.

* **Bug Fixes**
  * Improved curl and boundary calculations for more consistent simulation updates.
  * Fixed profile handling so boundary layers now return broadcast-friendly shapes and work correctly across grid dimensions.
  * Cached grid cell widths to avoid repeated recalculation during access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->