### PR TITLE
feat: per-axis pole parameters for diagonally anisotropic dispersion

### DIFF
--- a/.claude/skills/fdtdx/SKILL.md
+++ b/.claude/skills/fdtdx/SKILL.md
@@ -150,14 +150,16 @@ c3 =  (K·dt²)      / (1 + γ·dt/2)
 ```
 Stability needs `γ·dt < 2`; physically `γ·dt ≪ 1`, so `c2 ≈ −1` and the reverse-time inversion in `update_E_reverse` is well-conditioned.
 
+**Per-axis (diagonally anisotropic) dispersion:** every pole parameter accepts a scalar or a per-axis 3-tuple `(x, y, z)` — e.g. `DrudePole(plasma_frequency=(wp, 0.0, 0.0), damping=g)` for a hyperbolic medium metallic only along x. The canonical pole accessors are `omega_0_axes`/`gamma_axes`/`coupling_sq_axes`/`coupling_edot_axes` (the scalar `omega_0` etc. raise for per-axis poles). `compute_pole_coefficients_per_axis` returns `(n_poles, 3)` coefficient arrays; `DispersionModel.susceptibility_axes(omega)` gives per-axis χ. Static negative ε is unconditionally unstable in FDTD — hyperbolic/metallic behavior must come from poles with ε∞ ≥ 1 (`Material.__init__` warns otherwise).
+
 **ArrayContainer fields** (all `None` unless any object is dispersive):
 - `dispersive_P_curr`, `dispersive_P_prev` — shape `(num_poles, 3, Nx, Ny, Nz)`, field-dtype (complex if `use_complex_fields`). Not differentiable (state-only; `None` cotangent in both gradient paths).
-- `dispersive_c1`, `dispersive_c2`, `dispersive_c3` — shape `(num_poles, 1, Nx, Ny, Nz)` (middle axis broadcasts over field components). Config dtype. Differentiable: cotangents flow through them in both the reversible and checkpointed paths.
+- `dispersive_c1`, `dispersive_c2`, `dispersive_c3` — shape `(num_poles, C, Nx, Ny, Nz)` with `C = 1` when all dispersion is isotropic (middle axis broadcasts over field components) or `C = 3` for per-axis dispersion (gated by `ObjectContainer.all_objects_isotropic_dispersion`). Config dtype. Differentiable: cotangents flow through them in both the reversible and checkpointed paths.
 - `dispersive_inv_c2` — cached `1/c2`, closure-captured and `stop_gradient`'d so gradients flow through `c2` only and don't double-count.
 
 **Leading pole axis size:** `objects.max_num_dispersive_poles` — the max pole count across all `UniformMaterialObject`, `Device`, `StaticMultiMaterialObject`. Materials with fewer poles get zero-padded slots, so non-dispersive cells automatically contribute zero. `UniformMaterialObject` always writes the full zero-padded coefficient stack into its `grid_slice`, so a non-dispersive object placed over a dispersive one cleanly clears stale coefficients.
 
-**Restriction:** Dispersive materials cannot currently be combined with fully anisotropic (off-diagonal) permittivity tensors — `_init_arrays` raises `NotImplementedError`. Isotropic and diagonally anisotropic ε are both fine.
+**Restriction:** Dispersive materials cannot currently be combined with fully anisotropic (off-diagonal) permittivity **or electric conductivity** tensors — `_init_arrays` raises `NotImplementedError` (the full-tensor update branch has no ADE block). Isotropic and diagonally anisotropic ε/σ are both fine, including per-axis poles.
 
 **Devices with dispersive materials:** `apply_params` interpolates ADE coefficients the same way it interpolates `inv_permittivities` — linearly between the two bracketing materials for `CONTINUOUS` output, straight-through-estimator for `DISCRETE`. This is not equivalent to interpolating the pole *parameters*, but it keeps gradients smooth for inverse design.
 
@@ -420,7 +422,7 @@ assert jnp.all(jnp.isfinite(grads))
 - **Inverse storage**: Material arrays store `1/epsilon` and `1/mu`, not epsilon and mu directly. For dispersive materials, `Material.permittivity` represents ε∞ only — the full ε(ω) must be reconstructed via the dispersion model.
 - **Detector timing**: Detectors only record at timesteps where their `OnOffSwitch` is active. Check `switch` configuration if data appears missing.
 - **donate_argnames**: When JIT-compiling simulation functions, use `donate_argnames=["arrays"]` to allow JAX to reuse array memory.
-- **Dispersive + full anisotropic**: Not supported — `_init_arrays` raises `NotImplementedError`. Use diagonal anisotropy if you need directional ε alongside dispersion.
+- **Dispersive + full anisotropic**: Not supported — `_init_arrays` raises `NotImplementedError` (applies to off-diagonal ε *and* off-diagonal σ_E). Use diagonal anisotropy — including per-axis pole parameters — if you need directional ε alongside dispersion.
 - **Dispersive pole count is max'd globally**: The `num_poles` leading axis size = `objects.max_num_dispersive_poles`. Adding one 3-pole material allocates 3 pole slots for every dispersive cell in the sim; non-dispersive cells still have their `c1/c2/c3` set to zero (ADE term vanishes) but consume array memory.
 - **Dispersive source impedance**: Inside a dispersive medium, never use ε∞ as the source's effective permittivity — call `effective_inv_permittivity` at ω_c. Broadband pulses additionally need the `_temporal_H_filter` path to avoid TFSF leakage at off-carrier frequencies.
 - **Stacking objects with mixed dispersion**: `UniformMaterialObject` always writes a full zero-padded pole-coefficient stack into its `grid_slice`, so placing a non-dispersive object over a dispersive one cleanly overwrites stale coefficients. Rely on this rather than assuming "no dispersion = leave coefficients alone".

--- a/docs/source/07_api.rst
+++ b/docs/source/07_api.rst
@@ -24,6 +24,7 @@ API
     fdtdx.compute_integrated_power
     fdtdx.compute_mode
     fdtdx.compute_pole_coefficients
+    fdtdx.compute_pole_coefficients_per_axis
     fdtdx.compute_poynting_flux
     fdtdx.ConnectHolesAndStructures
     fdtdx.CustomTimeSignalProfile

--- a/examples/hyperbolic_dispersive_slab.py
+++ b/examples/hyperbolic_dispersive_slab.py
@@ -1,0 +1,201 @@
+"""Hyperbolic (indefinite) medium via per-axis Drude dispersion.
+
+A hyperbolic material has a permittivity tensor with mixed-sign components:
+metallic (Re eps < 0) along some axes and dielectric (Re eps > 0) along the
+others. In explicit FDTD a *static* negative permittivity is unconditionally
+unstable, so the metallic axes must be modeled with dispersion poles that
+drive Re eps(omega) negative in-band while eps_inf stays >= 1. Per-axis pole
+parameters make this possible: here a Drude plasma frequency acts only on
+the x axis, giving
+
+    eps_x(omega) = 1 - omega_p^2 / (omega^2 + i gamma omega)   (metallic)
+    eps_y = eps_z = 1                                          (dielectric)
+
+which is an indefinite (type-I-like hyperbolic) tensor for omega < omega_p.
+
+The script:
+
+    1. Plots Re eps_x(omega) and Re eps_y(omega) from
+       ``DispersionModel.susceptibility_axes``, marking the hyperbolic band.
+    2. Runs two normal-incidence simulations onto a half-space of the
+       material — one x-polarized, one y-polarized — plus a vacuum reference.
+    3. Logs the transmitted power fractions: the x polarization is strongly
+       reflected (metallic response) while the y polarization passes,
+       matching the analytic Fresnel values from the per-axis permittivity.
+"""
+
+import jax
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+import numpy as np
+from loguru import logger
+
+import fdtdx
+from fdtdx.constants import c as c0
+
+WAVELENGTH = 1e-6
+OMEGA = 2.0 * np.pi * c0 / WAVELENGTH
+
+# Drude pole on the x axis only: metallic for omega < omega_p.
+OMEGA_P = 5.0 * OMEGA
+GAMMA = 0.05 * OMEGA
+EPS_INF = 1.0
+
+RESOLUTION = 25e-9
+PML_CELLS = 10
+DOMAIN_XY = 3 * RESOLUTION
+DOMAIN_Z = 5e-6
+Z_CELLS = int(round(DOMAIN_Z / RESOLUTION))
+
+SOURCE_Z = PML_CELLS + 2
+INTERFACE_Z = Z_CELLS // 2
+DET_T_Z = INTERFACE_Z + 40
+
+SIM_TIME = 120e-15
+
+
+def build_model() -> fdtdx.DispersionModel:
+    return fdtdx.DispersionModel(
+        poles=(fdtdx.DrudePole(plasma_frequency=(OMEGA_P, 0.0, 0.0), damping=GAMMA),)
+    )
+
+
+def plot_permittivity(model: fdtdx.DispersionModel) -> None:
+    omegas = np.linspace(0.2 * OMEGA, 1.5 * OMEGA_P, 400)
+    eps_x = np.array([model.permittivity_axes(w, eps_inf=EPS_INF)[0] for w in omegas])
+    eps_y = np.array([model.permittivity_axes(w, eps_inf=EPS_INF)[1] for w in omegas])
+
+    fig, ax = plt.subplots(figsize=(7, 4.5))
+    ax.plot(omegas / OMEGA, eps_x.real, label=r"Re $\varepsilon_x(\omega)$ (Drude axis)")
+    ax.plot(omegas / OMEGA, eps_y.real, label=r"Re $\varepsilon_y(\omega) = \varepsilon_z(\omega)$")
+    ax.axhline(0.0, color="k", lw=0.8)
+    ax.axvline(1.0, color="gray", ls="--", lw=0.8, label=r"source $\omega$")
+    hyperbolic = (eps_x.real < 0) & (eps_y.real > 0)
+    if np.any(hyperbolic):
+        band = omegas[hyperbolic] / OMEGA
+        ax.axvspan(float(band.min()), float(band.max()), alpha=0.12, color="tab:red", label="hyperbolic band")
+    ax.set_xlabel(r"$\omega / \omega_{\mathrm{src}}$")
+    ax.set_ylabel(r"Re $\varepsilon$")
+    ax.set_title("Per-axis Drude model: indefinite permittivity tensor")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig("hyperbolic_permittivity.png", dpi=150)
+    logger.info("saved hyperbolic_permittivity.png")
+
+
+def build_scene(polarization, material=None):
+    config = fdtdx.SimulationConfig(
+        grid=fdtdx.UniformGrid(spacing=RESOLUTION),
+        time=SIM_TIME,
+        dtype=jnp.float32,
+    )
+    objects, constraints = [], []
+
+    volume = fdtdx.SimulationVolume(partial_real_shape=(DOMAIN_XY, DOMAIN_XY, DOMAIN_Z))
+    objects.append(volume)
+
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+        thickness=PML_CELLS,
+        override_types={
+            "min_x": "periodic",
+            "max_x": "periodic",
+            "min_y": "periodic",
+            "max_y": "periodic",
+        },
+    )
+    bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    constraints.extend(c_list)
+    objects.extend(bound_dict.values())
+
+    source = fdtdx.UniformPlaneSource(
+        partial_grid_shape=(None, None, 1),
+        wave_character=fdtdx.WaveCharacter(wavelength=WAVELENGTH),
+        direction="+",
+        fixed_E_polarization_vector=polarization,
+    )
+    constraints.extend(
+        [
+            source.same_size(volume, axes=(0, 1)),
+            source.place_at_center(volume, axes=(0, 1)),
+            source.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(SOURCE_Z,)),
+        ]
+    )
+    objects.append(source)
+
+    if material is not None:
+        slab = fdtdx.UniformMaterialObject(
+            partial_grid_shape=(None, None, Z_CELLS - INTERFACE_Z),
+            material=material,
+        )
+        constraints.extend(
+            [
+                slab.same_size(volume, axes=(0, 1)),
+                slab.place_at_center(volume, axes=(0, 1)),
+                slab.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(INTERFACE_Z,)),
+            ]
+        )
+        objects.append(slab)
+
+    det = fdtdx.PoyntingFluxDetector(
+        name="flux_t",
+        partial_grid_shape=(None, None, 1),
+        direction="+",
+        reduce_volume=True,
+        plot=False,
+    )
+    constraints.extend(
+        [
+            det.same_size(volume, axes=(0, 1)),
+            det.place_at_center(volume, axes=(0, 1)),
+            det.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(DET_T_Z,)),
+        ]
+    )
+    objects.append(det)
+
+    return objects, constraints, config
+
+
+def transmitted_flux(polarization, material=None) -> float:
+    objects, constraints, config = build_scene(polarization, material)
+    key = jax.random.PRNGKey(0)
+    obj, arrays, params, config, _ = fdtdx.place_objects(
+        object_list=objects, config=config, constraints=constraints, key=key
+    )
+    arrays, obj, _ = fdtdx.apply_params(arrays, obj, params, key)
+    _, arrays = fdtdx.run_fdtd(arrays=arrays, objects=obj, config=config, key=key)
+    flux = np.array(arrays.detector_states["flux_t"]["poynting_flux"][:, 0])
+    dt = config.time_step_duration
+    steps_per_period = int(round(WAVELENGTH / (c0 * dt)))
+    return float(np.mean(flux[-10 * steps_per_period :]))
+
+
+def fresnel_transmission(eps: complex) -> float:
+    n2 = np.sqrt(eps)
+    t = 2.0 / (1.0 + n2)
+    return float(np.real(n2) * np.abs(t) ** 2)
+
+
+def main() -> None:
+    model = build_model()
+    plot_permittivity(model)
+
+    eps_axes = model.permittivity_axes(OMEGA, eps_inf=EPS_INF)
+    logger.info(f"eps at source frequency: eps_x = {eps_axes[0]:.3f}, eps_y = {eps_axes[1]:.3f}")
+    material = fdtdx.Material(permittivity=EPS_INF, dispersion=model)
+
+    s0_x = transmitted_flux((1, 0, 0))
+    s0_y = transmitted_flux((0, 1, 0))
+    t_x = transmitted_flux((1, 0, 0), material) / s0_x
+    t_y = transmitted_flux((0, 1, 0), material) / s0_y
+
+    logger.info(
+        f"x polarization (metallic axis):   T = {t_x:.4f}  "
+        f"(interface Fresnel: {fresnel_transmission(eps_axes[0]):.4f}; the detector sits 1 um "
+        "inside the medium, far past the skin depth, so nearly nothing survives)"
+    )
+    logger.info(f"y polarization (dielectric axis): T = {t_y:.4f}  (Fresnel: {fresnel_transmission(eps_axes[1]):.4f})")
+    logger.info(f"polarization selectivity T_y - T_x = {t_y - t_x:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -43,6 +43,7 @@ from fdtdx.dispersion import (
     compute_eps_spectrum_from_coefficients,
     compute_impedance_corrected_temporal_profile,
     compute_pole_coefficients,
+    compute_pole_coefficients_per_axis,
 )
 from fdtdx.fdtd.backward import full_backward
 from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer, ParameterContainer, SimulationState
@@ -252,6 +253,7 @@ __all__ = [
     "compute_integrated_power",
     "compute_mode",
     "compute_pole_coefficients",
+    "compute_pole_coefficients_per_axis",
     "compute_poynting_flux",
     "detectors_from_gds_ports",
     "export_arrays_snapshot_to_vti",

--- a/src/fdtdx/dispersion.py
+++ b/src/fdtdx/dispersion.py
@@ -48,6 +48,19 @@ Stability requires :math:`\\gamma \\Delta t < 2`; in the physical regime
 of interest :math:`\\gamma \\Delta t \\ll 1`, so :math:`c_2 \\approx -1`,
 which makes the backward (reverse-time) recurrence numerically stable
 after algebraic inversion.
+
+Anisotropic (per-axis) dispersion
+---------------------------------
+Every pole parameter accepts either a scalar (isotropic, applied to all
+three axes) or a 3-tuple ``(x, y, z)`` giving a different value per grid
+axis. This yields a diagonally anisotropic susceptibility tensor
+:math:`\\chi(\\omega) = \\mathrm{diag}(\\chi_x, \\chi_y, \\chi_z)` — enough to
+model uniaxial/biaxial crystals and hyperbolic media (e.g. hBN) whose
+optical axes align with the grid. A pole that only acts on one axis is
+expressed by zeroing its strength on the others, e.g.
+``LorentzPole(resonance_frequency=w0, damping=g, delta_epsilon=(2.25, 0.0, 0.0))``:
+with zero coupling the polarization on that axis stays identically zero.
+Off-diagonal (rotated) dispersive tensors are not supported.
 """
 
 from __future__ import annotations
@@ -62,6 +75,24 @@ from fdtdx.constants import eps0
 from fdtdx.core.jax.pytrees import TreeClass, autoinit, frozen_field
 
 
+def _broadcast_axis_param(value: float | complex | tuple) -> tuple:
+    """Normalize a pole parameter to a per-axis 3-tuple ``(x, y, z)``.
+
+    Scalars are broadcast to all three axes; 3-tuples pass through unchanged.
+    """
+    if isinstance(value, tuple):
+        if len(value) != 3:
+            raise ValueError(
+                f"Per-axis pole parameters must be a scalar or a 3-tuple (x, y, z), got a tuple of length {len(value)}."
+            )
+        return value
+    return (value, value, value)
+
+
+def _is_uniform(axes: tuple) -> bool:
+    return bool(axes[0] == axes[1] == axes[2])
+
+
 @autoinit
 class Pole(TreeClass, ABC):
     """Abstract base class for a single 2nd-order ADE pole.
@@ -69,27 +100,40 @@ class Pole(TreeClass, ABC):
     Concrete subclasses store physically-meaningful parameters
     (e.g. ``delta_epsilon`` for Lorentz, ``omega_p`` for Drude) and
     expose the unified ``(omega_0, gamma, coupling_sq)`` triplet the
-    FDTD loop needs via abstract properties. New pole types can
+    FDTD loop needs via per-axis properties. New pole types can
     subclass :class:`Pole` as long as they fit the 2nd-order
     ODE form.
+
+    Every parameter may differ per grid axis (diagonally anisotropic
+    dispersion); the canonical accessors are the ``*_axes`` properties
+    returning ``(x, y, z)`` tuples. The scalar accessors (``omega_0`` etc.)
+    are a convenience for isotropic poles and raise for per-axis ones.
     """
 
+    def _uniform_or_raise(self, axes: tuple, name: str) -> float:
+        if not _is_uniform(axes):
+            raise ValueError(
+                f"{type(self).__name__} has per-axis parameters; use the per-axis "
+                f"accessor '{name}_axes' instead of the scalar '{name}'."
+            )
+        return axes[0]
+
     @property
     @abstractmethod
-    def omega_0(self) -> float:
-        """Resonance angular frequency (rad/s). Zero for pure Drude poles."""
+    def omega_0_axes(self) -> tuple[float, float, float]:
+        """Per-axis resonance angular frequency (rad/s). Zero for pure Drude poles."""
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def gamma(self) -> float:
-        """Damping rate (rad/s)."""
+    def gamma_axes(self) -> tuple[float, float, float]:
+        """Per-axis damping rate (rad/s)."""
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def coupling_sq(self) -> float:
-        """Effective squared coupling frequency ``K`` (rad^2/s^2).
+    def coupling_sq_axes(self) -> tuple[float, float, float]:
+        """Per-axis effective squared coupling frequency ``K`` (rad^2/s^2).
 
         ``delta_epsilon * omega_0**2`` for a Lorentz pole and
         ``omega_p**2`` for a Drude pole.
@@ -100,16 +144,58 @@ class Pole(TreeClass, ABC):
         raise NotImplementedError
 
     @property
-    def coupling_edot(self) -> float:
-        """Coefficient ``b`` of the ``dE/dt`` driving term (rad/s).
+    def coupling_edot_axes(self) -> tuple[float, float, float]:
+        """Per-axis coefficient ``b`` of the ``dE/dt`` driving term (rad/s).
 
         Zero for Lorentz and Drude poles (their susceptibility numerator has no
         ``omega`` term). A non-zero value is what distinguishes a general
         complex-conjugate pole-residue (CCPR) pole — it corresponds to a
         non-zero real part of the residue and adds the ``b E'`` term to the ADE.
-        Defaults to ``0.0`` so existing pole types need not override it.
+        Defaults to all-zero so existing pole types need not override it.
         """
-        return 0.0
+        return (0.0, 0.0, 0.0)
+
+    @property
+    def is_isotropic(self) -> bool:
+        """Whether all pole parameters are identical on the three axes."""
+        return (
+            _is_uniform(self.omega_0_axes)
+            and _is_uniform(self.gamma_axes)
+            and _is_uniform(self.coupling_sq_axes)
+            and _is_uniform(self.coupling_edot_axes)
+        )
+
+    @property
+    def omega_0(self) -> float:
+        """Resonance angular frequency (rad/s). Zero for pure Drude poles.
+
+        Raises ``ValueError`` for per-axis poles; use :attr:`omega_0_axes`.
+        """
+        return self._uniform_or_raise(self.omega_0_axes, "omega_0")
+
+    @property
+    def gamma(self) -> float:
+        """Damping rate (rad/s).
+
+        Raises ``ValueError`` for per-axis poles; use :attr:`gamma_axes`.
+        """
+        return self._uniform_or_raise(self.gamma_axes, "gamma")
+
+    @property
+    def coupling_sq(self) -> float:
+        """Effective squared coupling frequency ``K`` (rad^2/s^2).
+
+        Raises ``ValueError`` for per-axis poles; use :attr:`coupling_sq_axes`.
+        """
+        return self._uniform_or_raise(self.coupling_sq_axes, "coupling_sq")
+
+    @property
+    def coupling_edot(self) -> float:
+        """Coefficient ``b`` of the ``dE/dt`` driving term (rad/s).
+
+        Raises ``ValueError`` for per-axis poles; use :attr:`coupling_edot_axes`.
+        """
+        return self._uniform_or_raise(self.coupling_edot_axes, "coupling_edot")
 
 
 @autoinit
@@ -120,29 +206,38 @@ class LorentzPole(Pole):
 
     .. math::
         \\chi(\\omega) = \\frac{\\Delta\\varepsilon \\cdot \\omega_0^2}{\\omega_0^2 - \\omega^2 - i\\gamma\\omega}.
+
+    Each parameter is either a scalar (isotropic) or a per-axis 3-tuple
+    ``(x, y, z)`` for diagonally anisotropic dispersion. An axis without a
+    resonance is expressed by a zero ``delta_epsilon`` entry on that axis.
     """
 
     #: Resonance angular frequency (rad/s). Must be > 0.
-    resonance_frequency: float = frozen_field()
+    #: Scalar or per-axis 3-tuple.
+    resonance_frequency: float | tuple[float, float, float] = frozen_field()
 
-    #: Damping rate (rad/s). Must be >= 0.
-    damping: float = frozen_field()
+    #: Damping rate (rad/s). Must be >= 0. Scalar or per-axis 3-tuple.
+    damping: float | tuple[float, float, float] = frozen_field()
 
     #: Oscillator strength (dimensionless); the zero-frequency
-    #: contribution to the susceptibility.
-    delta_epsilon: float = frozen_field()
+    #: contribution to the susceptibility. Scalar or per-axis 3-tuple.
+    delta_epsilon: float | tuple[float, float, float] = frozen_field()
 
     @property
-    def omega_0(self) -> float:
-        return float(self.resonance_frequency)
+    def omega_0_axes(self) -> tuple[float, float, float]:
+        w = _broadcast_axis_param(self.resonance_frequency)
+        return (float(w[0]), float(w[1]), float(w[2]))
 
     @property
-    def gamma(self) -> float:
-        return float(self.damping)
+    def gamma_axes(self) -> tuple[float, float, float]:
+        g = _broadcast_axis_param(self.damping)
+        return (float(g[0]), float(g[1]), float(g[2]))
 
     @property
-    def coupling_sq(self) -> float:
-        return float(self.delta_epsilon) * float(self.resonance_frequency) ** 2
+    def coupling_sq_axes(self) -> tuple[float, float, float]:
+        w = self.omega_0_axes
+        de = _broadcast_axis_param(self.delta_epsilon)
+        return (float(de[0]) * w[0] ** 2, float(de[1]) * w[1] ** 2, float(de[2]) * w[2] ** 2)
 
 
 @autoinit
@@ -155,25 +250,33 @@ class DrudePole(Pole):
         \\chi(\\omega) = -\\frac{\\omega_p^2}{\\omega^2 + i\\gamma\\omega},
 
     equivalent to a Lorentz pole with ``omega_0 = 0``.
+
+    Each parameter is either a scalar (isotropic) or a per-axis 3-tuple
+    ``(x, y, z)`` for diagonally anisotropic dispersion — e.g.
+    ``plasma_frequency=(wp, 0.0, 0.0)`` gives a metallic (hyperbolic)
+    response only along x.
     """
 
     #: Plasma angular frequency (rad/s). Must be > 0.
-    plasma_frequency: float = frozen_field()
+    #: Scalar or per-axis 3-tuple.
+    plasma_frequency: float | tuple[float, float, float] = frozen_field()
 
-    #: Damping rate (rad/s). Must be >= 0.
-    damping: float = frozen_field()
-
-    @property
-    def omega_0(self) -> float:
-        return 0.0
+    #: Damping rate (rad/s). Must be >= 0. Scalar or per-axis 3-tuple.
+    damping: float | tuple[float, float, float] = frozen_field()
 
     @property
-    def gamma(self) -> float:
-        return float(self.damping)
+    def omega_0_axes(self) -> tuple[float, float, float]:
+        return (0.0, 0.0, 0.0)
 
     @property
-    def coupling_sq(self) -> float:
-        return float(self.plasma_frequency) ** 2
+    def gamma_axes(self) -> tuple[float, float, float]:
+        g = _broadcast_axis_param(self.damping)
+        return (float(g[0]), float(g[1]), float(g[2]))
+
+    @property
+    def coupling_sq_axes(self) -> tuple[float, float, float]:
+        wp = _broadcast_axis_param(self.plasma_frequency)
+        return (float(wp[0]) ** 2, float(wp[1]) ** 2, float(wp[2]) ** 2)
 
 
 @autoinit
@@ -205,31 +308,51 @@ class CCPRPole(Pole):
     vector-fitted permittivity data.
 
     A stable, passive (lossy) medium requires ``Re(q) < 0`` (so ``gamma > 0``).
+
+    Both ``pole`` and ``residue`` are either scalars (isotropic) or per-axis
+    3-tuples ``(x, y, z)`` for diagonally anisotropic dispersion (e.g. a
+    vector-fitted uniaxial material with a different ``(q, r)`` set per axis).
     """
 
     #: Complex pole ``q`` (rad/s). ``Re(q) < 0`` for a stable, lossy medium.
-    pole: complex = frozen_field()
+    #: Scalar or per-axis 3-tuple.
+    pole: complex | tuple[complex, complex, complex] = frozen_field()
 
-    #: Complex residue ``r`` (rad/s).
-    residue: complex = frozen_field()
-
-    @property
-    def omega_0(self) -> float:
-        return float(abs(complex(self.pole)))
+    #: Complex residue ``r`` (rad/s). Scalar or per-axis 3-tuple.
+    residue: complex | tuple[complex, complex, complex] = frozen_field()
 
     @property
-    def gamma(self) -> float:
-        return float(-2.0 * complex(self.pole).real)
+    def omega_0_axes(self) -> tuple[float, float, float]:
+        q = _broadcast_axis_param(self.pole)
+        return (float(abs(complex(q[0]))), float(abs(complex(q[1]))), float(abs(complex(q[2]))))
 
     @property
-    def coupling_sq(self) -> float:
-        q = complex(self.pole)
-        r = complex(self.residue)
-        return float(-2.0 * (r * q.conjugate()).real)
+    def gamma_axes(self) -> tuple[float, float, float]:
+        q = _broadcast_axis_param(self.pole)
+        return (
+            float(-2.0 * complex(q[0]).real),
+            float(-2.0 * complex(q[1]).real),
+            float(-2.0 * complex(q[2]).real),
+        )
 
     @property
-    def coupling_edot(self) -> float:
-        return float(2.0 * complex(self.residue).real)
+    def coupling_sq_axes(self) -> tuple[float, float, float]:
+        q = _broadcast_axis_param(self.pole)
+        r = _broadcast_axis_param(self.residue)
+        return (
+            float(-2.0 * (complex(r[0]) * complex(q[0]).conjugate()).real),
+            float(-2.0 * (complex(r[1]) * complex(q[1]).conjugate()).real),
+            float(-2.0 * (complex(r[2]) * complex(q[2]).conjugate()).real),
+        )
+
+    @property
+    def coupling_edot_axes(self) -> tuple[float, float, float]:
+        r = _broadcast_axis_param(self.residue)
+        return (
+            float(2.0 * complex(r[0]).real),
+            float(2.0 * complex(r[1]).real),
+            float(2.0 * complex(r[2]).real),
+        )
 
     @classmethod
     def from_critical_point(
@@ -288,11 +411,46 @@ class DispersionModel(TreeClass):
         """Number of poles in this model."""
         return len(self.poles)
 
+    @property
+    def is_isotropic(self) -> bool:
+        """Whether every pole applies the same parameters to all three axes."""
+        return all(p.is_isotropic for p in self.poles)
+
+    def susceptibility_axes(self, omega: complex | float) -> tuple[complex, complex, complex]:
+        """Evaluate the per-axis complex susceptibility :math:`(\\chi_x, \\chi_y, \\chi_z)`.
+
+        Uses the ``exp(-i omega t)`` Fourier convention (damping appears
+        with a ``-i gamma omega`` term in the Lorentz denominator). For an
+        isotropic model all three entries are equal.
+
+        Args:
+            omega: Angular frequency (rad/s).
+
+        Returns:
+            tuple: :math:`\\chi_a(\\omega) = \\sum_p \\chi_{p,a}(\\omega)` for
+            each axis ``a`` in ``(x, y, z)``.
+        """
+        w = complex(omega)
+        totals = [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j]
+        for p in self.poles:
+            omega_0 = p.omega_0_axes
+            gamma = p.gamma_axes
+            coupling_sq = p.coupling_sq_axes
+            coupling_edot = p.coupling_edot_axes
+            for ax in range(3):
+                denom = omega_0[ax] ** 2 - w * w - 1j * gamma[ax] * w
+                numer = coupling_sq[ax] - 1j * w * coupling_edot[ax]
+                totals[ax] = totals[ax] + numer / denom
+        return (totals[0], totals[1], totals[2])
+
     def susceptibility(self, omega: complex | float) -> complex:
         """Evaluate the complex susceptibility :math:`\\chi(\\omega)`.
 
         Uses the ``exp(-i omega t)`` Fourier convention (damping appears
         with a ``-i gamma omega`` term in the Lorentz denominator).
+
+        Raises ``ValueError`` for models with per-axis poles; use
+        :meth:`susceptibility_axes` for those.
 
         Args:
             omega: Angular frequency (rad/s).
@@ -300,16 +458,36 @@ class DispersionModel(TreeClass):
         Returns:
             complex: :math:`\\chi(\\omega) = \\sum_p \\chi_p(\\omega)`.
         """
-        w = complex(omega)
-        total = 0.0 + 0.0j
-        for p in self.poles:
-            denom = p.omega_0**2 - w * w - 1j * p.gamma * w
-            numer = p.coupling_sq - 1j * w * p.coupling_edot
-            total = total + numer / denom
-        return total
+        if not self.is_isotropic:
+            raise ValueError(
+                "DispersionModel has per-axis poles; use susceptibility_axes(omega) for the (x, y, z) values."
+            )
+        return self.susceptibility_axes(omega)[0]
+
+    def permittivity_axes(
+        self,
+        omega: complex | float,
+        eps_inf: float | tuple[float, float, float] = 1.0,
+    ) -> tuple[complex, complex, complex]:
+        """Per-axis complex relative permittivity :math:`\\varepsilon_a(\\omega) = \\varepsilon_{\\infty,a} + \\chi_a(\\omega)`.
+
+        Args:
+            omega: Angular frequency (rad/s).
+            eps_inf: High-frequency permittivity — scalar or per-axis
+                3-tuple (the diagonal of the ε∞ tensor). Defaults to 1.0.
+
+        Returns:
+            tuple: Relative permittivity at ``omega`` per axis ``(x, y, z)``.
+        """
+        chi = self.susceptibility_axes(omega)
+        e = _broadcast_axis_param(eps_inf)
+        return (complex(e[0]) + chi[0], complex(e[1]) + chi[1], complex(e[2]) + chi[2])
 
     def permittivity(self, omega: complex | float, eps_inf: float = 1.0) -> complex:
         """Complex relative permittivity :math:`\\varepsilon(\\omega) = \\varepsilon_\\infty + \\chi(\\omega)`.
+
+        Raises ``ValueError`` for models with per-axis poles; use
+        :meth:`permittivity_axes` for those.
 
         Args:
             omega: Angular frequency (rad/s).
@@ -321,13 +499,14 @@ class DispersionModel(TreeClass):
         return eps_inf + self.susceptibility(omega)
 
 
-def compute_pole_coefficients(
+def compute_pole_coefficients_per_axis(
     poles: tuple[Pole, ...],
     dt: float,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """Compute the discrete-time ADE recurrence coefficients.
+    """Compute the per-axis discrete-time ADE recurrence coefficients.
 
-    For each pole, returns ``(c1, c2, c3, c4)`` with (``D = 1 + gamma dt / 2``)
+    For each pole and grid axis, returns ``(c1, c2, c3, c4)`` with
+    (``D = 1 + gamma dt / 2``)
 
     .. math::
         c_1 = \\frac{2 - \\omega_0^2 \\Delta t^2}{D}, \\quad
@@ -341,37 +520,72 @@ def compute_pole_coefficients(
 
     :math:`p_p^{n+1} = c_1 p_p^n + c_2 p_p^{n-1} + c_3 E^n + c_4 E^{n+1}`.
 
-    For Lorentz and Drude poles ``b = 0``, so ``c4 = 0`` and ``c3`` reduces to
-    the classic :math:`K \\Delta t^2 / D` — making those pole types
-    bit-identical to before this coefficient was added.
+    For isotropic poles the three axis columns are identical. For Lorentz and
+    Drude poles ``b = 0``, so ``c4 = 0`` and ``c3`` reduces to the classic
+    :math:`K \\Delta t^2 / D`.
 
     Args:
         poles: Tuple of poles (may be empty).
         dt: Simulation time step (seconds).
 
     Returns:
+        Four ``numpy`` arrays of shape ``(len(poles), 3)`` with ``c1``, ``c2``,
+        ``c3``, ``c4`` per pole and axis. For an empty pole tuple, returns four
+        ``(0, 3)`` arrays.
+    """
+    n = len(poles)
+    c1 = np.zeros((n, 3), dtype=np.float64)
+    c2 = np.zeros((n, 3), dtype=np.float64)
+    c3 = np.zeros((n, 3), dtype=np.float64)
+    c4 = np.zeros((n, 3), dtype=np.float64)
+    for i, p in enumerate(poles):
+        omega_0 = p.omega_0_axes
+        gamma = p.gamma_axes
+        coupling_sq = p.coupling_sq_axes
+        coupling_edot = p.coupling_edot_axes
+        for ax in range(3):
+            gamma_dt = gamma[ax] * dt
+            if gamma_dt >= 2.0:
+                axis_note = "" if p.is_isotropic else f" on axis {'xyz'[ax]}"
+                raise ValueError(
+                    f"Pole {i} ({type(p).__name__}) has gamma * dt = {gamma_dt:.4g} >= 2{axis_note}; "
+                    "the reversible ADE update requires gamma * dt < 2 (physically gamma * dt << 1). "
+                    "Lower the damping or reduce the time step."
+                )
+            denom = 1.0 + 0.5 * gamma_dt
+            c1[i, ax] = (2.0 - (omega_0[ax] ** 2) * (dt**2)) / denom
+            c2[i, ax] = -(1.0 - 0.5 * gamma_dt) / denom
+            c3[i, ax] = (coupling_sq[ax] * dt**2 - coupling_edot[ax] * dt) / denom
+            c4[i, ax] = (coupling_edot[ax] * dt) / denom
+    return c1, c2, c3, c4
+
+
+def compute_pole_coefficients(
+    poles: tuple[Pole, ...],
+    dt: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Compute the discrete-time ADE recurrence coefficients of isotropic poles.
+
+    Scalar-per-pole variant of :func:`compute_pole_coefficients_per_axis` (see
+    there for the coefficient definitions). Raises ``ValueError`` when any
+    pole has per-axis parameters — use the per-axis function for those.
+
+    Args:
+        poles: Tuple of isotropic poles (may be empty).
+        dt: Simulation time step (seconds).
+
+    Returns:
         Four ``numpy`` arrays of shape ``(len(poles),)`` with ``c1``, ``c2``,
         ``c3``, ``c4``. For an empty pole tuple, returns four empty arrays.
     """
-    n = len(poles)
-    c1 = np.zeros(n, dtype=np.float64)
-    c2 = np.zeros(n, dtype=np.float64)
-    c3 = np.zeros(n, dtype=np.float64)
-    c4 = np.zeros(n, dtype=np.float64)
     for i, p in enumerate(poles):
-        gamma_dt = p.gamma * dt
-        if gamma_dt >= 2.0:
+        if not p.is_isotropic:
             raise ValueError(
-                f"Pole {i} ({type(p).__name__}) has gamma * dt = {gamma_dt:.4g} >= 2; "
-                "the reversible ADE update requires gamma * dt < 2 (physically gamma * dt << 1). "
-                "Lower the damping or reduce the time step."
+                f"Pole {i} ({type(p).__name__}) has per-axis parameters; "
+                "use compute_pole_coefficients_per_axis instead."
             )
-        denom = 1.0 + 0.5 * gamma_dt
-        c1[i] = (2.0 - (p.omega_0**2) * (dt**2)) / denom
-        c2[i] = -(1.0 - 0.5 * gamma_dt) / denom
-        c3[i] = (p.coupling_sq * dt**2 - p.coupling_edot * dt) / denom
-        c4[i] = (p.coupling_edot * dt) / denom
-    return c1, c2, c3, c4
+    c1, c2, c3, c4 = compute_pole_coefficients_per_axis(poles, dt)
+    return c1[:, 0], c2[:, 0], c3[:, 0], c4[:, 0]
 
 
 def susceptibility_from_coefficients(
@@ -472,9 +686,11 @@ def compute_eps_spectrum_from_coefficients(
     :func:`compute_impedance_corrected_temporal_profile`.
 
     Args:
-        c1: ADE coefficient array of shape ``(num_poles, 1, *spatial)`` as
-            stored on :class:`~fdtdx.fdtd.container.ArrayContainer` (the
-            middle size-1 axis is the material-component broadcast axis).
+        c1: ADE coefficient array of shape ``(num_poles, num_components, *spatial)``
+            as stored on :class:`~fdtdx.fdtd.container.ArrayContainer`, with
+            ``num_components in (1, 3)`` (the material-component axis; size 3
+            for per-axis anisotropic dispersion). Anisotropic components are
+            averaged, mirroring the ``inv_eps_inf`` reduction.
         c2: ADE coefficient array, same shape as ``c1``.
         c3: ADE coefficient array, same shape as ``c1``.
         inv_eps_inf: Per-cell inverse of the high-frequency permittivity,
@@ -519,15 +735,18 @@ def compute_eps_spectrum_from_coefficients(
     else:
         raise ValueError(f"Unexpected inv_eps_inf leading dimension {num_components}; expected 1, 3, or 9.")
 
-    # Broadcast: omegas over (M,); coefficient arrays have shape (P, 1, *spatial).
-    # After [None, ...] prepend: (M, P, 1, *spatial).
+    # Broadcast: omegas over (M,); coefficient arrays have shape (P, C, *spatial)
+    # with C in (1, 3). After [None, ...] prepend: (M, P, C, *spatial).
     omega_dt = (omegas_np * dt).reshape((-1,) + (1,) * c1_np.ndim)
     numer = a_dt2[None, ...] - 1j * omega_dt * b_dt[None, ...]
     denom = omega0_sq_dt2[None, ...] - omega_dt**2 - 1j * gamma_dt[None, ...] * omega_dt
     safe_denom = np.where(pole_mask[None, ...], denom, 1.0 + 0.0j)
     chi_per_pole = np.where(pole_mask[None, ...], numer / safe_denom, 0.0 + 0.0j)
-    chi_per_cell = chi_per_pole.sum(axis=1)  # sum over pole axis → (M, 1, *spatial)
-    chi_per_cell = chi_per_cell[:, 0]  # drop component broadcast axis → (M, *spatial)
+    chi_per_cell = chi_per_pole.sum(axis=1)  # sum over pole axis → (M, C, *spatial)
+    # Average the material-component axis (identity for C = 1), mirroring the
+    # eps_inf reduction above — this scalar spectrum feeds an impedance filter
+    # that has no notion of polarization.
+    chi_per_cell = chi_per_cell.mean(axis=1)  # → (M, *spatial)
 
     eps_per_cell = eps_inf_per_cell[None, ...] + chi_per_cell  # (M, *spatial)
 

--- a/src/fdtdx/fdtd/container.py
+++ b/src/fdtdx/fdtd/container.py
@@ -208,6 +208,20 @@ class ObjectContainer(TreeClass):
         return self._is_material_fn_true_for_all(_fn)
 
     @property
+    def all_objects_isotropic_dispersion(self) -> bool:
+        """Whether every dispersive material applies the same poles to all three axes.
+
+        Drives the size of the material-component axis of the dispersive
+        coefficient arrays: 1 (broadcast) when ``True``, 3 (per-axis, diagonally
+        anisotropic dispersion) when ``False``.
+        """
+
+        def _fn(m: Material):
+            return m.has_isotropic_dispersion
+
+        return self._is_material_fn_true_for_all(_fn)
+
+    @property
     def max_num_dispersive_poles(self) -> int:
         """Maximum number of dispersive poles required across all objects.
 
@@ -246,7 +260,7 @@ class ObjectContainer(TreeClass):
         def _material_has_edot(m: Material) -> bool:
             if m.dispersion is None:
                 return False
-            return any(p.coupling_edot != 0.0 for p in m.dispersion.poles)
+            return any(b != 0.0 for p in m.dispersion.poles for b in p.coupling_edot_axes)
 
         for o in self.objects:
             if isinstance(o, UniformMaterialObject):
@@ -398,27 +412,34 @@ class ArrayContainer(TreeClass):
     magnetic_conductivity: jax.Array | None = None
 
     #: Per-cell dispersive recurrence coefficient c1. Shape
-    #: ``(num_poles, 1, Nx, Ny, Nz)``. ``None`` for non-dispersive simulations.
+    #: ``(num_poles, num_components, Nx, Ny, Nz)`` with ``num_components`` 1
+    #: (isotropic dispersion, broadcast over the field components) or 3
+    #: (per-axis / diagonally anisotropic dispersion). ``None`` for
+    #: non-dispersive simulations.
     dispersive_c1: jax.Array | None = None
 
     #: Per-cell dispersive recurrence coefficient c2. Shape
-    #: ``(num_poles, 1, Nx, Ny, Nz)``. ``None`` for non-dispersive simulations.
+    #: ``(num_poles, num_components, Nx, Ny, Nz)``, ``num_components in (1, 3)``.
+    #: ``None`` for non-dispersive simulations.
     dispersive_c2: jax.Array | None = None
 
     #: Per-cell dispersive recurrence coefficient c3. Shape
-    #: ``(num_poles, 1, Nx, Ny, Nz)``. ``None`` for non-dispersive simulations.
+    #: ``(num_poles, num_components, Nx, Ny, Nz)``, ``num_components in (1, 3)``.
+    #: ``None`` for non-dispersive simulations.
     dispersive_c3: jax.Array | None = None
 
     #: Per-cell dispersive recurrence coefficient c4 (the ``dE/dt`` / CCPR
-    #: coupling to ``E^{n+1}``). Shape ``(num_poles, 1, Nx, Ny, Nz)``. ``None``
-    #: unless at least one CCPR pole with non-zero ``coupling_edot`` is present;
-    #: Lorentz/Drude-only sims leave it ``None`` and skip the CCPR update path.
+    #: coupling to ``E^{n+1}``). Shape ``(num_poles, num_components, Nx, Ny, Nz)``,
+    #: ``num_components in (1, 3)``. ``None`` unless at least one CCPR pole with
+    #: non-zero ``coupling_edot`` is present; Lorentz/Drude-only sims leave it
+    #: ``None`` and skip the CCPR update path.
     dispersive_c4: jax.Array | None = None
 
     #: Per-cell cached ``1 / c2`` with non-dispersive cells set to 0. Lets the
     #: reverse-time ADE update avoid a ``jnp.where`` + division per step.
     #: Derived from ``dispersive_c2``; never differentiated independently.
-    #: Shape ``(num_poles, 1, Nx, Ny, Nz)``. ``None`` for non-dispersive simulations.
+    #: Shape ``(num_poles, num_components, Nx, Ny, Nz)``, ``num_components in
+    #: (1, 3)``. ``None`` for non-dispersive simulations.
     dispersive_inv_c2: jax.Array | None = None
 
     #: Backup of inverse permittivity values array.

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -13,6 +13,7 @@ from fdtdx.core.jax.default_key import default_key
 from fdtdx.core.jax.guards import check_not_tracing
 from fdtdx.core.jax.sharding import create_named_sharded_matrix
 from fdtdx.core.jax.ste import straight_through_estimator
+from fdtdx.dispersion import compute_pole_coefficients_per_axis
 from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer, ParameterContainer
 from fdtdx.fdtd.symmetry import apply_mode_symmetry, make_symmetry_walls, reduce_resolved_slices
 from fdtdx.materials import (
@@ -21,7 +22,6 @@ from fdtdx.materials import (
     compute_allowed_magnetic_conductivities,
     compute_allowed_permeabilities,
     compute_allowed_permittivities,
-    compute_pole_coefficients,
 )
 from fdtdx.objects.boundaries.bloch import BlochBoundary
 from fdtdx.objects.device.parameters.transform import ParameterType
@@ -318,6 +318,9 @@ def apply_params(
     diagonally_anisotropic = num_perm_components == 3
 
     num_dispersive_poles = arrays.dispersive_c1.shape[0] if arrays.dispersive_c1 is not None else 0
+    # Component axis of the dispersive coefficient arrays: 1 (isotropic
+    # dispersion, broadcast) or 3 (per-axis anisotropic dispersion).
+    num_disp_components = arrays.dispersive_c1.shape[1] if arrays.dispersive_c1 is not None else 1
 
     if arrays.initial_inv_permittivities is not None:
         arrays = arrays.at["inv_permittivities"].set(arrays.initial_inv_permittivities)
@@ -361,6 +364,7 @@ def apply_params(
                 device.materials,
                 dt=dt,
                 max_num_poles=num_dispersive_poles,
+                num_components=num_disp_components,
             )
             allowed_c1_arr = jnp.asarray(allowed_c1_np, dtype=arrays.dispersive_c1.dtype)
             allowed_c2_arr = jnp.asarray(allowed_c2_np, dtype=arrays.dispersive_c2.dtype)
@@ -386,23 +390,24 @@ def apply_params(
             if write_dispersive:
                 assert allowed_c1_arr is not None and allowed_c2_arr is not None and allowed_c3_arr is not None
                 # Linear interpolation of dispersive coefficients between the two bracketing materials.
-                # allowed_cN_arr: (num_materials, num_poles) — here num_materials == 2.
-                # reshape to (num_poles, 1, 1, 1, 1) for broadcast over (num_poles, 1, Nx, Ny, Nz)
+                # allowed_cN_arr: (num_materials, num_poles, num_components) — here num_materials == 2.
+                # reshape to (num_poles, num_components, 1, 1, 1) for broadcast over
+                # (num_poles, num_components, Nx, Ny, Nz)
                 w0 = (1 - cur_material_indices)[None, None, ...]  # (1, 1, Nx, Ny, Nz)
                 w1 = cur_material_indices[None, None, ...]
-                c1_0 = allowed_c1_arr[0][:, None, None, None, None]  # (num_poles, 1, 1, 1, 1)
-                c1_1 = allowed_c1_arr[1][:, None, None, None, None]
-                c2_0 = allowed_c2_arr[0][:, None, None, None, None]
-                c2_1 = allowed_c2_arr[1][:, None, None, None, None]
-                c3_0 = allowed_c3_arr[0][:, None, None, None, None]
-                c3_1 = allowed_c3_arr[1][:, None, None, None, None]
+                c1_0 = allowed_c1_arr[0][:, :, None, None, None]  # (num_poles, num_components, 1, 1, 1)
+                c1_1 = allowed_c1_arr[1][:, :, None, None, None]
+                c2_0 = allowed_c2_arr[0][:, :, None, None, None]
+                c2_1 = allowed_c2_arr[1][:, :, None, None, None]
+                c3_0 = allowed_c3_arr[0][:, :, None, None, None]
+                c3_1 = allowed_c3_arr[1][:, :, None, None, None]
                 new_c1_slice = w0 * c1_0 + w1 * c1_1
                 new_c2_slice = w0 * c2_0 + w1 * c2_1
                 new_c3_slice = w0 * c3_0 + w1 * c3_1
                 if write_dispersive_c4:
                     assert allowed_c4_arr is not None
-                    c4_0 = allowed_c4_arr[0][:, None, None, None, None]
-                    c4_1 = allowed_c4_arr[1][:, None, None, None, None]
+                    c4_0 = allowed_c4_arr[0][:, :, None, None, None]
+                    c4_1 = allowed_c4_arr[1][:, :, None, None, None]
                     new_c4_slice = w0 * c4_0 + w1 * c4_1
         else:
             # Discrete material selection
@@ -420,13 +425,14 @@ def apply_params(
             if write_dispersive:
                 assert allowed_c1_arr is not None and allowed_c2_arr is not None and allowed_c3_arr is not None
                 int_idx = cur_material_indices.astype(jnp.int32)
-                # allowed_cN_arr[int_idx]: (Nx, Ny, Nz, num_poles) -> moveaxis -> (num_poles, Nx, Ny, Nz)
-                new_c1_slice = jnp.moveaxis(allowed_c1_arr[int_idx], -1, 0)[:, None, ...]
-                new_c2_slice = jnp.moveaxis(allowed_c2_arr[int_idx], -1, 0)[:, None, ...]
-                new_c3_slice = jnp.moveaxis(allowed_c3_arr[int_idx], -1, 0)[:, None, ...]
+                # allowed_cN_arr[int_idx]: (Nx, Ny, Nz, num_poles, num_components)
+                # -> moveaxis -> (num_poles, num_components, Nx, Ny, Nz)
+                new_c1_slice = jnp.moveaxis(allowed_c1_arr[int_idx], (-2, -1), (0, 1))
+                new_c2_slice = jnp.moveaxis(allowed_c2_arr[int_idx], (-2, -1), (0, 1))
+                new_c3_slice = jnp.moveaxis(allowed_c3_arr[int_idx], (-2, -1), (0, 1))
                 if write_dispersive_c4:
                     assert allowed_c4_arr is not None
-                    new_c4_slice = jnp.moveaxis(allowed_c4_arr[int_idx], -1, 0)[:, None, ...]
+                    new_c4_slice = jnp.moveaxis(allowed_c4_arr[int_idx], (-2, -1), (0, 1))
 
         # Update all components of inv_permittivities array at once
         new_inv_perm = arrays.inv_permittivities.at[:, *device.grid_slice].set(new_inv_perm_slice)
@@ -681,8 +687,11 @@ def _init_arrays(
         conductivity_spacing = constants.c * config.time_step_duration / config.courant_number
 
     # dispersive ADE auxiliary arrays - all None unless any material is dispersive.
-    # Per-cell coefficients are broadcast over component via a size-1 axis.
+    # Per-cell coefficients are broadcast over the field components via a size-1
+    # component axis when all dispersion is isotropic, or carry one value per
+    # axis (size 3) for per-axis (diagonally anisotropic) dispersion.
     num_dispersive_poles = objects.max_num_dispersive_poles
+    num_disp_components = 1 if objects.all_objects_isotropic_dispersion else 3
     # ``dispersive_c4`` (the CCPR dE/dt coupling) is only allocated when at least
     # one pole in the sim has a non-zero ``coupling_edot``. Lorentz/Drude-only
     # sims leave it None so the ADE update takes the classic path unchanged.
@@ -699,6 +708,14 @@ def _init_arrays(
                 "Dispersive materials cannot be combined with fully anisotropic "
                 "(off-diagonal) permittivity tensors in v1."
             )
+        if not (isotropic_electric_conductivity or diagonally_anisotropic_electric_conductivity):
+            # The full-tensor update branch (taken whenever sigma_E has 9
+            # components) has no ADE block, so allowing this would silently
+            # skip the polarization update everywhere in the simulation.
+            raise NotImplementedError(
+                "Dispersive materials cannot be combined with fully anisotropic "
+                "(off-diagonal) electric conductivity tensors in v1."
+            )
         dispersive_P_curr = create_named_sharded_matrix(
             (num_dispersive_poles, 3, *volume_shape),
             value=0.0,
@@ -714,21 +731,21 @@ def _init_arrays(
             backend=config.backend,
         )
         dispersive_c1 = create_named_sharded_matrix(
-            (num_dispersive_poles, 1, *volume_shape),
+            (num_dispersive_poles, num_disp_components, *volume_shape),
             value=0.0,
             dtype=config.dtype,
             sharding_axis=2,
             backend=config.backend,
         )
         dispersive_c2 = create_named_sharded_matrix(
-            (num_dispersive_poles, 1, *volume_shape),
+            (num_dispersive_poles, num_disp_components, *volume_shape),
             value=0.0,
             dtype=config.dtype,
             sharding_axis=2,
             backend=config.backend,
         )
         dispersive_c3 = create_named_sharded_matrix(
-            (num_dispersive_poles, 1, *volume_shape),
+            (num_dispersive_poles, num_disp_components, *volume_shape),
             value=0.0,
             dtype=config.dtype,
             sharding_axis=2,
@@ -736,7 +753,7 @@ def _init_arrays(
         )
         if allocate_c4:
             dispersive_c4 = create_named_sharded_matrix(
-                (num_dispersive_poles, 1, *volume_shape),
+                (num_dispersive_poles, num_disp_components, *volume_shape),
                 value=0.0,
                 dtype=config.dtype,
                 sharding_axis=2,
@@ -846,27 +863,33 @@ def _init_arrays(
                 # and drive an ADE update on cells that shouldn't have one.
                 assert dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None
                 poles = o.material.dispersion.poles if o.material.dispersion is not None else ()
-                c1_vals, c2_vals, c3_vals, c4_vals = compute_pole_coefficients(poles, config.time_step_duration)
+                c1_vals, c2_vals, c3_vals, c4_vals = compute_pole_coefficients_per_axis(
+                    poles, config.time_step_duration
+                )
                 n = len(poles)
-                c1_padded = jnp.zeros(num_dispersive_poles, dtype=config.dtype)
-                c2_padded = jnp.zeros(num_dispersive_poles, dtype=config.dtype)
-                c3_padded = jnp.zeros(num_dispersive_poles, dtype=config.dtype)
-                c4_padded = jnp.zeros(num_dispersive_poles, dtype=config.dtype)
+                c1_padded = jnp.zeros((num_dispersive_poles, num_disp_components), dtype=config.dtype)
+                c2_padded = jnp.zeros((num_dispersive_poles, num_disp_components), dtype=config.dtype)
+                c3_padded = jnp.zeros((num_dispersive_poles, num_disp_components), dtype=config.dtype)
+                c4_padded = jnp.zeros((num_dispersive_poles, num_disp_components), dtype=config.dtype)
                 if n > 0:
-                    c1_padded = c1_padded.at[:n].set(jnp.asarray(c1_vals, dtype=config.dtype))
-                    c2_padded = c2_padded.at[:n].set(jnp.asarray(c2_vals, dtype=config.dtype))
-                    c3_padded = c3_padded.at[:n].set(jnp.asarray(c3_vals, dtype=config.dtype))
-                    c4_padded = c4_padded.at[:n].set(jnp.asarray(c4_vals, dtype=config.dtype))
-                # Broadcast (num_poles,) → (num_poles, 1, Nx, Ny, Nz) over grid_slice
+                    # For num_disp_components == 1 all poles in the simulation are
+                    # isotropic (per all_objects_isotropic_dispersion), so the
+                    # three per-axis columns are identical and keeping the first
+                    # is exact.
+                    c1_padded = c1_padded.at[:n].set(jnp.asarray(c1_vals[:, :num_disp_components], dtype=config.dtype))
+                    c2_padded = c2_padded.at[:n].set(jnp.asarray(c2_vals[:, :num_disp_components], dtype=config.dtype))
+                    c3_padded = c3_padded.at[:n].set(jnp.asarray(c3_vals[:, :num_disp_components], dtype=config.dtype))
+                    c4_padded = c4_padded.at[:n].set(jnp.asarray(c4_vals[:, :num_disp_components], dtype=config.dtype))
+                # Broadcast (num_poles, num_components) → (num_poles, num_components, Nx, Ny, Nz) over grid_slice
                 slice_shape = dispersive_c1[:, :, *o.grid_slice].shape
-                c1_block = jnp.broadcast_to(c1_padded[:, None, None, None, None], slice_shape)
-                c2_block = jnp.broadcast_to(c2_padded[:, None, None, None, None], slice_shape)
-                c3_block = jnp.broadcast_to(c3_padded[:, None, None, None, None], slice_shape)
+                c1_block = jnp.broadcast_to(c1_padded[:, :, None, None, None], slice_shape)
+                c2_block = jnp.broadcast_to(c2_padded[:, :, None, None, None], slice_shape)
+                c3_block = jnp.broadcast_to(c3_padded[:, :, None, None, None], slice_shape)
                 dispersive_c1 = dispersive_c1.at[:, :, *o.grid_slice].set(c1_block)
                 dispersive_c2 = dispersive_c2.at[:, :, *o.grid_slice].set(c2_block)
                 dispersive_c3 = dispersive_c3.at[:, :, *o.grid_slice].set(c3_block)
                 if dispersive_c4 is not None:
-                    c4_block = jnp.broadcast_to(c4_padded[:, None, None, None, None], slice_shape)
+                    c4_block = jnp.broadcast_to(c4_padded[:, :, None, None, None], slice_shape)
                     dispersive_c4 = dispersive_c4.at[:, :, *o.grid_slice].set(c4_block)
 
         elif isinstance(o, (StaticMultiMaterialObject)):
@@ -970,16 +993,13 @@ def _init_arrays(
                     o.materials,
                     dt=config.time_step_duration,
                     max_num_poles=num_dispersive_poles,
+                    num_components=num_disp_components,
                 )
-                # Shape (num_materials, num_poles) -> index by (Nx, Ny, Nz) ->
-                # (Nx, Ny, Nz, num_poles) -> moveaxis -> (num_poles, Nx, Ny, Nz)
-                c1_voxels = jnp.moveaxis(jnp.asarray(allowed_c1, dtype=config.dtype)[indices], -1, 0)
-                c2_voxels = jnp.moveaxis(jnp.asarray(allowed_c2, dtype=config.dtype)[indices], -1, 0)
-                c3_voxels = jnp.moveaxis(jnp.asarray(allowed_c3, dtype=config.dtype)[indices], -1, 0)
-                # broadcast over component axis
-                c1_voxels = c1_voxels[:, None, ...]
-                c2_voxels = c2_voxels[:, None, ...]
-                c3_voxels = c3_voxels[:, None, ...]
+                # Shape (num_materials, num_poles, num_components) -> index by (Nx, Ny, Nz) ->
+                # (Nx, Ny, Nz, num_poles, num_components) -> moveaxis -> (num_poles, num_components, Nx, Ny, Nz)
+                c1_voxels = jnp.moveaxis(jnp.asarray(allowed_c1, dtype=config.dtype)[indices], (-2, -1), (0, 1))
+                c2_voxels = jnp.moveaxis(jnp.asarray(allowed_c2, dtype=config.dtype)[indices], (-2, -1), (0, 1))
+                c3_voxels = jnp.moveaxis(jnp.asarray(allowed_c3, dtype=config.dtype)[indices], (-2, -1), (0, 1))
                 mask_bc = mask[None, None, ...]
                 diff = c1_voxels - dispersive_c1[:, :, *o.grid_slice]
                 dispersive_c1 = dispersive_c1.at[:, :, *o.grid_slice].add(mask_bc * diff)
@@ -988,7 +1008,7 @@ def _init_arrays(
                 diff = c3_voxels - dispersive_c3[:, :, *o.grid_slice]
                 dispersive_c3 = dispersive_c3.at[:, :, *o.grid_slice].add(mask_bc * diff)
                 if dispersive_c4 is not None:
-                    c4_voxels = jnp.moveaxis(jnp.asarray(allowed_c4, dtype=config.dtype)[indices], -1, 0)[:, None, ...]
+                    c4_voxels = jnp.moveaxis(jnp.asarray(allowed_c4, dtype=config.dtype)[indices], (-2, -1), (0, 1))
                     diff = c4_voxels - dispersive_c4[:, :, *o.grid_slice]
                     dispersive_c4 = dispersive_c4.at[:, :, *o.grid_slice].add(mask_bc * diff)
         else:

--- a/src/fdtdx/fdtd/update.py
+++ b/src/fdtdx/fdtd/update.py
@@ -214,8 +214,10 @@ def update_E(
             disp_c3 = arrays.dispersive_c3
             disp_c4 = arrays.dispersive_c4
             assert P_prev is not None and disp_c1 is not None and disp_c2 is not None and disp_c3 is not None
-            # disp_c* are (num_poles, 1, Nx, Ny, Nz); arrays.fields.E is (3, Nx, Ny, Nz).
-            # Right-aligned broadcasting produces (num_poles, 3, Nx, Ny, Nz) without
+            # disp_c* are (num_poles, 1|3, Nx, Ny, Nz) — the component axis is 1
+            # (isotropic dispersion, broadcast) or 3 (per-axis anisotropic
+            # dispersion); arrays.fields.E is (3, Nx, Ny, Nz). Right-aligned
+            # broadcasting produces (num_poles, 3, Nx, Ny, Nz) either way without
             # an explicit newaxis — skip the reshape so the HLO stays flat.
             # P_hat is the explicit part of the recurrence (independent of E^{n+1}).
             P_hat = disp_c1 * P_curr + disp_c2 * P_prev + disp_c3 * arrays.fields.E

--- a/src/fdtdx/materials.py
+++ b/src/fdtdx/materials.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from typing import cast
 
 import numpy as np
@@ -6,7 +7,7 @@ import numpy as np
 from fdtdx import constants
 from fdtdx.core.jax.pytrees import TreeClass, frozen_field
 from fdtdx.core.wavelength import WaveCharacter
-from fdtdx.dispersion import DispersionModel, compute_pole_coefficients
+from fdtdx.dispersion import DispersionModel, compute_pole_coefficients_per_axis
 
 
 def _normalize_material_property(
@@ -207,6 +208,16 @@ class Material(TreeClass):
         object.__setattr__(self, "electric_conductivity", _normalize_material_property(electric_conductivity))
         object.__setattr__(self, "magnetic_conductivity", _normalize_material_property(magnetic_conductivity))
         object.__setattr__(self, "dispersion", dispersion)
+        eps = self.permittivity
+        diag = (eps[0], eps[4], eps[8])
+        if any(isinstance(v, (int, float)) and v <= 0.0 for v in diag):
+            warnings.warn(
+                "Material has a non-positive static permittivity on the diagonal, which is "
+                "unconditionally unstable in explicit FDTD. To model Re(eps) < 0 in-band (metals, "
+                "hyperbolic media), keep eps_inf >= 1 and use a DispersionModel (e.g. a DrudePole).",
+                UserWarning,
+                stacklevel=2,
+            )
 
     @property
     def is_all_isotropic(self) -> bool:
@@ -379,6 +390,16 @@ class Material(TreeClass):
             bool: True if a :class:`DispersionModel` with at least one pole is attached.
         """
         return self.dispersion is not None and self.dispersion.num_poles > 0
+
+    @property
+    def has_isotropic_dispersion(self) -> bool:
+        """Check whether the material's dispersion (if any) is isotropic.
+
+        Returns:
+            bool: True if the material is non-dispersive or every pole of its
+            dispersion model applies the same parameters to all three axes.
+        """
+        return self.dispersion is None or self.dispersion.is_isotropic
 
     @classmethod
     def from_complex_permittivity(
@@ -823,45 +844,56 @@ def compute_allowed_dispersive_coefficients(
     materials: dict[str, Material],
     dt: float,
     max_num_poles: int,
+    num_components: int,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Compute per-material discrete-time dispersive recurrence coefficients.
 
     For each material (in the canonical sorted order used elsewhere), returns
-    arrays of shape ``(num_materials, max_num_poles)`` containing the
-    ``c1``, ``c2``, ``c3``, ``c4`` coefficients from
-    :func:`fdtdx.dispersion.compute_pole_coefficients`. Materials with fewer
-    poles than ``max_num_poles``, or non-dispersive materials, get zero-padded
-    slots (so the polarization term automatically vanishes on those voxels).
-    ``c4`` is zero for Lorentz/Drude poles and only non-zero for CCPR poles.
+    arrays of shape ``(num_materials, max_num_poles, num_components)``
+    containing the ``c1``, ``c2``, ``c3``, ``c4`` coefficients from
+    :func:`fdtdx.dispersion.compute_pole_coefficients_per_axis`. Materials with
+    fewer poles than ``max_num_poles``, or non-dispersive materials, get
+    zero-padded slots (so the polarization term automatically vanishes on those
+    voxels). ``c4`` is zero for Lorentz/Drude poles and only non-zero for CCPR
+    poles.
 
     Args:
         materials: Dictionary mapping material names to Material objects.
         dt: Simulation time step (seconds).
         max_num_poles: Maximum pole count to pad every material to. When 0,
-            returns four ``(num_materials, 0)``-shaped arrays.
+            returns four ``(num_materials, 0, num_components)``-shaped arrays.
+        num_components: Size of the trailing component axis — 1 when all
+            materials have isotropic dispersion, 3 for per-axis (diagonally
+            anisotropic) dispersion.
 
     Returns:
-        Four numpy arrays of shape ``(num_materials, max_num_poles)``
+        Four numpy arrays of shape ``(num_materials, max_num_poles, num_components)``
         with ``c1``, ``c2``, ``c3``, ``c4``.
     """
+    if num_components not in (1, 3):
+        raise ValueError(f"num_components must be 1 or 3, got {num_components}.")
     ordered = compute_ordered_material_name_tuples(materials)
     num_mats = len(ordered)
-    c1 = np.zeros((num_mats, max_num_poles), dtype=np.float64)
-    c2 = np.zeros((num_mats, max_num_poles), dtype=np.float64)
-    c3 = np.zeros((num_mats, max_num_poles), dtype=np.float64)
-    c4 = np.zeros((num_mats, max_num_poles), dtype=np.float64)
+    c1 = np.zeros((num_mats, max_num_poles, num_components), dtype=np.float64)
+    c2 = np.zeros((num_mats, max_num_poles, num_components), dtype=np.float64)
+    c3 = np.zeros((num_mats, max_num_poles, num_components), dtype=np.float64)
+    c4 = np.zeros((num_mats, max_num_poles, num_components), dtype=np.float64)
     if max_num_poles == 0:
         return c1, c2, c3, c4
     for m_idx, (_, mat) in enumerate(ordered):
         if mat.dispersion is None:
             continue
+        if num_components == 1 and not mat.has_isotropic_dispersion:
+            raise ValueError("num_components=1 requires isotropic dispersion, but a material has per-axis poles.")
         poles = mat.dispersion.poles
-        c1_vals, c2_vals, c3_vals, c4_vals = compute_pole_coefficients(poles, dt)
+        c1_vals, c2_vals, c3_vals, c4_vals = compute_pole_coefficients_per_axis(poles, dt)
         n = len(poles)
-        c1[m_idx, :n] = c1_vals
-        c2[m_idx, :n] = c2_vals
-        c3[m_idx, :n] = c3_vals
-        c4[m_idx, :n] = c4_vals
+        # For num_components == 1 the isotropy check above guarantees all three
+        # axis columns are identical, so keeping only the first is exact.
+        c1[m_idx, :n] = c1_vals[:, :num_components]
+        c2[m_idx, :n] = c2_vals[:, :num_components]
+        c3[m_idx, :n] = c3_vals[:, :num_components]
+        c4[m_idx, :n] = c4_vals[:, :num_components]
     return c1, c2, c3, c4
 
 

--- a/src/fdtdx/objects/sources/tfsf.py
+++ b/src/fdtdx/objects/sources/tfsf.py
@@ -4,6 +4,7 @@ from typing import Self
 import jax
 import jax.numpy as jnp
 import numpy as np
+from loguru import logger
 
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.dispersion import (
@@ -86,6 +87,20 @@ def _build_dispersive_H_filter(
     c3_np = np.asarray(c3_slice)
     c4_np = None if c4_slice is None else np.asarray(c4_slice)
     inv_eps_inf_np = np.asarray(inv_eps_inf_slice)
+
+    # With per-axis (anisotropic) dispersion the coefficient arrays carry one
+    # value per component; the scalar impedance filter below can only use a
+    # component average. Warn once at setup so the approximation is visible.
+    if c1_np.shape[0] > 0 and c1_np.shape[1] > 1:
+        anisotropic = any(
+            bool(np.any(arr != arr[:, :1])) for arr in (c1_np, c2_np, c3_np) + (() if c4_np is None else (c4_np,))
+        )
+        if anisotropic:
+            logger.warning(
+                "TFSF source overlaps a material with per-axis (anisotropic) dispersion; the broadband "
+                "impedance filter uses a component-averaged eps(omega). The carrier-frequency amplitude "
+                "stays exact per component, but broadband impedance matching is approximate here."
+            )
 
     eps_spectrum = compute_eps_spectrum_from_coefficients(
         c1=c1_np,

--- a/tests/integration/fdtd/test_dispersive_init.py
+++ b/tests/integration/fdtd/test_dispersive_init.py
@@ -550,3 +550,188 @@ def test_plane_source_apply_changes_with_dispersion(simple_config, simple_volume
     assert diff > 0.1, (
         f"|H_disp - H_vac| / |H_vac| = {diff:.3f} — source apply() did not see the dispersive coefficients"
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-axis (diagonally anisotropic) dispersion
+# ---------------------------------------------------------------------------
+
+
+def _per_axis_lorentz_material(eps_inf=(2.0, 2.0, 3.0)):
+    from fdtdx.dispersion import compute_pole_coefficients_per_axis  # noqa: F401  (re-exported for tests below)
+
+    return Material(
+        permittivity=eps_inf,
+        dispersion=DispersionModel(
+            poles=(
+                LorentzPole(
+                    resonance_frequency=(2e15, 2e15, 1e15),
+                    damping=(1e13, 1e13, 2e13),
+                    delta_epsilon=(1.5, 1.5, 0.5),
+                ),
+            )
+        ),
+    )
+
+
+def test_per_axis_dispersion_allocates_3_component_coefficients(simple_config, simple_volume):
+    """A per-axis dispersive material widens the coefficient arrays to a
+    3-entry component axis and bakes per-axis values inside the object slice."""
+    from fdtdx.dispersion import compute_pole_coefficients_per_axis
+
+    material = _per_axis_lorentz_material()
+    obj = UniformMaterialObject(name="slab", partial_grid_shape=(10, 10, 10), material=material)
+    constraint = GridCoordinateConstraint(
+        object="slab", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[10, 10, 10]
+    )
+    key = jax.random.PRNGKey(0)
+    objects, arrays, _, config, _ = place_objects([simple_volume, obj], simple_config, [constraint], key)
+    placed = _placed(objects, "slab")
+
+    Nx, Ny, Nz = simple_volume.partial_grid_shape  # type: ignore[misc]
+    assert arrays.dispersive_c1 is not None
+    assert arrays.dispersive_c1.shape == (1, 3, Nx, Ny, Nz)
+    assert arrays.dispersive_c2.shape == (1, 3, Nx, Ny, Nz)
+    assert arrays.dispersive_c3.shape == (1, 3, Nx, Ny, Nz)
+    assert arrays.dispersive_inv_c2.shape == (1, 3, Nx, Ny, Nz)
+    # polarization state keeps its (num_poles, 3, ...) shape
+    assert arrays.fields.dispersive_P_curr.shape == (1, 3, Nx, Ny, Nz)
+
+    c1_ref, c2_ref, c3_ref, _ = compute_pole_coefficients_per_axis(
+        material.dispersion.poles,  # type: ignore[union-attr]
+        config.time_step_duration,
+    )
+    xs, ys, zs = placed.grid_slice
+    for ax in range(3):
+        assert jnp.allclose(arrays.dispersive_c1[0, ax, xs, ys, zs], c1_ref[0, ax])
+        assert jnp.allclose(arrays.dispersive_c2[0, ax, xs, ys, zs], c2_ref[0, ax])
+        assert jnp.allclose(arrays.dispersive_c3[0, ax, xs, ys, zs], c3_ref[0, ax])
+    # the axis columns genuinely differ (x vs z resonance)
+    assert not jnp.allclose(arrays.dispersive_c1[0, 0, xs, ys, zs], arrays.dispersive_c1[0, 2, xs, ys, zs])
+    # outside the slab everything is zero
+    inside_mask = jnp.zeros((Nx, Ny, Nz), dtype=bool).at[xs, ys, zs].set(True)
+    assert jnp.all(arrays.dispersive_c3[0, :, ~inside_mask] == 0.0)
+
+
+def test_isotropic_dispersion_keeps_1_component_axis(simple_config, simple_volume):
+    """Purely isotropic dispersion must keep the memory-saving size-1 component
+    axis (regression guard for the per-axis feature)."""
+    obj = UniformMaterialObject(name="slab", partial_grid_shape=(10, 10, 10), material=_lorentz_material())
+    constraint = GridCoordinateConstraint(
+        object="slab", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[10, 10, 10]
+    )
+    key = jax.random.PRNGKey(0)
+    _, arrays, _, _, _ = place_objects([simple_volume, obj], simple_config, [constraint], key)
+    assert arrays.dispersive_c1.shape[1] == 1
+
+
+def test_static_multi_material_per_axis_coefficients(simple_config, simple_volume):
+    """A Sphere with a per-axis Drude material bakes per-axis coefficients
+    through the multi-material indexing path."""
+    from fdtdx.dispersion import compute_pole_coefficients_per_axis
+
+    per_axis_drude = Material(
+        permittivity=1.0,
+        dispersion=DispersionModel(poles=(DrudePole(plasma_frequency=(1.37e16, 0.0, 0.0), damping=1e14),)),
+    )
+    materials = {
+        "background": Material(permittivity=1.0),
+        "drude": per_axis_drude,
+    }
+    sphere = Sphere(
+        name="sphere",
+        materials=materials,
+        material_name="drude",
+        radius=5.0 * simple_config.uniform_spacing(),
+    )
+    constraint = GridCoordinateConstraint(object="sphere", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[8, 8, 8])
+    key = jax.random.PRNGKey(0)
+    objects, arrays, _, config, _ = place_objects([simple_volume, sphere], simple_config, [constraint], key)
+    placed = _placed(objects, "sphere")
+
+    assert arrays.dispersive_c3 is not None
+    assert arrays.dispersive_c3.shape[1] == 3
+
+    c1_ref, _, c3_ref, _ = compute_pole_coefficients_per_axis(
+        per_axis_drude.dispersion.poles,  # type: ignore[union-attr]
+        config.time_step_duration,
+    )
+    xs, ys, zs = placed.grid_slice
+    voxel_mask = placed.get_voxel_mask_for_shape().astype(bool)
+    inside_x = arrays.dispersive_c3[0, 0, xs, ys, zs]
+    inside_y = arrays.dispersive_c3[0, 1, xs, ys, zs]
+    # x axis carries the plasma coupling, y axis has none
+    assert jnp.allclose(inside_x[voxel_mask], c3_ref[0, 0])
+    assert c3_ref[0, 0] > 0.0
+    assert jnp.all(inside_y[voxel_mask] == 0.0)
+    # c1 is still non-zero on the y axis (recurrence exists, zero coupling)
+    assert jnp.allclose(arrays.dispersive_c1[0, 1, xs, ys, zs][voxel_mask], c1_ref[0, 1])
+
+
+def test_device_per_axis_dispersive_continuous_and_discrete(simple_config, simple_volume):
+    """Devices write per-axis coefficient stacks through both the CONTINUOUS
+    interpolation branch and the DISCRETE selection branch."""
+    from fdtdx.dispersion import compute_pole_coefficients_per_axis
+
+    per_axis_drude = Material(
+        permittivity=1.0,
+        dispersion=DispersionModel(poles=(DrudePole(plasma_frequency=(1.37e16, 0.0, 5.0e15), damping=1e14),)),
+    )
+    materials = {
+        "air": Material(permittivity=1.0),
+        "drude": per_axis_drude,
+    }
+    for transforms in ([], [ClosestIndex()]):
+        device = Device(
+            name="device",
+            partial_grid_shape=(10, 10, 10),
+            partial_voxel_grid_shape=(5, 5, 5),
+            materials=materials,
+            param_transforms=transforms,
+        )
+        constraint = GridCoordinateConstraint(
+            object="device", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[10, 10, 10]
+        )
+        key = jax.random.PRNGKey(0)
+        objects, arrays, params, config, _ = place_objects([simple_volume, device], simple_config, [constraint], key)
+        placed_device = _placed(objects, "device")
+        xs, ys, zs = placed_device.grid_slice
+
+        drude_params = {name: jnp.ones_like(p) for name, p in params.items()}
+        arrays, objects, _ = apply_params(arrays, objects, drude_params, key)
+
+        assert arrays.dispersive_c1.shape[1] == 3
+        c1_ref, _, c3_ref, _ = compute_pole_coefficients_per_axis(
+            per_axis_drude.dispersion.poles,  # type: ignore[union-attr]
+            config.time_step_duration,
+        )
+        for ax in range(3):
+            assert jnp.allclose(arrays.dispersive_c1[0, ax, xs, ys, zs], c1_ref[0, ax])
+            assert jnp.allclose(arrays.dispersive_c3[0, ax, xs, ys, zs], c3_ref[0, ax])
+        # x and z couplings differ by construction
+        assert c3_ref[0, 0] != c3_ref[0, 2]
+        # inv_c2 must be the exact reciprocal of the stored c2
+        assert jnp.allclose(
+            arrays.dispersive_inv_c2[0, :, xs, ys, zs] * arrays.dispersive_c2[0, :, xs, ys, zs],
+            1.0,
+        )
+
+
+def test_full_tensor_sigma_plus_dispersive_raises(simple_config, simple_volume):
+    """Dispersion combined with an off-diagonal conductivity tensor must be
+    rejected: the full-tensor update branch has no ADE block, so this would
+    silently skip the polarization update."""
+    sigma_tensor = Material(
+        permittivity=2.0,
+        electric_conductivity=(1.0, 0.1, 0.0, 0.1, 1.0, 0.0, 0.0, 0.0, 1.0),  # off-diagonal
+    )
+    disp = _lorentz_material(eps_inf=2.0)
+    obj1 = UniformMaterialObject(name="sigma_slab", partial_grid_shape=(6, 6, 6), material=sigma_tensor)
+    obj2 = UniformMaterialObject(name="disp", partial_grid_shape=(6, 6, 6), material=disp)
+    constraints = [
+        GridCoordinateConstraint(object="sigma_slab", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[2, 2, 2]),
+        GridCoordinateConstraint(object="disp", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[15, 15, 15]),
+    ]
+    key = jax.random.PRNGKey(0)
+    with pytest.raises(NotImplementedError, match="conductivity"):
+        place_objects([simple_volume, obj1, obj2], simple_config, constraints, key)

--- a/tests/simulation/fdtd/test_fdtd.py
+++ b/tests/simulation/fdtd/test_fdtd.py
@@ -193,9 +193,12 @@ class TestReversibleFdtdGradients:
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-def _build_lossy_dispersive_scene(dtype):
+def _build_lossy_dispersive_scene(dtype, material=None):
     """Lorentz + σ_E = 100 S/m + dipole, periodic. The scene where the recent
     conductivity-not-forwarded bug actually mattered.
+
+    ``material`` overrides the slab material (used by the per-axis dispersive
+    gradient cross-check below).
     """
     config = SimulationConfig(
         time=_SIM_TIME,
@@ -223,13 +226,14 @@ def _build_lossy_dispersive_scene(dtype):
     objects.extend(bound_dict.values())
     constraints.extend(c_list)
 
-    material = fdtdx.Material(
-        permittivity=2.0,
-        electric_conductivity=1e2,
-        dispersion=fdtdx.DispersionModel(
-            poles=(fdtdx.LorentzPole(resonance_frequency=2e15, damping=1e13, delta_epsilon=1.5),),
-        ),
-    )
+    if material is None:
+        material = fdtdx.Material(
+            permittivity=2.0,
+            electric_conductivity=1e2,
+            dispersion=fdtdx.DispersionModel(
+                poles=(fdtdx.LorentzPole(resonance_frequency=2e15, damping=1e13, delta_epsilon=1.5),),
+            ),
+        )
     slab_cells = _VOLUME_CELLS // 2
     slab = fdtdx.UniformMaterialObject(
         name="slab",
@@ -526,3 +530,73 @@ class TestReversibleVsCheckpointedGradient:
             max_diff = float(jnp.max(jnp.abs(grad_rev - grad_chk)))
             rel = max_diff / (max_abs + 1e-30)
             assert rel < 1e-5, f"c3 gradient mismatch: max|Δ|={max_diff:.3e}, max|grad|={max_abs:.3e}, rel={rel:.3e}"
+
+    def test_gradients_agree_per_axis_dispersive_c3_float64(self):
+        """Same c3 cross-check with PER-AXIS (diagonally anisotropic) dispersion:
+        the coefficient arrays carry a 3-entry component axis instead of the
+        broadcast size-1 axis, and each axis has different pole parameters.
+        Validates that the elementwise forward/reverse ADE updates and the VJP
+        stay exact when the coefficients vary per field component."""
+        per_axis_material = fdtdx.Material(
+            permittivity=(2.0, 2.5, 3.0),
+            electric_conductivity=1e2,
+            dispersion=fdtdx.DispersionModel(
+                poles=(
+                    fdtdx.LorentzPole(
+                        resonance_frequency=(2e15, 2.5e15, 3e15),
+                        damping=(1e13, 2e13, 1.5e13),
+                        delta_epsilon=(1.5, 0.5, 1.0),
+                    ),
+                ),
+            ),
+        )
+
+        def run(method):
+            obj, arrays, config = _build_lossy_dispersive_scene(dtype=jnp.float64, material=per_axis_material)
+            assert arrays.dispersive_c3 is not None and arrays.dispersive_c3.shape[1] == 3
+            arrays, config = _attach_gradient(arrays, config, obj, method=method)
+
+            def loss_fn(c3):
+                arr = ArrayContainer(
+                    fields=FieldState(
+                        E=arrays.fields.E,
+                        H=arrays.fields.H,
+                        psi_E=arrays.fields.psi_E,
+                        psi_H=arrays.fields.psi_H,
+                        dispersive_P_curr=arrays.fields.dispersive_P_curr,
+                        dispersive_P_prev=arrays.fields.dispersive_P_prev,
+                    ),
+                    inv_permittivities=arrays.inv_permittivities,
+                    inv_permeabilities=arrays.inv_permeabilities,
+                    detector_states=arrays.detector_states,
+                    recording_state=arrays.recording_state,
+                    electric_conductivity=arrays.electric_conductivity,
+                    magnetic_conductivity=arrays.magnetic_conductivity,
+                    dispersive_c1=arrays.dispersive_c1,
+                    dispersive_c2=arrays.dispersive_c2,
+                    dispersive_c3=c3,
+                    dispersive_inv_c2=arrays.dispersive_inv_c2,
+                )
+                fdtd_impl = reversible_fdtd if method == "reversible" else checkpointed_fdtd
+                _, out = fdtd_impl(arr, obj, config, jax.random.PRNGKey(99), show_progress=False)
+                return jnp.sum(jnp.real(out.fields.E) ** 2)
+
+            return jax.value_and_grad(loss_fn)(arrays.dispersive_c3)
+
+        with _x64_enabled():
+            loss_rev, grad_rev = run("reversible")
+            loss_chk, grad_chk = run("checkpointed")
+            assert jnp.isfinite(loss_rev) and jnp.isfinite(loss_chk)
+            assert jnp.allclose(loss_rev, loss_chk, rtol=1e-9, atol=1e-12)
+            max_abs = float(jnp.max(jnp.abs(grad_rev) + jnp.abs(grad_chk)))
+            max_diff = float(jnp.max(jnp.abs(grad_rev - grad_chk)))
+            rel = max_diff / (max_abs + 1e-30)
+            assert rel < 1e-5, (
+                f"per-axis c3 gradient mismatch: max|Δ|={max_diff:.3e}, max|grad|={max_abs:.3e}, rel={rel:.3e}"
+            )
+            # The per-axis gradient must genuinely differ across the component
+            # axis inside the slab — otherwise this test degenerates to the
+            # isotropic case.
+            gx = float(jnp.max(jnp.abs(grad_rev[:, 0])))
+            gy = float(jnp.max(jnp.abs(grad_rev[:, 1])))
+            assert gx != gy

--- a/tests/simulation/fdtd/test_time_reversal.py
+++ b/tests/simulation/fdtd/test_time_reversal.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 
 import jax
 import jax.numpy as jnp
+import pytest
 
 import fdtdx
 from fdtdx.config import GradientConfig, SimulationConfig
@@ -362,7 +363,7 @@ class TestTimeReversalDispersiveLorentz:
     """
 
     @staticmethod
-    def _build():
+    def _build(material=None):
         config = SimulationConfig(
             time=_SIM_TIME,
             grid=UniformGrid(spacing=_RESOLUTION),
@@ -385,12 +386,13 @@ class TestTimeReversalDispersiveLorentz:
         objects.extend(bound_dict.values())
         constraints.extend(c_list)
 
-        material = fdtdx.Material(
-            permittivity=2.0,
-            dispersion=fdtdx.DispersionModel(
-                poles=(fdtdx.LorentzPole(resonance_frequency=2e15, damping=1e13, delta_epsilon=1.5),),
-            ),
-        )
+        if material is None:
+            material = fdtdx.Material(
+                permittivity=2.0,
+                dispersion=fdtdx.DispersionModel(
+                    poles=(fdtdx.LorentzPole(resonance_frequency=2e15, damping=1e13, delta_epsilon=1.5),),
+                ),
+            )
         slab_cells = _VOLUME_CELLS // 2
         slab = fdtdx.UniformMaterialObject(
             partial_grid_shape=(None, None, slab_cells),
@@ -415,12 +417,30 @@ class TestTimeReversalDispersiveLorentz:
         arrays, obj_container, _ = fdtdx.apply_params(arrays, obj_container, params, key)
         return obj_container, arrays, config
 
-    def test_fields_and_polarization_reconstructed_exactly(self):
-        obj, arrays, config = self._build()
+    @pytest.mark.parametrize("per_axis", [False, True], ids=["isotropic", "per_axis"])
+    def test_fields_and_polarization_reconstructed_exactly(self, per_axis):
+        material = None
+        if per_axis:
+            # Per-axis pole parameters (with non-zero coupling on every axis so
+            # the seeded polarization stays recoverable everywhere in the slab).
+            material = fdtdx.Material(
+                permittivity=(2.0, 2.5, 3.0),
+                dispersion=fdtdx.DispersionModel(
+                    poles=(
+                        fdtdx.LorentzPole(
+                            resonance_frequency=(2e15, 2.5e15, 3e15),
+                            damping=(1e13, 2e13, 1.5e13),
+                            delta_epsilon=(1.5, 0.5, 1.0),
+                        ),
+                    ),
+                ),
+            )
+        obj, arrays, config = self._build(material)
         # Allocation sanity: the slab should have triggered allocation.
         assert arrays.fields.dispersive_P_curr is not None
         assert arrays.fields.dispersive_P_prev is not None
         assert arrays.dispersive_c3 is not None
+        assert arrays.dispersive_c3.shape[1] == (3 if per_axis else 1)
 
         key = jax.random.PRNGKey(42)
         k_E, k_H, k_Pc, k_Pp = jax.random.split(key, 4)

--- a/tests/simulation/physics/test_anisotropic_dispersion.py
+++ b/tests/simulation/physics/test_anisotropic_dispersion.py
@@ -1,0 +1,280 @@
+"""Physics simulation tests for per-axis (diagonally anisotropic) dispersion.
+
+A per-axis dispersive medium applies different pole parameters to the x, y and
+z field components. For a normally incident plane wave propagating along z,
+an x-polarized wave sees only chi_x and a y-polarized wave only chi_y — so
+the per-axis run must match (i) an equivalent isotropic run per polarization
+and (ii) the analytic Fresnel transmission from ``susceptibility_axes``.
+
+The hyperbolic test drives a per-axis Drude medium in the band where
+Re(eps_x) < 0 < eps_y: the x polarization is reflected like a metal while the
+y polarization passes through — the defining anisotropy of a hyperbolic
+(indefinite) medium. This is the physics that motivates per-axis dispersion:
+a *static* negative permittivity is unconditionally unstable in FDTD, so
+hyperbolic behavior must come from poles.
+
+Layout mirrors ``test_dispersion.py`` — 3x3 periodic transverse, PMLs in z,
+``UniformPlaneSource`` in +z, one transmission-side Poynting flux detector.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import fdtdx
+from fdtdx.constants import c as c0
+
+_WAVELENGTH = 1e-6
+_OMEGA = 2.0 * np.pi * c0 / _WAVELENGTH
+_RESOLUTION = 25e-9  # 40 cells/wavelength in vacuum
+_PML_CELLS = 10
+_DOMAIN_XY = 3 * _RESOLUTION
+_DOMAIN_Z = 5e-6
+_Z_CELLS = round(_DOMAIN_Z / _RESOLUTION)  # = 200
+
+_SOURCE_Z = _PML_CELLS + 2
+_INTERFACE_Z = 100
+_DET_T_Z = 140
+_DIEL_CELLS_Z = _Z_CELLS - _INTERFACE_Z
+
+_SIM_TIME = 120e-15
+_TOLERANCE = 0.05
+
+_DT_APPROX = 0.99 * _RESOLUTION / (c0 * np.sqrt(3))
+_STEPS_PER_PERIOD = round(_WAVELENGTH / (c0 * _DT_APPROX))
+_N_AVG_STEPS = 10 * _STEPS_PER_PERIOD
+
+# Per-axis Lorentz strengths: x sees a strong resonance, y/z a weak one.
+_DE_X = 2.25  # eps_x ~ 4 at _OMEGA (resonance at 2*_OMEGA)
+_DE_Y = 0.75  # eps_y ~ 2 at _OMEGA
+_LORENTZ_W0 = 2.0 * _OMEGA
+_LORENTZ_GAMMA = 1e13
+
+
+def _per_axis_lorentz_model():
+    return fdtdx.DispersionModel(
+        poles=(
+            fdtdx.LorentzPole(
+                resonance_frequency=_LORENTZ_W0,
+                damping=_LORENTZ_GAMMA,
+                delta_epsilon=(_DE_X, _DE_Y, _DE_Y),
+            ),
+        )
+    )
+
+
+def _isotropic_lorentz_model(delta_eps):
+    return fdtdx.DispersionModel(
+        poles=(
+            fdtdx.LorentzPole(
+                resonance_frequency=_LORENTZ_W0,
+                damping=_LORENTZ_GAMMA,
+                delta_epsilon=delta_eps,
+            ),
+        )
+    )
+
+
+def _fresnel_transmission_semi_infinite(eps_complex: complex) -> float:
+    n2 = np.sqrt(eps_complex)
+    t = 2.0 / (1.0 + n2)
+    return float(np.real(n2) * np.abs(t) ** 2)
+
+
+def _build_base(polarization):
+    config = fdtdx.SimulationConfig(
+        grid=fdtdx.UniformGrid(spacing=_RESOLUTION),
+        time=_SIM_TIME,
+        dtype=jnp.float32,
+    )
+    objects, constraints = [], []
+
+    volume = fdtdx.SimulationVolume(
+        partial_real_shape=(_DOMAIN_XY, _DOMAIN_XY, _DOMAIN_Z),
+    )
+    objects.append(volume)
+
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+        thickness=_PML_CELLS,
+        override_types={
+            "min_x": "periodic",
+            "max_x": "periodic",
+            "min_y": "periodic",
+            "max_y": "periodic",
+        },
+    )
+    bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    constraints.extend(c_list)
+    objects.extend(bound_dict.values())
+
+    wave = fdtdx.WaveCharacter(wavelength=_WAVELENGTH)
+    source = fdtdx.UniformPlaneSource(
+        partial_grid_shape=(None, None, 1),
+        wave_character=wave,
+        direction="+",
+        fixed_E_polarization_vector=polarization,
+    )
+    constraints.extend(
+        [
+            source.same_size(volume, axes=(0, 1)),
+            source.place_at_center(volume, axes=(0, 1)),
+            source.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_SOURCE_Z,)),
+        ]
+    )
+    objects.append(source)
+
+    return objects, constraints, config, volume
+
+
+def _add_flux_det(name, z_idx, volume, objects, constraints):
+    det = fdtdx.PoyntingFluxDetector(
+        name=name,
+        partial_grid_shape=(None, None, 1),
+        direction="+",
+        reduce_volume=True,
+        plot=False,
+    )
+    constraints.extend(
+        [
+            det.same_size(volume, axes=(0, 1)),
+            det.place_at_center(volume, axes=(0, 1)),
+            det.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(z_idx,)),
+        ]
+    )
+    objects.append(det)
+
+
+def _add_half_space(material, volume, objects, constraints):
+    slab = fdtdx.UniformMaterialObject(
+        partial_grid_shape=(None, None, _DIEL_CELLS_Z),
+        material=material,
+    )
+    constraints.extend(
+        [
+            slab.same_size(volume, axes=(0, 1)),
+            slab.place_at_center(volume, axes=(0, 1)),
+            slab.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_INTERFACE_Z,)),
+        ]
+    )
+    objects.append(slab)
+
+
+def _run(objects, constraints, config):
+    key = jax.random.PRNGKey(0)
+    obj_container, arrays, params, config, _ = fdtdx.place_objects(
+        object_list=objects,
+        config=config,
+        constraints=constraints,
+        key=key,
+    )
+    arrays, obj_container, _ = fdtdx.apply_params(arrays, obj_container, params, key)
+    _, arrays = fdtdx.run_fdtd(arrays=arrays, objects=obj_container, config=config, key=key)
+    return arrays
+
+
+def _mean_flux(arrays, name):
+    flux = np.array(arrays.detector_states[name]["poynting_flux"][:, 0])
+    return float(np.mean(flux[-_N_AVG_STEPS:]))
+
+
+def _transmitted_flux(material, polarization):
+    obj, con, cfg, vol = _build_base(polarization)
+    if material is not None:
+        _add_half_space(material, vol, obj, con)
+    _add_flux_det("flux_t", _DET_T_Z, vol, obj, con)
+    return _mean_flux(_run(obj, con, cfg), "flux_t")
+
+
+_X_POL = (1, 0, 0)
+_Y_POL = (0, 1, 0)
+
+
+@pytest.fixture(scope="module")
+def vacuum_flux():
+    """Vacuum reference flux per polarization (normalization)."""
+    return {
+        _X_POL: _transmitted_flux(None, _X_POL),
+        _Y_POL: _transmitted_flux(None, _Y_POL),
+    }
+
+
+class TestPerAxisLorentz:
+    def test_per_axis_equals_isotropic_run_per_polarization(self):
+        """The airtight equivalence check: for each polarization, the per-axis
+        run must match an isotropic run built from that axis' pole parameters.
+        The underlying arithmetic is identical (the coefficient arrays merely
+        stop broadcasting), so agreement is expected to near float32 precision.
+        """
+        eps_inf = 1.0
+        per_axis_mat = fdtdx.Material(permittivity=eps_inf, dispersion=_per_axis_lorentz_model())
+
+        for pol, de in ((_X_POL, _DE_X), (_Y_POL, _DE_Y)):
+            iso_mat = fdtdx.Material(permittivity=eps_inf, dispersion=_isotropic_lorentz_model(de))
+            s_per_axis = _transmitted_flux(per_axis_mat, pol)
+            s_iso = _transmitted_flux(iso_mat, pol)
+            assert s_iso > 0
+            rel = abs(s_per_axis - s_iso) / abs(s_iso)
+            assert rel < 1e-4, (
+                f"per-axis run diverged from equivalent isotropic run for polarization {pol}: "
+                f"S_per_axis={s_per_axis:.6e}, S_iso={s_iso:.6e}, rel={rel:.2e}"
+            )
+
+    def test_transmission_matches_fresnel_per_polarization(self, vacuum_flux):
+        """x- and y-polarized transmissions match the analytic Fresnel values
+        computed from ``susceptibility_axes`` — and differ from each other."""
+        eps_inf = 1.0
+        model = _per_axis_lorentz_model()
+        material = fdtdx.Material(permittivity=eps_inf, dispersion=model)
+        chi = model.susceptibility_axes(_OMEGA)
+
+        t_measured = {}
+        for pol, chi_ax in ((_X_POL, chi[0]), (_Y_POL, chi[1])):
+            t_analytic = _fresnel_transmission_semi_infinite(eps_inf + chi_ax)
+            s_t = _transmitted_flux(material, pol)
+            t_meas = s_t / vacuum_flux[pol]
+            t_measured[pol] = t_meas
+            rel_err = abs(t_meas - t_analytic) / t_analytic
+            assert rel_err < _TOLERANCE, (
+                f"polarization {pol}: T_measured={t_meas:.4f}, T_analytic={t_analytic:.4f} "
+                f"(eps={eps_inf + chi_ax}), rel_err={rel_err:.3f} > {_TOLERANCE}"
+            )
+        # The two polarizations must see genuinely different media.
+        assert abs(t_measured[_X_POL] - t_measured[_Y_POL]) > 0.02
+
+
+class TestHyperbolicDrude:
+    def test_hyperbolic_medium_is_polarization_selective(self, vacuum_flux):
+        """Per-axis Drude with a plasma frequency only on x: at _OMEGA the
+        permittivity tensor is indefinite (Re eps_x < 0 < eps_y = eps_z) — a
+        hyperbolic medium. The x polarization reflects like a metal while the
+        y polarization transmits per Fresnel."""
+        eps_inf = 1.0
+        omega_p = 5.0 * _OMEGA
+        gamma = 0.05 * _OMEGA
+        model = fdtdx.DispersionModel(poles=(fdtdx.DrudePole(plasma_frequency=(omega_p, 0.0, 0.0), damping=gamma),))
+        chi = model.susceptibility_axes(_OMEGA)
+        eps_x = eps_inf + chi[0]
+        eps_y = eps_inf + chi[1]
+        # Premise: the tensor is indefinite at the test frequency.
+        assert eps_x.real < 0 < eps_y.real, f"premise broken: eps_x={eps_x}, eps_y={eps_y}"
+
+        material = fdtdx.Material(permittivity=eps_inf, dispersion=model)
+
+        t_x_analytic = _fresnel_transmission_semi_infinite(eps_x)
+        assert t_x_analytic < 0.05, f"premise: metallic x response should barely transmit, got {t_x_analytic}"
+        s_x = _transmitted_flux(material, _X_POL)
+        t_x = s_x / vacuum_flux[_X_POL]
+        assert abs(t_x - t_x_analytic) < _TOLERANCE, (
+            f"x-pol (metallic axis): T_measured={t_x:.4f}, T_analytic={t_x_analytic:.4f}"
+        )
+
+        # y polarization sees eps_y = eps_inf = 1 (vacuum): full transmission.
+        s_y = _transmitted_flux(material, _Y_POL)
+        t_y = s_y / vacuum_flux[_Y_POL]
+        t_y_analytic = _fresnel_transmission_semi_infinite(eps_y)
+        assert abs(t_y - t_y_analytic) < _TOLERANCE, (
+            f"y-pol (dielectric axis): T_measured={t_y:.4f}, T_analytic={t_y_analytic:.4f}"
+        )
+        # The defining hyperbolic signature: strong polarization selectivity.
+        assert t_y - t_x > 0.8

--- a/tests/unit/test_dispersion.py
+++ b/tests/unit/test_dispersion.py
@@ -11,6 +11,7 @@ from fdtdx.dispersion import (
     Pole,
     compute_eps_spectrum_from_coefficients,
     compute_pole_coefficients,
+    compute_pole_coefficients_per_axis,
     susceptibility_from_coefficients,
 )
 from fdtdx.materials import (
@@ -156,11 +157,11 @@ class TestAllowedDispersiveCoefficients:
             "air": Material(permittivity=1.0),
             "si": Material(permittivity=11.7),
         }
-        c1, c2, c3, c4 = compute_allowed_dispersive_coefficients(mats, dt=1e-17, max_num_poles=0)
-        assert c1.shape == (2, 0)
-        assert c2.shape == (2, 0)
-        assert c3.shape == (2, 0)
-        assert c4.shape == (2, 0)
+        c1, c2, c3, c4 = compute_allowed_dispersive_coefficients(mats, dt=1e-17, max_num_poles=0, num_components=1)
+        assert c1.shape == (2, 0, 1)
+        assert c2.shape == (2, 0, 1)
+        assert c3.shape == (2, 0, 1)
+        assert c4.shape == (2, 0, 1)
 
     def test_max_num_dispersive_poles_helper(self):
         mats = {
@@ -196,8 +197,8 @@ class TestAllowedDispersiveCoefficients:
                 ),
             ),
         }
-        c1, c2, c3, c4 = compute_allowed_dispersive_coefficients(mats, dt=1e-17, max_num_poles=2)
-        assert c1.shape == (3, 2)
+        c1, c2, c3, c4 = compute_allowed_dispersive_coefficients(mats, dt=1e-17, max_num_poles=2, num_components=1)
+        assert c1.shape == (3, 2, 1)
         # Lorentz/Drude materials have no dE/dt coupling -> c4 all zero.
         assert np.all(c4 == 0.0)
         # Non-dispersive material (air) must have all-zero coefficients.
@@ -323,3 +324,215 @@ class TestCCPRPole:
 
         for omega in (0.5e15, 1.8e15, 2.6e15):
             assert m.susceptibility(omega) == pytest.approx(cp_chi(omega), rel=1e-9)
+
+
+class TestPerAxisPoles:
+    """Per-axis (diagonally anisotropic) pole parameters."""
+
+    def test_scalar_pole_is_isotropic_and_axes_uniform(self):
+        p = LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0)
+        assert p.is_isotropic
+        assert p.omega_0_axes == (1e15, 1e15, 1e15)
+        assert p.gamma_axes == (1e13, 1e13, 1e13)
+        assert p.coupling_sq_axes == pytest.approx((2e30, 2e30, 2e30))
+        assert p.coupling_edot_axes == (0.0, 0.0, 0.0)
+
+    def test_per_axis_lorentz_axes_values(self):
+        p = LorentzPole(
+            resonance_frequency=(1e15, 2e15, 3e15),
+            damping=(1e13, 2e13, 3e13),
+            delta_epsilon=(1.0, 2.0, 0.0),
+        )
+        assert not p.is_isotropic
+        assert p.omega_0_axes == (1e15, 2e15, 3e15)
+        assert p.gamma_axes == (1e13, 2e13, 3e13)
+        assert p.coupling_sq_axes == pytest.approx((1e30, 2.0 * 4e30, 0.0))
+
+    def test_per_axis_drude_axes_values(self):
+        p = DrudePole(plasma_frequency=(2e15, 0.0, 0.0), damping=1e13)
+        assert not p.is_isotropic
+        assert p.omega_0_axes == (0.0, 0.0, 0.0)
+        assert p.coupling_sq_axes == pytest.approx((4e30, 0.0, 0.0))
+
+    def test_per_axis_ccpr_axes_values(self):
+        qx = complex(-1.0e13, -2.0e15)
+        qy = complex(-2.0e13, -1.5e15)
+        rx = complex(1.0e14, 5.0e14)
+        ry = complex(-3.0e14, 2.0e14)
+        p = CCPRPole(pole=(qx, qy, qy), residue=(rx, ry, ry))
+        assert not p.is_isotropic
+        assert p.omega_0_axes[0] == pytest.approx(abs(qx))
+        assert p.omega_0_axes[1] == pytest.approx(abs(qy))
+        assert p.gamma_axes[0] == pytest.approx(-2.0 * qx.real)
+        assert p.coupling_sq_axes[1] == pytest.approx(-2.0 * (ry * qy.conjugate()).real)
+        assert p.coupling_edot_axes[0] == pytest.approx(2.0 * rx.real)
+        assert p.coupling_edot_axes[1] == pytest.approx(2.0 * ry.real)
+
+    def test_scalar_accessors_raise_for_per_axis_pole(self):
+        p = LorentzPole(resonance_frequency=(1e15, 2e15, 3e15), damping=1e13, delta_epsilon=2.0)
+        with pytest.raises(ValueError, match="omega_0_axes"):
+            _ = p.omega_0
+        with pytest.raises(ValueError, match="coupling_sq_axes"):
+            _ = p.coupling_sq
+        # damping is uniform, so its scalar accessor still works
+        assert p.gamma == 1e13
+
+    def test_invalid_tuple_length_raises(self):
+        p = LorentzPole(resonance_frequency=(1e15, 2e15), damping=1e13, delta_epsilon=2.0)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="3-tuple"):
+            _ = p.omega_0_axes
+
+    def test_model_is_isotropic(self):
+        iso = DispersionModel(poles=(LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0),))
+        aniso = DispersionModel(poles=(DrudePole(plasma_frequency=(2e15, 0.0, 0.0), damping=1e13),))
+        assert iso.is_isotropic
+        assert not aniso.is_isotropic
+
+    def test_susceptibility_axes_matches_scalar_for_isotropic(self):
+        m = DispersionModel(poles=(LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0),))
+        for omega in (0.5e15, 1.5e15):
+            chi_axes = m.susceptibility_axes(omega)
+            chi = m.susceptibility(omega)
+            assert chi_axes[0] == chi
+            assert chi_axes[1] == chi
+            assert chi_axes[2] == chi
+
+    def test_susceptibility_raises_for_anisotropic_model(self):
+        m = DispersionModel(poles=(DrudePole(plasma_frequency=(2e15, 0.0, 0.0), damping=1e13),))
+        with pytest.raises(ValueError, match="susceptibility_axes"):
+            m.susceptibility(1e15)
+        with pytest.raises(ValueError, match="susceptibility_axes"):
+            m.permittivity(1e15)
+
+    def test_per_axis_susceptibility_matches_independent_models(self):
+        # A per-axis model must equal three independent isotropic models per axis.
+        w0 = (1e15, 2e15, 1.5e15)
+        g = (1e13, 3e13, 2e13)
+        de = (2.0, 0.5, 1.0)
+        m = DispersionModel(poles=(LorentzPole(resonance_frequency=w0, damping=g, delta_epsilon=de),))
+        for omega in (0.7e15, 1.8e15):
+            chi_axes = m.susceptibility_axes(omega)
+            for ax in range(3):
+                ref = DispersionModel(
+                    poles=(LorentzPole(resonance_frequency=w0[ax], damping=g[ax], delta_epsilon=de[ax]),)
+                )
+                assert chi_axes[ax] == pytest.approx(ref.susceptibility(omega), rel=1e-12)
+
+    def test_zero_coupling_axis_contributes_zero(self):
+        m = DispersionModel(poles=(LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=(2.0, 0.0, 0.0)),))
+        chi_axes = m.susceptibility_axes(1.2e15)
+        assert chi_axes[0] != 0.0
+        assert chi_axes[1] == 0.0
+        assert chi_axes[2] == 0.0
+
+    def test_permittivity_axes_with_tuple_eps_inf(self):
+        m = DispersionModel(poles=(DrudePole(plasma_frequency=(2e15, 0.0, 0.0), damping=1e13),))
+        eps = m.permittivity_axes(1e15, eps_inf=(2.0, 3.0, 4.0))
+        chi = m.susceptibility_axes(1e15)
+        assert eps[0] == pytest.approx(2.0 + chi[0])
+        assert eps[1] == pytest.approx(3.0)
+        assert eps[2] == pytest.approx(4.0)
+
+
+class TestPerAxisCoefficients:
+    def test_per_axis_coefficient_shapes_and_closed_form(self):
+        w0 = (1e15, 2e15, 3e15)
+        g = (1e13, 2e13, 3e13)
+        de = (1.0, 2.0, 3.0)
+        p = LorentzPole(resonance_frequency=w0, damping=g, delta_epsilon=de)
+        dt = 4e-18
+        c1, c2, c3, c4 = compute_pole_coefficients_per_axis((p,), dt=dt)
+        assert c1.shape == (1, 3)
+        for ax in range(3):
+            denom = 1.0 + 0.5 * g[ax] * dt
+            assert c1[0, ax] == pytest.approx((2.0 - w0[ax] ** 2 * dt**2) / denom, rel=1e-12)
+            assert c2[0, ax] == pytest.approx(-(1.0 - 0.5 * g[ax] * dt) / denom, rel=1e-12)
+            assert c3[0, ax] == pytest.approx((de[ax] * w0[ax] ** 2 * dt**2) / denom, rel=1e-12)
+            assert c4[0, ax] == 0.0
+
+    def test_empty_poles_return_empty_arrays(self):
+        c1, _c2, _c3, c4 = compute_pole_coefficients_per_axis((), dt=1e-17)
+        assert c1.shape == (0, 3)
+        assert c4.shape == (0, 3)
+
+    def test_wrapper_matches_per_axis_for_isotropic(self):
+        poles = (
+            LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0),
+            DrudePole(plasma_frequency=2e15, damping=5e13),
+        )
+        dt = 4e-18
+        c1s, c2s, c3s, c4s = compute_pole_coefficients(poles, dt=dt)
+        c1a, c2a, c3a, c4a = compute_pole_coefficients_per_axis(poles, dt=dt)
+        assert c1s.shape == (2,)
+        for scalar, axes in ((c1s, c1a), (c2s, c2a), (c3s, c3a), (c4s, c4a)):
+            assert np.array_equal(scalar, axes[:, 0])
+            assert np.array_equal(axes[:, 0], axes[:, 1])
+            assert np.array_equal(axes[:, 0], axes[:, 2])
+
+    def test_wrapper_raises_for_per_axis_pole(self):
+        p = DrudePole(plasma_frequency=(2e15, 0.0, 0.0), damping=1e13)
+        with pytest.raises(ValueError, match="per-axis"):
+            compute_pole_coefficients((p,), dt=1e-17)
+
+    def test_per_axis_stability_check_names_axis(self):
+        # gamma * dt >= 2 only on the y axis must raise and identify the axis.
+        p = LorentzPole(resonance_frequency=1e15, damping=(1e13, 3e17, 1e13), delta_epsilon=1.0)
+        with pytest.raises(ValueError, match="axis y"):
+            compute_pole_coefficients_per_axis((p,), dt=1e-17)
+
+    def test_eps_spectrum_averages_component_axis(self):
+        # With a 3-component coefficient axis the spectrum helper must average
+        # the per-axis susceptibilities (mirroring its eps_inf reduction).
+        p = LorentzPole(resonance_frequency=(1e15, 2e15, 1.5e15), damping=1e13, delta_epsilon=(2.0, 1.0, 0.5))
+        dt = 4e-18
+        c1, c2, c3, c4 = compute_pole_coefficients_per_axis((p,), dt=dt)
+        # shape (num_poles, 3, 1) with a single spatial cell
+        c1a, c2a, c3a, c4a = (x[:, :, None] for x in (c1, c2, c3, c4))
+        eps_inf = 2.25
+        inv_eps = np.full((1, 1), 1.0 / eps_inf)
+        omegas = np.array([0.7e15, 1.9e15])
+        eps = compute_eps_spectrum_from_coefficients(c1a, c2a, c3a, inv_eps, omegas, dt, c4=c4a)
+        m = DispersionModel(poles=(p,))
+        for i, omega in enumerate(omegas):
+            chi_axes = m.susceptibility_axes(float(omega))
+            expected = eps_inf + sum(chi_axes) / 3.0
+            assert eps[i] == pytest.approx(expected, rel=1e-9)
+
+
+class TestAllowedDispersiveCoefficientsPerAxis:
+    def test_three_component_output(self):
+        mats = {
+            "air": Material(permittivity=1.0),
+            "hbn_like": Material(
+                permittivity=(4.9, 4.9, 2.9),
+                dispersion=DispersionModel(
+                    poles=(
+                        LorentzPole(
+                            resonance_frequency=(2.6e14, 2.6e14, 1.5e14),
+                            damping=(9e11, 9e11, 7e11),
+                            delta_epsilon=(2.0, 2.0, 0.5),
+                        ),
+                    )
+                ),
+            ),
+        }
+        c1, _c2, c3, _c4 = compute_allowed_dispersive_coefficients(mats, dt=1e-17, max_num_poles=1, num_components=3)
+        assert c1.shape == (2, 1, 3)
+        # air row is all zero
+        assert np.all(c1[0] == 0.0)
+        # per-axis columns differ for the anisotropic material
+        assert c3[1, 0, 0] != c3[1, 0, 2]
+
+    def test_num_components_one_with_anisotropic_material_raises(self):
+        mats = {
+            "aniso": Material(
+                permittivity=1.0,
+                dispersion=DispersionModel(poles=(DrudePole(plasma_frequency=(2e15, 0.0, 0.0), damping=1e13),)),
+            ),
+        }
+        with pytest.raises(ValueError, match="isotropic dispersion"):
+            compute_allowed_dispersive_coefficients(mats, dt=1e-17, max_num_poles=1, num_components=1)
+
+    def test_invalid_num_components_raises(self):
+        with pytest.raises(ValueError, match="num_components"):
+            compute_allowed_dispersive_coefficients({}, dt=1e-17, max_num_poles=0, num_components=2)

--- a/tests/unit/test_materials.py
+++ b/tests/unit/test_materials.py
@@ -846,3 +846,47 @@ class TestLossyMaterialConstructors:
 
         with pytest.raises(ValueError):
             Material.from_complex_permittivity(((2.0 + 0.1j, 0.0, 0.0),), wavelength=self._WL)
+
+
+class TestStaticNegativePermittivityWarning:
+    def test_negative_diagonal_entry_warns(self):
+        with pytest.warns(UserWarning, match="unconditionally unstable"):
+            Material(permittivity=(-2.0, 1.0, 1.0))
+
+    def test_zero_diagonal_entry_warns(self):
+        with pytest.warns(UserWarning, match="unconditionally unstable"):
+            Material(permittivity=0.0)
+
+    def test_negative_eps_inf_warns_even_with_dispersion(self):
+        from fdtdx.dispersion import DispersionModel, DrudePole
+
+        disp = DispersionModel(poles=(DrudePole(plasma_frequency=2e15, damping=1e13),))
+        with pytest.warns(UserWarning, match="unconditionally unstable"):
+            Material(permittivity=-2.0, dispersion=disp)
+
+    def test_positive_permittivity_does_not_warn(self):
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Material(permittivity=2.25)
+            Material(permittivity=(2.0, 3.0, 4.0))
+            # negative off-diagonals of a positive-definite tensor are fine
+            Material(permittivity=(2.0, -0.5, 0.0, -0.5, 2.0, 0.0, 0.0, 0.0, 2.0))
+
+
+class TestHasIsotropicDispersion:
+    def test_non_dispersive_material(self):
+        assert Material(permittivity=2.25).has_isotropic_dispersion
+
+    def test_isotropic_dispersion(self):
+        from fdtdx.dispersion import DispersionModel, LorentzPole
+
+        disp = DispersionModel(poles=(LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0),))
+        assert Material(permittivity=2.25, dispersion=disp).has_isotropic_dispersion
+
+    def test_per_axis_dispersion(self):
+        from fdtdx.dispersion import DispersionModel, DrudePole
+
+        disp = DispersionModel(poles=(DrudePole(plasma_frequency=(2e15, 0.0, 0.0), damping=1e13),))
+        assert not Material(permittivity=2.25, dispersion=disp).has_isotropic_dispersion


### PR DESCRIPTION
This adds per-axis pole parameters to the dispersion models, enabling diagonally anisotropic dispersion, and with it natural hyperbolic materials (hBN and friends), where Re(ε) is negative along some crystal axes and positive along others inside a Reststrahlen band. Since a static negative permittivity is unconditionally unstable in explicit FDTD, such materials can only be modelled through dispersion, which so far applied one pole set to all three field components.

Every pole parameter now accepts either a scalar (isotropic, behaviour unchanged) or an (x, y, z) tuple, following the parameter-widening pattern from #75:

```
# hBN: different phonon resonances in-plane vs out-of-plane
hbn = fdtdx.Material(
    permittivity=(4.87, 4.87, 2.95),  # eps_inf per axis
    dispersion=fdtdx.DispersionModel(poles=(
        fdtdx.LorentzPole(
            resonance_frequency=(w_to_perp, w_to_perp, w_to_par),
            damping=(g_perp, g_perp, g_par),
            delta_epsilon=(de_perp, de_perp, de_par),
        ),
    )),
```
A pole acting on a single axis is expressed by zeroing its strength on the others, e.g. DrudePole(plasma_frequency=(wp, 0.0, 0.0), damping=g) for a medium that is metallic only along x.

## Implementation notes:

- The dispersive coefficient arrays get a conditional component axis: `(num_poles, 1, ...)` as before when all dispersion is isotropic (no memory or behaviour change), `(num_poles, 3, ...)` when any material has per-axis poles — mirroring the existing 1/3/9 material array sizing.
- The E-field update and its time-reversed counterpart are already elementwise over that axis, so the update equations are untouched (comment changes only). Reversible autodiff works unchanged.
- New `compute_pole_coefficients_per_axis` returns `(n_poles, 3)` coefficients; the existing `compute_pole_coefficients` and the scalar pole accessors are bit-identical for isotropic poles and raise a descriptive error for per-axis ones. `DispersionModel.susceptibility_axes` / `permittivity_axes` evaluate per-axis spectra.
- `Material` now warns when a static (non-dispersive) diagonal permittivity entry is ≤ 0, since that diverges silently at runtime.

## Two fixes found while testing:

- Dispersion combined with a fully anisotropic (off-diagonal) conductivity tensor silently skipped the ADE update - the full-tensor update branch has no polarisation step and the existing guard only checked the permittivity. This now raises `NotImplementedError` like the permittivity case.
- `has_dispersive_edot` and `compute_eps_spectrum_from_coefficients` assumed the size-1 component axis. The broadband TFSF impedance filter now also logs a warning in per-axis-dispersive media (it uses a component-averaged ε(ω); the carrier-frequency correction stays exact per component).

## Validation:

- A per-axis Lorentz slab matches the equivalent isotropic run per polarization (the arithmetic is identical, the coefficients just stop broadcasting).
- x/y-polarised transmission through a per-axis Lorentz half-space matches Fresnel computed from the per-axis susceptibility, at the same tolerance as the existing isotropic dispersion tests.
- Hyperbolic sanity check: a per-axis Drude half-space with Re(ε_x) < 0 < ε_y reflects x-polarization like a metal and transmits y-polarization per Fresnel.
- Reversible and checkpointed gradients agree (float64, rel < 1e-5) with per-axis coefficients; the time-reversal round-trip reconstructs E/H and the polarization state exactly.
- Full unit + integration suite passes; isotropic setups produce identical arrays.

Example: `examples/hyperbolic_dispersive_slab.py` — per-axis Drude, ε(ω) plot per axis, polarization-selective transmission through the hyperbolic band.

Out of scope: dispersion with off-diagonal (rotated) tensors, the existing `NotImplementedError` stays in place (and now also covers off-diagonal σ). Optical axes must align with the grid.

Related: #4, #75, #204, #294.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for diagonally anisotropic dispersive materials with per-axis Lorentz, Drude, and CCPR parameters.
  * Added public per-axis susceptibility, permittivity, and pole-coefficient calculations.
  * Added an example demonstrating hyperbolic dispersive media and polarization-selective transmission.

* **Bug Fixes**
  * Improved validation and warnings for unstable permittivity and unsupported anisotropic conductivity combinations.
  * Added support for per-axis dispersion across material initialization, interpolation, and simulations.

* **Documentation**
  * Updated API documentation, usage guidance, and shape descriptions for per-axis dispersion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->