### PR TITLE
Perf: region-restricted detector recording + opt-in phasor DFT subsampling

### DIFF
--- a/src/fdtdx/core/physics/curl.py
+++ b/src/fdtdx/core/physics/curl.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 from fdtdx.config import SimulationConfig
 from fdtdx.constants import c as c0
 from fdtdx.fdtd.container import ObjectContainer, PmlAuxField
+from fdtdx.typing import SliceTuple3D
 
 
 def _metric_scale(
@@ -43,12 +44,24 @@ def _backward_edge_average(
     previous: jax.Array,
     config: SimulationConfig | None,
     axis: int,
+    region_slice: SliceTuple3D | None = None,
 ) -> jax.Array:
     """Interpolate center-staggered samples back to an edge on a rectilinear grid.
 
     Uniform grids use the historical arithmetic mean.  On stretched grids the
     target edge is not halfway between neighboring cell centers, so the average
     is weighted by the half-widths of the cells on each side of the edge.
+
+    Args:
+        current: Center-staggered samples of the cells on the target edges.
+        previous: Center-staggered samples of the neighboring cells behind the edges.
+        config: Optional simulation configuration carrying the grid.
+        axis: Grid axis along which the interpolation is performed.
+        region_slice: Grid slice ``((x0, x1), (y0, y1), (z0, z1))`` covered by the inputs
+            when they are a sub-block of the domain. The cell widths are sliced to match.
+
+    Returns:
+        Edge-interpolated samples of the same shape as ``current``.
     """
     if config is None or not config.has_nonuniform_grid:
         return 0.5 * (current + previous)
@@ -57,6 +70,10 @@ def _backward_edge_average(
     assert grid is not None
     widths = grid.cell_widths(axis)
     previous_widths = jnp.concatenate([widths[:1], widths[:-1]])
+    if region_slice is not None:
+        start, stop = region_slice[axis]
+        widths = widths[start:stop]
+        previous_widths = previous_widths[start:stop]
     current_half_width = 0.5 * widths
     previous_half_width = 0.5 * previous_widths
     broadcast_shape = [1, 1, 1]
@@ -70,6 +87,7 @@ def interpolate_fields(
     E_pad: jax.Array,
     H_pad: jax.Array,
     config: SimulationConfig | None = None,
+    region_slice: SliceTuple3D | None = None,
 ) -> tuple[jax.Array, jax.Array]:
     """Interpolates E and H fields onto the E_z Yee grid point (i, j, k+½).
 
@@ -92,6 +110,9 @@ def interpolate_fields(
         config: Optional simulation configuration.  When it carries a
             non-uniform ``RectilinearGrid``, center-to-edge interpolations use local
             physical distances instead of equal weights.
+        region_slice: Grid slice ``((x0, x1), (y0, y1), (z0, z1))`` covered by the inputs
+            when they are a haloed sub-block of the domain instead of the whole padded
+            domain. The interpolation weights are sliced to match.
 
     Returns:
         Tuple of (E_interp, H_interp), each of shape (3, Nx, Ny, Nz)
@@ -105,12 +126,14 @@ def interpolate_fields(
         previous=E_x[:-2, 1:-1, 1:-1],
         config=config,
         axis=0,
+        region_slice=region_slice,
     )
     E_x_upper_z = _backward_edge_average(
         current=E_x[1:-1, 1:-1, 2:],
         previous=E_x[:-2, 1:-1, 2:],
         config=config,
         axis=0,
+        region_slice=region_slice,
     )
     E_x = (E_x_lower_z + E_x_upper_z) / 2.0
 
@@ -120,12 +143,14 @@ def interpolate_fields(
         previous=E_y[1:-1, :-2, 1:-1],
         config=config,
         axis=1,
+        region_slice=region_slice,
     )
     E_y_upper_z = _backward_edge_average(
         current=E_y[1:-1, 1:-1, 2:],
         previous=E_y[1:-1, :-2, 2:],
         config=config,
         axis=1,
+        region_slice=region_slice,
     )
     E_y = (E_y_lower_z + E_y_upper_z) / 2.0
 
@@ -138,6 +163,7 @@ def interpolate_fields(
         previous=H_x[1:-1, :-2, 1:-1],
         config=config,
         axis=1,
+        region_slice=region_slice,
     )
 
     # H_y: (i+½, j, k+½) → (i, j, k+½): x backward only
@@ -146,6 +172,7 @@ def interpolate_fields(
         previous=H_y[:-2, 1:-1, 1:-1],
         config=config,
         axis=0,
+        region_slice=region_slice,
     )
 
     # H_z: (i+½, j+½, k) → (i, j, k+½): x backward, y backward, z forward
@@ -154,6 +181,7 @@ def interpolate_fields(
         previous=H_z[:-2, 1:-1, 1:-1],
         config=config,
         axis=0,
+        region_slice=region_slice,
     )
     H_z_lower_z_xy = _backward_edge_average(
         current=H_z_lower_z_x,
@@ -162,15 +190,18 @@ def interpolate_fields(
             previous=H_z[:-2, :-2, 1:-1],
             config=config,
             axis=0,
+            region_slice=region_slice,
         ),
         config=config,
         axis=1,
+        region_slice=region_slice,
     )
     H_z_upper_z_x = _backward_edge_average(
         current=H_z[1:-1, 1:-1, 2:],
         previous=H_z[:-2, 1:-1, 2:],
         config=config,
         axis=0,
+        region_slice=region_slice,
     )
     H_z_upper_z_xy = _backward_edge_average(
         current=H_z_upper_z_x,
@@ -179,9 +210,11 @@ def interpolate_fields(
             previous=H_z[:-2, :-2, 2:],
             config=config,
             axis=0,
+            region_slice=region_slice,
         ),
         config=config,
         axis=1,
+        region_slice=region_slice,
     )
     H_z = (H_z_lower_z_xy + H_z_upper_z_xy) / 2.0
 

--- a/src/fdtdx/fdtd/update.py
+++ b/src/fdtdx/fdtd/update.py
@@ -15,7 +15,7 @@ from fdtdx.fdtd.misc import (
     compute_anisotropic_update_matrices,
     compute_anisotropic_update_matrices_reverse,
 )
-from fdtdx.objects.detectors.detector import Detector
+from fdtdx.objects.detectors.detector import Detector, DetectorState
 
 
 def _source_uses_default_always_on_switch(source) -> bool:
@@ -862,6 +862,36 @@ def update_H_reverse(
     return arrays
 
 
+def _check_updated_state_layout(detector: Detector, old: DetectorState, new: DetectorState) -> None:
+    """Checks that a detector update kept the layout of its initialized state.
+
+    A mismatch usually means the update sliced `self.grid_slice` on fields that were already
+    restricted to the detector region (double slicing).
+
+    Args:
+        detector (Detector): Detector whose state was updated.
+        old (DetectorState): Detector state before the update.
+        new (DetectorState): Detector state returned by the update.
+
+    Raises:
+        Exception: If the updated state has different keys, shapes or dtypes than before.
+    """
+    problems = [f"state keys changed from {sorted(old)} to {sorted(new)}"] if set(old) != set(new) else []
+    problems += [
+        f"'{k}' expected shape {jnp.shape(old[k])} / dtype {jnp.result_type(old[k])}, "
+        f"got {jnp.shape(new[k])} / {jnp.result_type(new[k])}"
+        for k in old
+        if k in new and (jnp.shape(old[k]) != jnp.shape(new[k]) or jnp.result_type(old[k]) != jnp.result_type(new[k]))
+    ]
+    if problems:
+        raise Exception(
+            f"Detector '{detector.name}': update() returned a state that does not match its initialized "
+            f"layout: {'; '.join(problems)}. Note that fields and materials are passed to Detector.update() "
+            "already restricted to the detector's grid_slice, so slicing self.grid_slice inside update() "
+            "(double slicing) is the most common cause."
+        )
+
+
 def update_detector_states(
     time_step: jax.Array,
     arrays: ArrayContainer,
@@ -872,10 +902,10 @@ def update_detector_states(
 ) -> ArrayContainer:
     """Updates detector states based on current field values.
 
-    Handles field interpolation for accurate detector measurements. By default,
-    interpolation is disabled for performance during optimization, but can be
-    enabled for final evaluation. Interpolation is needed due to the staggered
-    nature of E and H fields on the Yee grid.
+    Handles field interpolation for accurate detector measurements. Interpolation
+    is enabled by default, but can be disabled per detector for performance during
+    optimization. Interpolation is needed due to the staggered nature of E and H
+    fields on the Yee grid.
 
     Args:
         time_step (jax.Array): Current simulation time step
@@ -886,34 +916,76 @@ def update_detector_states(
 
     Returns:
         ArrayContainer: Updated ArrayContainer with new detector states
+
+    Notes:
+        Each detector receives fields and materials already restricted to its `grid_slice`. Since
+        the interpolation stencil only reaches the neighboring cell, a strictly interior detector
+        is interpolated over its region plus a one-cell halo; the full-domain interpolation is
+        only built as a shared fallback for detectors touching a domain edge, where the boundary
+        padding matters.
     """
-    E_pad = pad_fields_for_boundaries(arrays.fields.E, objects, config)
-    H_avg_pad = pad_fields_for_boundaries((H_prev + arrays.fields.H) / 2, objects, config)
-    interpolated_E, interpolated_H = interpolate_fields(
-        E_pad=E_pad,
-        H_pad=H_avg_pad,
-        config=config,
-    )
-
-    def helper_fn(E_input, H_input, detector: Detector):
-        return detector.update(
-            time_step=time_step,
-            E=E_input,
-            H=H_input,
-            state=arrays.detector_states[detector.name],
-            inv_permittivity=arrays.inv_permittivities,
-            inv_permeability=arrays.inv_permeabilities,
-        )
-
     state = arrays.detector_states
     to_update = objects.backward_detectors if inverse else objects.forward_detectors
+    if not to_update:
+        return arrays
+
+    grid_shape = objects.volume.grid_shape
+
+    def is_interior(detector: Detector) -> bool:
+        # The co-location stencil reads domain indices [s-1 .. e]; interior iff that stays in-bounds.
+        return all(s >= 1 and e <= grid_shape[a] - 1 for a, (s, e) in enumerate(detector.grid_slice_tuple))
+
+    # The full-domain interpolation is only needed for exact detectors whose stencil reaches a domain edge.
+    full = None
+    if any(d.exact_interpolation and not is_interior(d) for d in to_update):
+        full = interpolate_fields(
+            E_pad=pad_fields_for_boundaries(arrays.fields.E, objects, config),
+            H_pad=pad_fields_for_boundaries((H_prev + arrays.fields.H) / 2, objects, config),
+            config=config,
+        )
+
+    def helper_fn(E: jax.Array, H: jax.Array, H_prev: jax.Array, detector: Detector) -> DetectorState:
+        gs = detector.grid_slice
+        if not detector.exact_interpolation:
+            E_reg, H_reg = E[:, *gs], H[:, *gs]
+        elif is_interior(detector):
+            block = (slice(None), *(slice(s - 1, e + 1) for (s, e) in detector.grid_slice_tuple))
+            H_avg = (H_prev[block] + H[block]) / 2
+            E_reg, H_reg = interpolate_fields(E[block], H_avg, config=config, region_slice=detector.grid_slice_tuple)
+        else:
+            assert full is not None  # built above whenever an edge-touching exact detector exists
+            E_reg, H_reg = full[0][:, *gs], full[1][:, *gs]
+        # inv_permeabilities is a plain scalar when all materials are non-magnetic.
+        inv_mu = arrays.inv_permeabilities
+        try:
+            new_state = detector.update(
+                time_step=time_step,
+                E=E_reg,
+                H=H_reg,
+                state=state[detector.name],
+                inv_permittivity=arrays.inv_permittivities[:, *gs],
+                inv_permeability=inv_mu[:, *gs] if isinstance(inv_mu, jax.Array) and inv_mu.ndim > 0 else inv_mu,
+            )
+        except Exception as e:
+            raise Exception(
+                f"Detector '{detector.name}': update() raised while recording (see exception above). Fields "
+                "and materials are passed to Detector.update() already restricted to the detector's "
+                "grid_slice, so slicing self.grid_slice inside update() (double slicing) is a common cause "
+                "of shape errors here."
+            ) from e
+        _check_updated_state_layout(detector, state[detector.name], new_state)
+        return new_state
+
     for d in to_update:
+        # E already lives at the detector's integer time step; H lives at half steps, so exact
+        # detectors time-center H as (H_prev + H) / 2 on their region inside the branch.
         state[d.name] = jax.lax.cond(
             d._is_on_at_time_step_arr[time_step],
             helper_fn,
-            lambda e, h, _: state[d.name],
-            interpolated_E if d.exact_interpolation else arrays.fields.E,
-            interpolated_H if d.exact_interpolation else arrays.fields.H,
+            lambda e, h, h_prev, detector: state[detector.name],
+            arrays.fields.E,
+            arrays.fields.H,
+            H_prev,
             d,
         )
     arrays = arrays.aset("detector_states", state)

--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -248,6 +248,10 @@ class Detector(SimulationObject, ABC):
     ) -> DetectorState:
         """Updates detector state with current field values.
 
+        Note that fields and materials arrive already restricted to this detector's ``grid_slice``
+        and, when ``exact_interpolation`` is set, already co-located onto the E_z Yee point, so
+        implementations must not slice ``grid_slice`` again.
+
         Args:
             time_step (jax.Array): Current simulation time step.
             E (jax.Array): Electric field array.

--- a/src/fdtdx/objects/detectors/diffractive.py
+++ b/src/fdtdx/objects/detectors/diffractive.py
@@ -137,13 +137,9 @@ class DiffractiveDetector(Detector):
         plane_dims = get_transverse_axes(prop_axis)
         Nx, Ny = [self.grid_shape[i] for i in plane_dims]
 
-        # Get current field values at the specified plane
-        cur_E = E[:, *self.grid_slice]  # Shape: (3, nx, ny, 1)
-        cur_H = H[:, *self.grid_slice]  # Shape: (3, nx, ny, 1)
-
         # Remove the normal axis dimension since it should be 1
-        cur_E = jnp.squeeze(cur_E, axis=prop_axis + 1)  # Shape: (3, nx, ny)
-        cur_H = jnp.squeeze(cur_H, axis=prop_axis + 1)  # Shape: (3, nx, ny)
+        cur_E = jnp.squeeze(E, axis=prop_axis + 1)  # Shape: (3, nx, ny)
+        cur_H = jnp.squeeze(H, axis=prop_axis + 1)  # Shape: (3, nx, ny)
 
         transverse_centers = self._transverse_centers(plane_dims)
         if transverse_centers is None:

--- a/src/fdtdx/objects/detectors/energy.py
+++ b/src/fdtdx/objects/detectors/energy.py
@@ -91,19 +91,11 @@ class EnergyDetector(Detector):
         inv_permittivity: jax.Array,
         inv_permeability: jax.Array | float,
     ) -> DetectorState:
-        cur_E = E[:, *self.grid_slice]
-        cur_H = H[:, *self.grid_slice]
-        cur_inv_permittivity = inv_permittivity[:, *self.grid_slice]
-        if isinstance(inv_permeability, jax.Array) and inv_permeability.ndim > 0:
-            cur_inv_permeability = inv_permeability[:, *self.grid_slice]
-        else:
-            cur_inv_permeability = inv_permeability
-
         energy = compute_energy(
-            E=cur_E,
-            H=cur_H,
-            inv_permittivity=cur_inv_permittivity,
-            inv_permeability=cur_inv_permeability,
+            E=E,
+            H=H,
+            inv_permittivity=inv_permittivity,
+            inv_permeability=inv_permeability,
         )
 
         arr_idx = self._time_step_to_arr_idx[time_step]

--- a/src/fdtdx/objects/detectors/field.py
+++ b/src/fdtdx/objects/detectors/field.py
@@ -39,7 +39,6 @@ class FieldDetector(Detector):
     ) -> DetectorState:
         del inv_permeability, inv_permittivity
 
-        E, H = E[:, *self.grid_slice], H[:, *self.grid_slice]
         fields = []
         if "Ex" in self.components:
             fields.append(E[0])

--- a/src/fdtdx/objects/detectors/field_projection.py
+++ b/src/fdtdx/objects/detectors/field_projection.py
@@ -354,14 +354,9 @@ class FieldProjectionDetectorBase(PhasorDetector):
 
         del inv_permeability, inv_permittivity
         time_passed = time_step * self._config.time_step_duration
-        if self.scaling_mode == "continuous":
-            static_scale = 2 / self.num_time_steps_recorded
-        elif self.scaling_mode == "pulse":
-            static_scale = 1
-        else:
-            raise Exception(f"Invalid scaling mode: {self.scaling_mode=}")
+        static_scale = self._static_scale()
 
-        fields = jnp.concatenate((E[:, *self.grid_slice], H[:, *self.grid_slice]), axis=0)
+        fields = jnp.concatenate((E, H), axis=0)
         phase_angles = self._angular_frequencies * time_passed
         phasors = jnp.exp(1j * phase_angles)
         phasors = phasors.reshape((len(self._angular_frequencies),) + (1,) * fields.ndim)

--- a/src/fdtdx/objects/detectors/phasor.py
+++ b/src/fdtdx/objects/detectors/phasor.py
@@ -1,11 +1,19 @@
-from typing import Literal, Sequence
+import math
+from typing import Literal, Self, Sequence
 
 import jax
 import jax.numpy as jnp
+from loguru import logger
 
-from fdtdx.core.jax.pytrees import autoinit, field, frozen_field
+from fdtdx.config import SimulationConfig
+from fdtdx.core.jax.pytrees import autoinit, field, frozen_field, frozen_private_field
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.detectors.detector import Detector, DetectorState
+from fdtdx.typing import SliceTuple3D
+
+# Oversampling margin for the "auto" DFT subsampling stride: keep about this many samples per
+# period of the highest recorded frequency.
+_DFT_OVERSAMPLE = 12
 
 
 @autoinit
@@ -41,6 +49,15 @@ class PhasorDetector(Detector):
     #: In pulse mode, the result is not scaled.
     scaling_mode: Literal["continuous", "pulse"] = frozen_field(default="continuous")
 
+    #: Subsampling stride for the phasor DFT. Only every stride-th active time step is recorded,
+    #: with the kept samples rescaled to match every-step recording. If set to "auto", the stride
+    #: is derived from the highest recorded frequency and the time step duration. Defaults to 1,
+    #: which records every active time step.
+    dft_subsample: int | Literal["auto"] = frozen_field(default=1)
+
+    #: Concrete recording stride, resolved from dft_subsample at placement (1 = every active step).
+    _dft_stride: int = frozen_private_field(default=1)
+
     def __post_init__(
         self,
     ):
@@ -51,6 +68,70 @@ class PhasorDetector(Detector):
     def _angular_frequencies(self) -> jax.Array:
         freqs = [wc.get_frequency() for wc in self.wave_characters]
         return 2 * jnp.pi * jnp.array(freqs)
+
+    def _resolve_dft_stride(self) -> int:
+        """Resolves dft_subsample to a concrete stride (>= 1). Requires the detector to be placed."""
+        sub = self.dft_subsample
+        if isinstance(sub, str):
+            if sub != "auto":
+                raise Exception(f"Invalid dft_subsample: {sub!r}")
+            dt = float(self._config.time_step_duration)
+            f_max = max((abs(float(wc.get_frequency())) for wc in self.wave_characters), default=0.0)
+            if f_max <= 0.0 or dt <= 0.0:
+                return 1
+            return max(1, math.floor(1.0 / (_DFT_OVERSAMPLE * f_max * dt)))
+        return max(1, int(sub))
+
+    def _calculate_on_list(self) -> list[bool]:
+        # Thin the base on-list to every stride-th active step; num_time_steps_recorded then
+        # reflects the kept count.
+        on_list = super()._calculate_on_list()
+        stride = self._resolve_dft_stride()
+        if stride <= 1:
+            return on_list
+        active = [t for t, on in enumerate(on_list) if on]
+        kept = [False] * len(on_list)
+        for t in active[::stride]:
+            kept[t] = True
+        return kept
+
+    def place_on_grid(
+        self: Self,
+        grid_slice_tuple: SliceTuple3D,
+        config: SimulationConfig,
+        key: jax.Array,
+    ) -> Self:
+        self = super().place_on_grid(grid_slice_tuple=grid_slice_tuple, config=config, key=key)
+        stride = self._resolve_dft_stride()
+        if stride > 1:
+            # Warn about explicit strides close to the Nyquist limit ("auto" never trips this).
+            dt = float(self._config.time_step_duration)
+            f_max = max((abs(float(wc.get_frequency())) for wc in self.wave_characters), default=0.0)
+            if stride * dt * f_max > 0.25:
+                logger.warning(
+                    f"Detector '{self.name}': dft_subsample={stride} leaves fewer than 4 samples per "
+                    f"period of the highest recorded frequency ({f_max:.3e} Hz); the phasor may alias. "
+                    'Reduce the stride or use dft_subsample="auto".'
+                )
+        # Store the concrete stride so update() reads a plain int (no host concretization under jit).
+        self = self.aset("_dft_stride", stride, create_new_ok=True)
+        return self
+
+    def _static_scale(self) -> float | int:
+        """Computes the static scale factor for the configured scaling mode.
+
+        In continuous mode, the result is scaled by 2 / N with N the number of recorded time
+        steps. In pulse mode, each kept sample is weighted by the dft_subsample stride so that
+        subsampled recording matches the every-step DFT sum.
+
+        Returns:
+            float | int: Scale factor applied to each recorded sample.
+        """
+        if self.scaling_mode == "continuous":
+            return 2 / self.num_time_steps_recorded
+        if self.scaling_mode == "pulse":
+            return self._dft_stride
+        raise Exception(f"Invalid scaling mode: {self.scaling_mode=}")
 
     def _num_latent_time_steps(self) -> int:
         return 1
@@ -76,14 +157,8 @@ class PhasorDetector(Detector):
     ) -> DetectorState:
         del inv_permeability, inv_permittivity
         time_passed = time_step * self._config.time_step_duration
-        if self.scaling_mode == "continuous":
-            static_scale = 2 / self.num_time_steps_recorded
-        elif self.scaling_mode == "pulse":
-            static_scale = 1
-        else:
-            raise Exception(f"Invalid scaling mode: {self.scaling_mode=}")
+        static_scale = self._static_scale()
 
-        E, H = E[:, *self.grid_slice], H[:, *self.grid_slice]
         fields = []
         if "Ex" in self.components:
             fields.append(E[0])

--- a/src/fdtdx/objects/detectors/poynting_flux.py
+++ b/src/fdtdx/objects/detectors/poynting_flux.py
@@ -109,10 +109,7 @@ class PoyntingFluxDetector(Detector):
         inv_permeability: jax.Array | float,
     ) -> DetectorState:
         del inv_permeability, inv_permittivity
-        cur_E = E[:, *self.grid_slice]
-        cur_H = H[:, *self.grid_slice]
-
-        pf = compute_poynting_flux(cur_E, cur_H).real
+        pf = compute_poynting_flux(E, H).real
         if not self.keep_all_components:
             pf = pf[self.propagation_axis]
         if self.direction == "-":

--- a/tests/integration/fdtd/test_detector_region_parity.py
+++ b/tests/integration/fdtd/test_detector_region_parity.py
@@ -88,9 +88,7 @@ def _configs():
     uniform = fdtdx.SimulationConfig(time=1e-13, grid=UniformGrid(spacing=_RES))
     widths = np.array([1.0, 1.4, 0.8, 1.2, 1.0, 1.5, 0.9, 1.3, 1.1, 0.7, 1.6, 1.0]) * _RES
     edges = jnp.asarray(np.concatenate([[0.0], np.cumsum(widths)]))
-    nonuniform = fdtdx.SimulationConfig(
-        time=1e-13, grid=RectilinearGrid(x_edges=edges, y_edges=edges, z_edges=edges)
-    )
+    nonuniform = fdtdx.SimulationConfig(time=1e-13, grid=RectilinearGrid(x_edges=edges, y_edges=edges, z_edges=edges))
     return {"uniform": uniform, "nonuniform": nonuniform}
 
 

--- a/tests/integration/fdtd/test_detector_region_parity.py
+++ b/tests/integration/fdtd/test_detector_region_parity.py
@@ -1,0 +1,117 @@
+"""End-to-end parity: region-restricted detector recording == full-domain interpolation + slice.
+
+For every detector kind, an interior detector recorded through ``update_detector_states`` (which now
+interpolates only over the detector's ``grid_slice`` + halo) must produce byte-for-byte the same
+state as the historical path: interpolate the whole domain, then slice the region into the
+detector's ``update``. Run on uniform and non-uniform grids.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import fdtdx
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
+from fdtdx.core.physics.curl import interpolate_fields
+from fdtdx.fdtd.update import pad_fields_for_boundaries, update_detector_states
+
+_N = 12  # cube side (cells)
+_RES = 50e-9
+_FREQ = fdtdx.constants.c / 1e-6
+
+
+def _detectors():
+    wave = fdtdx.WaveCharacter(frequency=_FREQ)
+    return [
+        fdtdx.PhasorDetector(name="phasor", partial_grid_shape=(4, 4, 4), wave_characters=(wave,), plot=False),
+        fdtdx.PhasorDetector(
+            name="phasor_reduced",
+            partial_grid_shape=(4, 4, 4),
+            wave_characters=(wave,),
+            reduce_volume=True,
+            plot=False,
+        ),
+        fdtdx.EnergyDetector(name="energy", partial_grid_shape=(4, 4, 4), plot=False),
+        fdtdx.EnergyDetector(name="energy_reduced", partial_grid_shape=(4, 4, 4), reduce_volume=True, plot=False),
+        fdtdx.PoyntingFluxDetector(name="poynting", partial_grid_shape=(4, 4, 1), direction="+", plot=False),
+        fdtdx.FieldDetector(name="field", partial_grid_shape=(4, 4, 4), plot=False),
+    ]
+
+
+def _build(config):
+    objects, constraints = [], []
+    volume = fdtdx.SimulationVolume(partial_grid_shape=(_N, _N, _N))
+    objects.append(volume)
+
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+        thickness=2,
+        override_types={f: "periodic" for f in ("min_x", "max_x", "min_y", "max_y", "min_z", "max_z")},
+    )
+    bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    objects.extend(bound_dict.values())
+    constraints.extend(c_list)
+
+    for det in _detectors():
+        # Centering a 4-cell (or 1-cell) detector in a 12-cell domain lands it strictly interior
+        # (cells ~4..8; halo stays in-bounds) on both uniform and non-uniform grids.
+        objects.append(det)
+        constraints.append(det.place_at_center(volume, axes=(0, 1, 2)))
+
+    key = jax.random.PRNGKey(0)
+    obj, arrays, params, config, _ = fdtdx.place_objects(
+        object_list=objects, config=config, constraints=constraints, key=key
+    )
+    arrays, obj, _ = fdtdx.apply_params(arrays, obj, params, key)
+    return obj, arrays, config
+
+
+def _reference_state(det, arrays, objects, config, H_prev, time_step):
+    """The historical full-domain path: pad + interpolate the whole domain, then slice the region."""
+    E_pad = pad_fields_for_boundaries(arrays.fields.E, objects, config)
+    H_avg_pad = pad_fields_for_boundaries((H_prev + arrays.fields.H) / 2, objects, config)
+    full_E, full_H = interpolate_fields(E_pad=E_pad, H_pad=H_avg_pad, config=config)
+    gs = det.grid_slice
+    inv_mu = arrays.inv_permeabilities
+    inv_mu_r = inv_mu[:, *gs] if isinstance(inv_mu, jax.Array) and inv_mu.ndim > 0 else inv_mu
+    return det.update(
+        time_step=time_step,
+        E=full_E[:, *gs],
+        H=full_H[:, *gs],
+        state=det.init_state(),
+        inv_permittivity=arrays.inv_permittivities[:, *gs],
+        inv_permeability=inv_mu_r,
+    )
+
+
+def _configs():
+    uniform = fdtdx.SimulationConfig(time=1e-13, grid=UniformGrid(spacing=_RES))
+    widths = np.array([1.0, 1.4, 0.8, 1.2, 1.0, 1.5, 0.9, 1.3, 1.1, 0.7, 1.6, 1.0]) * _RES
+    edges = jnp.asarray(np.concatenate([[0.0], np.cumsum(widths)]))
+    nonuniform = fdtdx.SimulationConfig(
+        time=1e-13, grid=RectilinearGrid(x_edges=edges, y_edges=edges, z_edges=edges)
+    )
+    return {"uniform": uniform, "nonuniform": nonuniform}
+
+
+@pytest.mark.parametrize("grid_kind", ["uniform", "nonuniform"])
+def test_region_recording_matches_full_domain(grid_kind):
+    obj, arrays, config = _build(_configs()[grid_kind])
+
+    # Drive with reproducible random fields so the interpolation actually varies across cells.
+    kE, kH, kHp = jax.random.split(jax.random.PRNGKey(1), 3)
+    shape = arrays.fields.E.shape
+    arrays = arrays.aset("fields->E", jax.random.normal(kE, shape, dtype=arrays.fields.E.dtype))
+    arrays = arrays.aset("fields->H", jax.random.normal(kH, shape, dtype=arrays.fields.H.dtype))
+    H_prev = jax.random.normal(kHp, shape, dtype=arrays.fields.H.dtype)
+    time_step = jnp.array(0)
+
+    # Region path (the implementation under test).
+    new_arrays = update_detector_states(time_step, arrays, obj, config, H_prev, inverse=False)
+
+    for det in obj.forward_detectors:
+        ref = _reference_state(det, arrays, obj, config, H_prev, time_step)
+        got = new_arrays.detector_states[det.name]
+        assert set(got) == set(ref)
+        for k in ref:
+            assert jnp.allclose(got[k], ref[k], atol=1e-6, rtol=1e-5), f"{det.name}:{k} mismatch ({grid_kind})"

--- a/tests/simulation/fdtd/test_detector_region.py
+++ b/tests/simulation/fdtd/test_detector_region.py
@@ -1,0 +1,132 @@
+"""Simulation-level checks for region-restricted detector recording.
+
+- Autodiff safety: a loss built on a detector's recorded output must produce a finite, nonzero
+  gradient w.r.t. ``inv_permittivities`` through ``run_fdtd`` (region recording is the path inverse
+  design relies on).
+- DFT subsampling physics: an auto-subsampled phasor must match every-step recording in a full
+  simulation (the deterministic single-tone version of this check lives in
+  tests/unit/objects/detectors/test_phasor_subsample.py::test_subsample_recovers_amplitude).
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import fdtdx
+from fdtdx.config import GradientConfig, SimulationConfig
+from fdtdx.constants import c as c0
+from fdtdx.core.grid import UniformGrid
+from fdtdx.fdtd.container import ArrayContainer, FieldState
+from fdtdx.fdtd.fdtd import reversible_fdtd
+from fdtdx.interfaces.recorder import Recorder
+
+_RES = 50e-9
+_SIM_TIME = 60e-15
+_VOL = 8
+_PML = 2
+_FREQ = c0 / 800e-9
+
+
+def _build(dft_subsample=1, with_gradient=True):
+    config = SimulationConfig(
+        time=_SIM_TIME,
+        grid=UniformGrid(spacing=_RES),
+        backend="cpu",
+        dtype=jnp.float32,
+        courant_factor=0.99,
+        gradient_config=None,
+    )
+    objects, constraints = [], []
+    volume = fdtdx.SimulationVolume(partial_grid_shape=(_VOL, _VOL, _VOL))
+    objects.append(volume)
+
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+        thickness=_PML,
+        override_types={f: "periodic" for f in ("min_x", "max_x", "min_y", "max_y", "min_z", "max_z")},
+    )
+    bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    objects.extend(bound_dict.values())
+    constraints.extend(c_list)
+
+    source = fdtdx.PointDipoleSource(
+        name="dip",
+        partial_grid_shape=(1, 1, 1),
+        wave_character=fdtdx.WaveCharacter(frequency=_FREQ),
+        polarization=0,
+        amplitude=1.0,
+    )
+    constraints.append(
+        source.set_grid_coordinates(axes=(0, 1, 2), sides=("-", "-", "-"), coordinates=(_VOL // 2,) * 3)
+    )
+    objects.append(source)
+
+    det = fdtdx.PhasorDetector(
+        name="det",
+        partial_grid_shape=(4, 4, 4),  # centered → interior on the 8-cell domain
+        wave_characters=(fdtdx.WaveCharacter(frequency=_FREQ),),
+        dft_subsample=dft_subsample,
+        plot=False,
+    )
+    constraints.append(det.place_at_center(volume, axes=(0, 1, 2)))
+    objects.append(det)
+
+    key = jax.random.PRNGKey(0)
+    obj, arrays, params, config, _ = fdtdx.place_objects(
+        object_list=objects, config=config, constraints=constraints, key=key
+    )
+    arrays, obj, _ = fdtdx.apply_params(arrays, obj, params, key)
+
+    if with_gradient:
+        recorder = Recorder(modules=[])
+        recorder, recording_state = recorder.init_state(
+            input_shape_dtypes={}, max_time_steps=config.time_steps_total, backend="cpu"
+        )
+        config = config.aset("gradient_config", GradientConfig(method="reversible", recorder=recorder))
+        arrays = arrays.aset("recording_state", recording_state)
+    return obj, arrays, config
+
+
+def test_dft_subsample_matches_every_step_recording():
+    """An auto-subsampled phasor matches every-step recording in a full FDTD run."""
+    key = jax.random.PRNGKey(1)
+
+    def _run(dft_subsample):
+        obj, arrays, config = _build(dft_subsample=dft_subsample, with_gradient=False)
+        det = next(d for d in obj.forward_detectors if d.name == "det")
+        _, out = fdtdx.run_fdtd(arrays=arrays, objects=obj, config=config, key=key, show_progress=False)
+        return det, np.asarray(out.detector_states["det"]["phasor"][0])
+
+    _, exact = _run(1)
+    det_auto, subsampled = _run("auto")
+    assert det_auto._dft_stride > 1  # sanity: subsampling is actually active
+
+    scale = np.max(np.abs(exact))
+    assert scale > 0
+    assert np.max(np.abs(subsampled - exact)) / scale < 0.05
+
+
+def test_detector_loss_gradient_is_finite_and_nonzero():
+    obj, arrays, config = _build(dft_subsample=1, with_gradient=True)
+    key = jax.random.PRNGKey(1)
+
+    def loss_fn(inv_permittivities):
+        a = ArrayContainer(
+            fields=FieldState(
+                E=arrays.fields.E, H=arrays.fields.H, psi_E=arrays.fields.psi_E, psi_H=arrays.fields.psi_H
+            ),
+            inv_permittivities=inv_permittivities,
+            inv_permeabilities=arrays.inv_permeabilities,
+            detector_states=arrays.detector_states,
+            recording_state=arrays.recording_state,
+            electric_conductivity=arrays.electric_conductivity,
+            magnetic_conductivity=arrays.magnetic_conductivity,
+        )
+        _, out = reversible_fdtd(a, obj, config, key, show_progress=False)
+        phasor = out.detector_states["det"]["phasor"]
+        return jnp.sum(jnp.abs(phasor) ** 2)
+
+    loss, grads = jax.value_and_grad(loss_fn)(arrays.inv_permittivities)
+    assert jnp.isfinite(loss)
+    assert loss > 0, "Detector-based loss should be nonzero with a driven source"
+    assert jnp.all(jnp.isfinite(grads)), "Gradient through region detector recording must be finite"
+    assert jnp.any(grads != 0), "Gradient must flow through the region-restricted recording path"

--- a/tests/simulation/fdtd/test_detector_region.py
+++ b/tests/simulation/fdtd/test_detector_region.py
@@ -55,9 +55,7 @@ def _build(dft_subsample=1, with_gradient=True):
         polarization=0,
         amplitude=1.0,
     )
-    constraints.append(
-        source.set_grid_coordinates(axes=(0, 1, 2), sides=("-", "-", "-"), coordinates=(_VOL // 2,) * 3)
-    )
+    constraints.append(source.set_grid_coordinates(axes=(0, 1, 2), sides=("-", "-", "-"), coordinates=(_VOL // 2,) * 3))
     objects.append(source)
 
     det = fdtdx.PhasorDetector(

--- a/tests/unit/core/physics/test_curl.py
+++ b/tests/unit/core/physics/test_curl.py
@@ -127,6 +127,33 @@ def test_interpolate_fields_nonuniform_center_to_edge_weights():
     assert jnp.allclose(E_interp[0][1:, :, :-1], expected[1:, :, :-1], atol=1e-6)
 
 
+def _region_config(nonuniform):
+    if not nonuniform:
+        return SimulationConfig(time=400e-15, grid=UniformGrid(spacing=1.0), courant_factor=0.99)
+    edges = jnp.cumsum(jnp.asarray([0.0, 1.0, 2.0, 1.5, 3.0, 1.0, 2.5, 2.0, 1.2]))
+    return SimulationConfig(
+        time=400e-15, grid=RectilinearGrid(x_edges=edges, y_edges=1.3 * edges, z_edges=0.7 * edges), courant_factor=0.99
+    )
+
+
+def test_interpolate_fields_region_matches_full_domain_slice():
+    """interpolate_fields on an interior haloed sub-block (region_slice) equals slicing the full result."""
+    n = 8
+    raw = jnp.arange(2 * 3 * n * n * n, dtype=jnp.float32).reshape(2, 3, n, n, n)
+    E, H = jnp.sin(raw[0]), jnp.cos(raw[1])
+    for nonuniform in (False, True):
+        config = _region_config(nonuniform)
+        full_E, full_H = interpolate_fields(
+            pad_fields(E, (False, False, False)), pad_fields(H, (False, False, False)), config=config
+        )
+        for gst in (((2, 6), (2, 6), (2, 6)), ((1, 7), (3, 4), (2, 5))):
+            region = (slice(None), *(slice(s, e) for (s, e) in gst))
+            block = (slice(None), *(slice(s - 1, e + 1) for (s, e) in gst))
+            reg_E, reg_H = interpolate_fields(E[block], H[block], config=config, region_slice=gst)
+            assert jnp.allclose(reg_E, full_E[region], atol=1e-6)
+            assert jnp.allclose(reg_H, full_H[region], atol=1e-6)
+
+
 # ──────────────────────────────────────────────────────────────
 # curl_E
 # ──────────────────────────────────────────────────────────────

--- a/tests/unit/fdtd/test_update.py
+++ b/tests/unit/fdtd/test_update.py
@@ -580,15 +580,26 @@ class TestUpdateHReverse:
 
 
 class TestUpdateDetectorStates:
-    """Tests for update_detector_states."""
+    """Tests for update_detector_states (region-restricted + activity-gated recording)."""
 
-    def _make_detector(self, name="det1", exact_interpolation=False):
+    # An interior slice on the 4^3 test domain (stencil reads [0..3], in-bounds on every axis).
+    INTERIOR_GST = ((1, 3), (1, 3), (1, 3))
+    # An edge-touching slice (reaches index -1 / N on the stencil halo → needs the full-domain path).
+    EDGE_GST = ((0, 4), (0, 4), (0, 4))
+
+    def _make_detector(self, name="det1", exact_interpolation=False, grid_slice_tuple=INTERIOR_GST):
         d = Mock()
         d.name = name
         d.exact_interpolation = exact_interpolation
+        d.grid_slice_tuple = grid_slice_tuple
+        d.grid_slice = tuple(slice(s, e) for (s, e) in grid_slice_tuple)
         d._is_on_at_time_step_arr = [True] * 100
         d.update.return_value = {"value": jnp.zeros((1,))}
         return d
+
+    def _init_state(self, det):
+        """Initial detector_states matching the mock's update return layout."""
+        return {det.name: {"value": jnp.zeros((1,))}}
 
     def _make_det_objects(self, **kwargs):
         """Build a mock ObjectContainer for detector tests (includes volume)."""
@@ -602,22 +613,16 @@ class TestUpdateDetectorStates:
         return obj
 
     def test_forward_uses_forward_detectors(self):
-        """inverse=False iterates over objects.forward_detectors."""
+        """inverse=False iterates over objects.forward_detectors; cond fires once per detector."""
         det = self._make_detector()
         objects = self._make_det_objects(forward_detectors=[det])
-        arrays = _make_arrays(detector_states={det.name: {}})
+        arrays = _make_arrays(detector_states=self._init_state(det))
         H_prev = jnp.zeros(FIELD_SHAPE)
 
-        with (
-            patch(
-                "fdtdx.fdtd.update.interpolate_fields",
-                return_value=(jnp.ones(FIELD_SHAPE), jnp.ones(FIELD_SHAPE)),
-            ),
-            patch(
-                "fdtdx.fdtd.update.jax.lax.cond",
-                side_effect=lambda cond, t, f, e, h, d: t(e, h, d),
-            ) as mock_cond,
-        ):
+        with patch(
+            "fdtdx.fdtd.update.jax.lax.cond",
+            side_effect=lambda cond, t, f, e, h, hp, d: t(e, h, hp, d),
+        ) as mock_cond:
             update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=False)
         mock_cond.assert_called_once()
 
@@ -625,19 +630,13 @@ class TestUpdateDetectorStates:
         """inverse=True iterates over objects.backward_detectors."""
         det = self._make_detector()
         objects = self._make_det_objects(backward_detectors=[det])
-        arrays = _make_arrays(detector_states={det.name: {}})
+        arrays = _make_arrays(detector_states=self._init_state(det))
         H_prev = jnp.zeros(FIELD_SHAPE)
 
-        with (
-            patch(
-                "fdtdx.fdtd.update.interpolate_fields",
-                return_value=(jnp.ones(FIELD_SHAPE), jnp.ones(FIELD_SHAPE)),
-            ),
-            patch(
-                "fdtdx.fdtd.update.jax.lax.cond",
-                side_effect=lambda cond, t, f, e, h, d: t(e, h, d),
-            ) as mock_cond,
-        ):
+        with patch(
+            "fdtdx.fdtd.update.jax.lax.cond",
+            side_effect=lambda cond, t, f, e, h, hp, d: t(e, h, hp, d),
+        ) as mock_cond:
             update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=True)
         mock_cond.assert_called_once()
 
@@ -647,88 +646,118 @@ class TestUpdateDetectorStates:
         arrays = _make_arrays(detector_states={})
         H_prev = jnp.zeros(FIELD_SHAPE)
 
-        with (
-            patch(
-                "fdtdx.fdtd.update.interpolate_fields",
-                return_value=(jnp.ones(FIELD_SHAPE), jnp.ones(FIELD_SHAPE)),
-            ),
-            patch("fdtdx.fdtd.update.jax.lax.cond") as mock_cond,
-        ):
+        with patch("fdtdx.fdtd.update.jax.lax.cond") as mock_cond:
             update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=False)
         mock_cond.assert_not_called()
 
-    def test_exact_interpolation_passes_interpolated_fields(self):
-        """exact_interpolation=True: helper_fn receives interpolated E and H."""
-        det = self._make_detector(exact_interpolation=True)
+    def test_interior_exact_interpolates_haloed_region(self):
+        """A strictly-interior exact detector interpolates its haloed region, not the full domain."""
+        det = self._make_detector(exact_interpolation=True, grid_slice_tuple=self.INTERIOR_GST)
         objects = self._make_det_objects(forward_detectors=[det])
-        arrays = _make_arrays(detector_states={det.name: {}})
-        H_prev = jnp.zeros(FIELD_SHAPE)
-        interp_E = jnp.ones(FIELD_SHAPE) * 42.0
-        interp_H = jnp.ones(FIELD_SHAPE) * 99.0
-        captured = {}
-
-        def fake_cond(cond_val, t_fn, f_fn, e_arg, h_arg, d_arg):
-            captured["E"] = e_arg
-            captured["H"] = h_arg
-            return t_fn(e_arg, h_arg, d_arg)
-
-        with (
-            patch("fdtdx.fdtd.update.interpolate_fields", return_value=(interp_E, interp_H)),
-            patch("fdtdx.fdtd.update.jax.lax.cond", side_effect=fake_cond),
-        ):
-            update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=False)
-
-        assert jnp.allclose(captured["E"], interp_E)
-        assert jnp.allclose(captured["H"], interp_H)
-
-    def test_no_interpolation_passes_raw_fields(self):
-        """exact_interpolation=False: helper_fn receives raw arrays.fields.E and arrays.fields.H."""
-        det = self._make_detector(exact_interpolation=False)
-        objects = self._make_det_objects(forward_detectors=[det])
-        raw_E = jnp.ones(FIELD_SHAPE) * 5.0
-        raw_H = jnp.ones(FIELD_SHAPE) * 6.0
-        arrays = _make_arrays(E=raw_E, H=raw_H, detector_states={det.name: {}})
-        H_prev = jnp.zeros(FIELD_SHAPE)
-        captured = {}
-
-        def fake_cond(cond_val, t_fn, f_fn, e_arg, h_arg, d_arg):
-            captured["E"] = e_arg
-            captured["H"] = h_arg
-            return t_fn(e_arg, h_arg, d_arg)
-
-        with (
-            patch(
-                "fdtdx.fdtd.update.interpolate_fields",
-                return_value=(jnp.ones(FIELD_SHAPE) * 99.0, jnp.ones(FIELD_SHAPE) * 99.0),
-            ),
-            patch("fdtdx.fdtd.update.jax.lax.cond", side_effect=fake_cond),
-        ):
-            update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=False)
-
-        # Should receive the raw fields, not the interpolated ones
-        assert jnp.allclose(captured["E"], raw_E)
-        assert jnp.allclose(captured["H"], raw_H)
-
-    def test_interpolate_fields_receives_h_avg(self):
-        """interpolate_fields receives padded (H_prev + arrays.fields.H) / 2 as H_pad."""
-        objects = self._make_det_objects(forward_detectors=[])
+        raw_E = jnp.arange(3 * NX * NY * NZ, dtype=jnp.float32).reshape(FIELD_SHAPE)
         H_field = jnp.ones(FIELD_SHAPE) * 4.0
         H_prev = jnp.ones(FIELD_SHAPE) * 2.0
-        arrays = _make_arrays(H=H_field, detector_states={})
+        region = (jnp.ones((3, 2, 2, 2)) * 7.0, jnp.ones((3, 2, 2, 2)) * 8.0)
+        arrays = _make_arrays(E=raw_E, H=H_field, detector_states=self._init_state(det))
 
-        with patch(
-            "fdtdx.fdtd.update.interpolate_fields",
-            return_value=(jnp.zeros(FIELD_SHAPE), jnp.zeros(FIELD_SHAPE)),
-        ) as mock_interp:
+        with (
+            patch("fdtdx.fdtd.update.interpolate_fields", return_value=region) as mock_interp,
+            patch("fdtdx.fdtd.update.jax.lax.cond", side_effect=lambda cond, t, f, e, h, hp, d: t(e, h, hp, d)),
+        ):
             update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=False)
 
-        # H_pad is the padded version of (H_prev + H_field) / 2
-        # With no boundaries, padding is constant (zero-pad)
-        expected_H_avg = (H_prev + H_field) / 2  # all 3.0
-        actual_H_pad = mock_interp.call_args[1]["H_pad"]
-        # The padded array has shape (3, NX+2, NY+2, NZ+2), interior should match
-        assert actual_H_pad.shape == (3, NX + 2, NY + 2, NZ + 2)
-        assert jnp.allclose(actual_H_pad[:, 1:-1, 1:-1, 1:-1], expected_H_avg)
+        # Interpolated once over the region — INTERIOR_GST grown by the 1-cell halo → [0:4] blocks —
+        # with the matching region_slice, and never over the full padded domain.
+        mock_interp.assert_called_once()
+        assert mock_interp.call_args.kwargs["region_slice"] == self.INTERIOR_GST
+        assert jnp.allclose(mock_interp.call_args.args[0], raw_E[:, 0:4, 0:4, 0:4])
+        assert jnp.allclose(mock_interp.call_args.args[1], jnp.ones((3, 4, 4, 4)) * 3.0)  # (2 + 4) / 2
+        assert jnp.allclose(det.update.call_args.kwargs["E"], region[0])
+
+    def test_edge_exact_uses_full_domain_interpolation(self):
+        """An edge-touching exact detector falls back to the full-domain (padded) interpolation."""
+        det = self._make_detector(exact_interpolation=True, grid_slice_tuple=self.EDGE_GST)
+        objects = self._make_det_objects(forward_detectors=[det])
+        arrays = _make_arrays(detector_states=self._init_state(det))
+        H_prev = jnp.zeros(FIELD_SHAPE)
+        full = (jnp.ones(FIELD_SHAPE) * 42.0, jnp.ones(FIELD_SHAPE) * 99.0)
+
+        with (
+            patch("fdtdx.fdtd.update.interpolate_fields", return_value=full) as mock_interp,
+            patch("fdtdx.fdtd.update.jax.lax.cond", side_effect=lambda cond, t, f, e, h, hp, d: t(e, h, hp, d)),
+        ):
+            update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=False)
+
+        # Full-domain path: interpolate the padded fields (no region_slice); detector gets the slice.
+        mock_interp.assert_called_once()
+        assert mock_interp.call_args.kwargs.get("region_slice") is None
+        assert jnp.allclose(det.update.call_args.kwargs["E"], full[0])  # EDGE_GST spans the whole domain
+
+    def test_non_exact_passes_raw_region_slice(self):
+        """exact_interpolation=False: detector receives the raw (non-interpolated) region slice."""
+        det = self._make_detector(exact_interpolation=False, grid_slice_tuple=self.INTERIOR_GST)
+        objects = self._make_det_objects(forward_detectors=[det])
+        raw_E = jnp.arange(3 * NX * NY * NZ, dtype=jnp.float32).reshape(FIELD_SHAPE)
+        raw_H = raw_E * 2.0
+        arrays = _make_arrays(E=raw_E, H=raw_H, detector_states=self._init_state(det))
+        H_prev = jnp.zeros(FIELD_SHAPE)
+
+        with (
+            patch("fdtdx.fdtd.update.interpolate_fields") as mock_interp,
+            patch("fdtdx.fdtd.update.jax.lax.cond", side_effect=lambda cond, t, f, e, h, hp, d: t(e, h, hp, d)),
+        ):
+            update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=False)
+
+        mock_interp.assert_not_called()
+        assert jnp.allclose(det.update.call_args.kwargs["E"], raw_E[:, 1:3, 1:3, 1:3])
+        assert jnp.allclose(det.update.call_args.kwargs["H"], raw_H[:, 1:3, 1:3, 1:3])
+
+    def test_materials_are_region_sliced(self):
+        """The detector receives inv_permittivity/permeability restricted to its region."""
+        det = self._make_detector(exact_interpolation=False, grid_slice_tuple=self.INTERIOR_GST)
+        objects = self._make_det_objects(forward_detectors=[det])
+        inv_eps = jnp.arange(3 * NX * NY * NZ, dtype=jnp.float32).reshape(FIELD_SHAPE)
+        inv_mu = inv_eps + 100.0
+        arrays = _make_arrays(
+            inv_permittivities=inv_eps, inv_permeabilities=inv_mu, detector_states=self._init_state(det)
+        )
+        H_prev = jnp.zeros(FIELD_SHAPE)
+
+        with patch("fdtdx.fdtd.update.jax.lax.cond", side_effect=lambda cond, t, f, e, h, hp, d: t(e, h, hp, d)):
+            update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=False)
+
+        assert jnp.allclose(det.update.call_args.kwargs["inv_permittivity"], inv_eps[:, 1:3, 1:3, 1:3])
+        assert jnp.allclose(det.update.call_args.kwargs["inv_permeability"], inv_mu[:, 1:3, 1:3, 1:3])
+
+    def test_update_exception_is_wrapped_with_detector_context(self):
+        """An exception inside update() (e.g. a double-slice broadcast error) names the detector and cause."""
+        det = self._make_detector(exact_interpolation=False, grid_slice_tuple=self.INTERIOR_GST)
+        det.update.side_effect = TypeError("Incompatible types for broadcasting")
+        objects = self._make_det_objects(forward_detectors=[det])
+        arrays = _make_arrays(detector_states=self._init_state(det))
+        H_prev = jnp.zeros(FIELD_SHAPE)
+
+        with (
+            patch("fdtdx.fdtd.update.jax.lax.cond", side_effect=lambda cond, t, f, e, h, hp, d: t(e, h, hp, d)),
+            pytest.raises(Exception, match="double slicing") as exc_info,
+        ):
+            update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=False)
+        assert isinstance(exc_info.value.__cause__, TypeError)
+
+    def test_state_layout_drift_raises_descriptive_error(self):
+        """An update() that changes its state layout (as double-slicing grid_slice would) fails clearly."""
+        det = self._make_detector(exact_interpolation=False, grid_slice_tuple=self.INTERIOR_GST)
+        # Re-slicing the already-restricted region by the domain-level grid_slice empties the arrays.
+        det.update.return_value = {"value": jnp.zeros((0,))}
+        objects = self._make_det_objects(forward_detectors=[det])
+        arrays = _make_arrays(detector_states=self._init_state(det))
+        H_prev = jnp.zeros(FIELD_SHAPE)
+
+        with (
+            patch("fdtdx.fdtd.update.jax.lax.cond", side_effect=lambda cond, t, f, e, h, hp, d: t(e, h, hp, d)),
+            pytest.raises(Exception, match="double slicing"),
+        ):
+            update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=False)
 
 
 # ─── TestCollectInterfaces ────────────────────────────────────────────────────

--- a/tests/unit/objects/detectors/test_diffractive.py
+++ b/tests/unit/objects/detectors/test_diffractive.py
@@ -186,8 +186,8 @@ class TestDiffractiveDetectorUpdate:
 
         new_state = det.update(
             time_step=jnp.array(0),
-            E=constant_E_field,
-            H=constant_H_field,
+            E=constant_E_field[:, *det.grid_slice],
+            H=constant_H_field[:, *det.grid_slice],
             state=state,
             inv_permittivity=inv_permittivity,
             inv_permeability=inv_permeability,
@@ -209,8 +209,8 @@ class TestDiffractiveDetectorUpdate:
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
         state = det.init_state()
 
-        E = jnp.zeros((3, 8, 8, 8), dtype=jnp.float32)
-        H = jnp.zeros((3, 8, 8, 8), dtype=jnp.float32)
+        E = jnp.zeros((3, 8, 8, 8), dtype=jnp.float32)[:, *det.grid_slice]
+        H = jnp.zeros((3, 8, 8, 8), dtype=jnp.float32)[:, *det.grid_slice]
 
         new_state = det.update(
             time_step=jnp.array(0),
@@ -278,8 +278,8 @@ class TestDiffractiveDetectorUpdate:
 
         new_state = det.update(
             time_step=jnp.array(0),
-            E=constant_E_field,
-            H=constant_H_field,
+            E=constant_E_field[:, *det.grid_slice],
+            H=constant_H_field[:, *det.grid_slice],
             state=state,
             inv_permittivity=inv_permittivity,
             inv_permeability=inv_permeability,
@@ -308,16 +308,16 @@ class TestDiffractiveDetectorUpdate:
 
         new_pos = det_pos.update(
             jnp.array(0),
-            sinusoidal_E_field,
-            sinusoidal_H_field,
+            sinusoidal_E_field[:, *det_pos.grid_slice],
+            sinusoidal_H_field[:, *det_pos.grid_slice],
             state_pos,
             inv_permittivity,
             inv_permeability,
         )
         new_neg = det_neg.update(
             jnp.array(0),
-            sinusoidal_E_field,
-            sinusoidal_H_field,
+            sinusoidal_E_field[:, *det_neg.grid_slice],
+            sinusoidal_H_field[:, *det_neg.grid_slice],
             state_neg,
             inv_permittivity,
             inv_permeability,
@@ -346,8 +346,8 @@ class TestDiffractiveDetectorUpdate:
 
         new_state = det.update(
             time_step=jnp.array(0),
-            E=sinusoidal_E_field,
-            H=sinusoidal_H_field,
+            E=sinusoidal_E_field[:, *det.grid_slice],
+            H=sinusoidal_H_field[:, *det.grid_slice],
             state=state,
             inv_permittivity=inv_permittivity,
             inv_permeability=inv_permeability,
@@ -372,8 +372,8 @@ class TestDiffractiveDetectorUpdate:
 
         new_state = det.update(
             time_step=jnp.array(0),
-            E=sinusoidal_E_field,
-            H=sinusoidal_H_field,
+            E=sinusoidal_E_field[:, *det.grid_slice],
+            H=sinusoidal_H_field[:, *det.grid_slice],
             state=state,
             inv_permittivity=inv_permittivity,
             inv_permeability=inv_permeability,
@@ -398,8 +398,8 @@ class TestDiffractiveDetectorUpdate:
 
         new_state = det.update(
             time_step=jnp.array(0),
-            E=constant_E_field,
-            H=constant_H_field,
+            E=constant_E_field[:, *det.grid_slice],
+            H=constant_H_field[:, *det.grid_slice],
             state=state,
             inv_permittivity=inv_permittivity,
             inv_permeability=inv_permeability,
@@ -425,8 +425,8 @@ class TestDiffractiveDetectorUpdate:
 
         new_state = det.update(
             time_step=jnp.array(0),
-            E=constant_E_field,
-            H=constant_H_field,
+            E=constant_E_field[:, *det.grid_slice],
+            H=constant_H_field[:, *det.grid_slice],
             state=state,
             inv_permittivity=inv_permittivity,
             inv_permeability=inv_permeability,

--- a/tests/unit/objects/detectors/test_energy.py
+++ b/tests/unit/objects/detectors/test_energy.py
@@ -339,16 +339,16 @@ class TestEnergyDetectorEdgeCases:
         detector = detector.place_on_grid(point_grid_slice, simulation_config, random_key)
         state = detector.init_state()
 
-        E = jnp.ones((3, 8, 8, 8), dtype=jnp.float32)
-        H = jnp.zeros((3, 8, 8, 8), dtype=jnp.float32)
+        E = jnp.ones((3, 8, 8, 8), dtype=jnp.float32)[:, *detector.grid_slice]
+        H = jnp.zeros((3, 8, 8, 8), dtype=jnp.float32)[:, *detector.grid_slice]
 
         new_state = detector.update(
             time_step=jnp.array(0),
             E=E,
             H=H,
             state=state,
-            inv_permittivity=inv_permittivity,
-            inv_permeability=inv_permeability,
+            inv_permittivity=inv_permittivity[:, *detector.grid_slice],
+            inv_permeability=inv_permeability,  # scalar for non-magnetic materials, never sliced
         )
 
         # Should be a single point
@@ -371,11 +371,11 @@ class TestEnergyDetectorEdgeCases:
 
         new_state = detector.update(
             time_step=jnp.array(0),
-            E=constant_E_field,
-            H=constant_H_field,
+            E=constant_E_field[:, *detector.grid_slice],
+            H=constant_H_field[:, *detector.grid_slice],
             state=state,
-            inv_permittivity=inv_permittivity,
-            inv_permeability=inv_permeability,
+            inv_permittivity=inv_permittivity[:, *detector.grid_slice],
+            inv_permeability=inv_permeability,  # scalar for non-magnetic materials, never sliced
         )
 
         assert new_state["energy"][0].shape == (8, 8, 1)

--- a/tests/unit/objects/detectors/test_field_projection.py
+++ b/tests/unit/objects/detectors/test_field_projection.py
@@ -575,6 +575,33 @@ class TestFieldProjectionAngleDetector:
             expected = expected_fields[tuple(face_slices)] * static_scale
             assert np.allclose(np.asarray(updated[_surface_state_key(surface)])[0, 0], expected)
 
+    def test_box_pulse_update_weights_by_subsample_stride(self, random_key, single_frequency):
+        """Box-mode pulse scaling weights each kept sample by the dft_subsample stride."""
+        common = dict(wave_characters=single_frequency, scaling_mode="pulse", exclude_surfaces=("z+",))
+        grid_slice = ((0, 4), (0, 5), (0, 6))
+        exact = FieldProjectionAngleDetector(**common, dft_subsample=1)
+        exact = exact.place_on_grid(grid_slice, UNIFORM_CONFIG, random_key)
+        strided = FieldProjectionAngleDetector(**common, dft_subsample=3)
+        strided = strided.place_on_grid(grid_slice, UNIFORM_CONFIG, random_key)
+        fields_e = jnp.ones((3, 4, 5, 6), dtype=jnp.float32)
+        fields_h = 2.0 * jnp.ones((3, 4, 5, 6), dtype=jnp.float32)
+
+        def record(detector):
+            return detector.update(
+                time_step=jnp.asarray(0),
+                E=fields_e,
+                H=fields_h,
+                state=detector.init_state(),
+                inv_permittivity=jnp.ones((3, 4, 5, 6), dtype=jnp.float32),
+                inv_permeability=1.0,
+            )
+
+        exact_state = record(exact)
+        strided_state = record(strided)
+        assert set(strided_state) == set(exact_state)
+        for state_key in exact_state:
+            assert np.allclose(np.asarray(strided_state[state_key]), 3.0 * np.asarray(exact_state[state_key]))
+
     def test_surface_update_uses_single_phasor_state(self, random_key, single_frequency):
         detector = FieldProjectionAngleDetector(wave_characters=single_frequency, direction="+")
         detector = detector.place_on_grid(((0, 5), (0, 6), (0, 1)), UNIFORM_CONFIG, random_key)

--- a/tests/unit/objects/detectors/test_phasor_subsample.py
+++ b/tests/unit/objects/detectors/test_phasor_subsample.py
@@ -40,9 +40,7 @@ def test_stride_one_matches_default(simulation_config, small_grid_slice, random_
         PhasorDetector(wave_characters=(wave,), dft_subsample=1), simulation_config, small_grid_slice, random_key
     )
     assert one_det._dft_stride == default_det._dft_stride == 1
-    assert np.array_equal(
-        np.asarray(one_det._is_on_at_time_step_arr), np.asarray(default_det._is_on_at_time_step_arr)
-    )
+    assert np.array_equal(np.asarray(one_det._is_on_at_time_step_arr), np.asarray(default_det._is_on_at_time_step_arr))
 
 
 def test_explicit_stride_thins_on_list(simulation_config, small_grid_slice, random_key, wave):
@@ -139,7 +137,12 @@ def test_subsample_recovers_amplitude(random_key):
     freq = 1e14
     omega = 2 * math.pi * freq
     small_slice = ((0, 8), (0, 8), (0, 8))
-    common = dict(wave_characters=(WaveCharacter(frequency=freq),), scaling_mode="continuous", components=("Ex",), reduce_volume=True)
+    common = dict(
+        wave_characters=(WaveCharacter(frequency=freq),),
+        scaling_mode="continuous",
+        components=("Ex",),
+        reduce_volume=True,
+    )
 
     exact = PhasorDetector(**common, dft_subsample=1).place_on_grid(small_slice, config, random_key)
     auto = PhasorDetector(**common, dft_subsample="auto").place_on_grid(small_slice, config, random_key)

--- a/tests/unit/objects/detectors/test_phasor_subsample.py
+++ b/tests/unit/objects/detectors/test_phasor_subsample.py
@@ -1,0 +1,174 @@
+"""Unit tests for opt-in phasor DFT auto-subsampling.
+
+Subsampling records only every ``stride``-th active step and rescales the kept samples so the
+magnitude matches every-step recording. Default is exact (stride 1, byte-identical to before).
+"""
+
+import math
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from loguru import logger
+
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
+from fdtdx.core.wavelength import WaveCharacter
+from fdtdx.objects.detectors.phasor import _DFT_OVERSAMPLE, PhasorDetector
+
+
+@pytest.fixture
+def wave():
+    return WaveCharacter(frequency=1e14)
+
+
+def _place(det, simulation_config, small_grid_slice, random_key):
+    return det.place_on_grid(small_grid_slice, simulation_config, random_key)
+
+
+def test_default_is_exact(simulation_config, small_grid_slice, random_key, wave):
+    det = PhasorDetector(wave_characters=(wave,))
+    det = _place(det, simulation_config, small_grid_slice, random_key)
+    assert det._dft_stride == 1
+    # No steps dropped: recorded count equals the base (every-step) count.
+    assert det.num_time_steps_recorded == simulation_config.time_steps_total
+
+
+def test_stride_one_matches_default(simulation_config, small_grid_slice, random_key, wave):
+    default_det = _place(PhasorDetector(wave_characters=(wave,)), simulation_config, small_grid_slice, random_key)
+    one_det = _place(
+        PhasorDetector(wave_characters=(wave,), dft_subsample=1), simulation_config, small_grid_slice, random_key
+    )
+    assert one_det._dft_stride == default_det._dft_stride == 1
+    assert np.array_equal(
+        np.asarray(one_det._is_on_at_time_step_arr), np.asarray(default_det._is_on_at_time_step_arr)
+    )
+
+
+def test_explicit_stride_thins_on_list(simulation_config, small_grid_slice, random_key, wave):
+    stride = 3
+    det = PhasorDetector(wave_characters=(wave,), dft_subsample=stride)
+    det = _place(det, simulation_config, small_grid_slice, random_key)
+    assert det._dft_stride == stride
+
+    on = np.asarray(det._is_on_at_time_step_arr)
+    active = np.nonzero(on)[0]
+    # Kept steps are exactly every stride-th of the base active steps (which are all steps here).
+    expected = np.arange(simulation_config.time_steps_total)[::stride]
+    assert np.array_equal(active, expected)
+    assert det.num_time_steps_recorded == len(expected)
+
+
+def test_explicit_stride_near_nyquist_warns(simulation_config, small_grid_slice, random_key, wave):
+    """An explicit stride leaving fewer than 4 samples per period triggers an aliasing warning."""
+    dt = float(simulation_config.time_step_duration)
+    stride = math.ceil(1.0 / (2.0 * 1e14 * dt))  # at/above Nyquist for the 1e14 Hz wave
+    messages = []
+    sink_id = logger.add(lambda message: messages.append(message), level="WARNING")
+    try:
+        det = PhasorDetector(wave_characters=(wave,), dft_subsample=stride)
+        _place(det, simulation_config, small_grid_slice, random_key)
+    finally:
+        logger.remove(sink_id)
+    assert any("alias" in message for message in messages)
+
+
+def test_auto_derives_stride(simulation_config, small_grid_slice, random_key, wave):
+    det = PhasorDetector(wave_characters=(wave,), dft_subsample="auto")
+    det = _place(det, simulation_config, small_grid_slice, random_key)
+    dt = float(simulation_config.time_step_duration)
+    f_max = 1e14
+    expected = max(1, math.floor(1.0 / (_DFT_OVERSAMPLE * f_max * dt)))
+    assert expected > 1  # sanity: this config is well-oversampled
+    assert det._dft_stride == expected
+
+
+def test_pulse_scaling_multiplies_by_stride(simulation_config, small_grid_slice, random_key, wave):
+    """Pulse mode weights each kept sample by the stride (Riemann sum), restoring magnitude."""
+    field = jnp.ones((3, 8, 8, 8), dtype=jnp.float32)
+    common = dict(wave_characters=(wave,), scaling_mode="pulse", components=("Ex",))
+
+    exact = _place(PhasorDetector(**common, dft_subsample=1), simulation_config, small_grid_slice, random_key)
+    strided = _place(PhasorDetector(**common, dft_subsample=3), simulation_config, small_grid_slice, random_key)
+
+    # At time_step 0 the phasor factor is exp(0) = 1, so the recorded value is field * static_scale.
+    def _record(det):
+        return det.update(
+            time_step=jnp.array(0),
+            E=field,
+            H=field,
+            state=det.init_state(),
+            inv_permittivity=jnp.ones((3, 8, 8, 8)),
+            inv_permeability=1.0,
+        )["phasor"]
+
+    exact_val = _record(exact)
+    strided_val = _record(strided)
+    assert jnp.allclose(strided_val, 3.0 * exact_val)
+
+
+def _accumulate_phasor(det, config, omega):
+    """Drive the detector with a synthetic CW field cos(omega*t) over its active steps."""
+    dt = float(config.time_step_duration)
+    on = np.asarray(det._is_on_at_time_step_arr)
+    state = det.init_state()
+    H = jnp.zeros((3, 8, 8, 8), dtype=jnp.float32)
+    for t in np.nonzero(on)[0]:
+        amp = float(np.cos(omega * t * dt))
+        E = jnp.ones((3, 8, 8, 8), dtype=jnp.float32) * amp
+        state = det.update(
+            time_step=jnp.array(int(t)),
+            E=E,
+            H=H,
+            state=state,
+            inv_permittivity=jnp.ones((3, 8, 8, 8)),
+            inv_permeability=1.0,
+        )
+    return complex(state["phasor"][0, 0, 0])
+
+
+def test_subsample_recovers_amplitude(random_key):
+    """Physics: an auto-subsampled phasor recovers the same amplitude as exact recording.
+
+    A single-tone cos(omega t) sampled at dt has amplitude 1; the continuous-mode phasor magnitude
+    should recover ~1 both with every-step recording and with auto-subsampling, since the FDTD dt
+    keeps the tone far below Nyquist (the whole point of the oversampling margin).
+    """
+    # Short run (few hundred steps) that is still well-oversampled, so the loop stays fast.
+    config = SimulationConfig(time=1e-13, grid=UniformGrid(spacing=1e-7))
+    freq = 1e14
+    omega = 2 * math.pi * freq
+    small_slice = ((0, 8), (0, 8), (0, 8))
+    common = dict(wave_characters=(WaveCharacter(frequency=freq),), scaling_mode="continuous", components=("Ex",), reduce_volume=True)
+
+    exact = PhasorDetector(**common, dft_subsample=1).place_on_grid(small_slice, config, random_key)
+    auto = PhasorDetector(**common, dft_subsample="auto").place_on_grid(small_slice, config, random_key)
+    assert auto._dft_stride > 1  # sanity: subsampling is actually active
+
+    mag_exact = abs(_accumulate_phasor(exact, config, omega))
+    mag_auto = abs(_accumulate_phasor(auto, config, omega))
+
+    assert mag_exact == pytest.approx(1.0, abs=0.05)
+    assert mag_auto == pytest.approx(mag_exact, rel=0.05)
+
+
+def test_continuous_scaling_uses_kept_count(simulation_config, small_grid_slice, random_key, wave):
+    """Continuous mode's 2/N scaling reflects the thinned kept-sample count."""
+    strided = _place(
+        PhasorDetector(wave_characters=(wave,), scaling_mode="continuous", components=("Ex",), dft_subsample=4),
+        simulation_config,
+        small_grid_slice,
+        random_key,
+    )
+    field = jnp.ones((3, 8, 8, 8), dtype=jnp.float32)
+    val = strided.update(
+        time_step=jnp.array(0),
+        E=field,
+        H=field,
+        state=strided.init_state(),
+        inv_permittivity=jnp.ones((3, 8, 8, 8)),
+        inv_permeability=1.0,
+    )["phasor"]
+    # static_scale = 2 / num_time_steps_recorded at time_step 0 (phasor factor 1).
+    expected = 2.0 / strided.num_time_steps_recorded
+    assert jnp.allclose(val[0, 0], expected)


### PR DESCRIPTION
## Summary

Detector recording currently interpolates E/H over the **whole domain on every time step** unconditionally, even when detectors (1) are off at that step, (2) don't use exact interpolation, or (3) only cover a small monitor plane. Each detector then re-slices the full-domain arrays inside its own `update()`.

This PR restricts all detector recording to each detector's own region and gates it on the detector's activity switch:

- `update_detector_states` now passes fields and materials **already restricted to `grid_slice`** into `Detector.update()`.
- A strictly interior detector with `exact_interpolation` is co-located over just its region plus a one-cell halo, **inside** the `lax.cond` gate (skipped entirely on off-steps). This is byte-identical to slicing the full-domain interpolation (see parity test). The H time-centering `(H_prev + H) / 2` is likewise computed only on the detector block.
- The full-domain interpolation is built only as a shared fallback for exact detectors whose stencil touches a domain edge (where boundary padding matters), preserving existing behavior there.
- On non-uniform `RectilinearGrid`s, a new optional `region_slice` argument to `interpolate_fields` keeps the physical-distance weights aligned with the sub-block.
- New opt-in `PhasorDetector.dft_subsample` (`int` or `"auto"`): records only every stride-th active step with the kept samples rescaled, exploiting the fact that FDTD time steps oversample optical frequencies by ~10–20×. `"auto"` keeps 12 samples per period of the highest recorded frequency; explicit strides near Nyquist trigger a warning. Default (1) is byte-identical to current behavior.

## Performance

Forward run, PML, Gaussian plane source, w/ three always-on monitors (24×24 Poynting plane, 24×24 phasor plane, 16^3 reduced energy volume), 629 steps, float32, CPU (Apple Silicon):

| Domain | Detector overhead (main) | Detector overhead (this PR) | Reduction |
|---|---|---|---|
| 72^3 | 0.356 ms/step | 0.165 ms/step | **2.2×** |
| 96^3 | 0.735 ms/step | 0.292 ms/step | **2.5×** |

End-to-end runtime with this monitor set drops ~12% at both sizes; the gap widens with domain size because the old cost scales with the domain volume while the new cost scales with monitor size. `dft_subsample="auto"` reduces phasor recording cost by a further ~2–10× depending on resolution (validated to 0.16% agreement in a full simulation, see tests).

## Breaking change

`Detector.update()` implementations now receive region-restricted inputs and **must not slice `self.grid_slice` themselves**. All built-in detectors are updated; downstream custom detectors (ones outside fdtdx repo) need the same one-line deletion. Two safeguards report the failure into an actionable error:

- exceptions raised inside `update()` are re-raised naming the detector and the double-slicing cause;
- a trace-time check rejects updates whose returned state layout drifted from `init_state()`.

Also fixes a latent inconsistency found while consolidating: box-mode `FieldProjectionDetector` duplicated the phasor scaling logic; both paths now share `PhasorDetector._static_scale()` (fixes missing pulse-mode stride weight).

The stale `update_detector_states` docstring ("interpolation is disabled by default") is corrected to match the actual default (`exact_interpolation=True` since 7a05ac1) <- this default description was left unchanged after that update.

## Testing

- `tests/integration/fdtd/test_detector_region_parity.py` — byte-level parity of region recording vs. the historical full-domain path for every detector kind, on uniform and non-uniform grids.
- `tests/unit/core/physics/test_curl.py` — `region_slice` sub-block interpolation equals the sliced full-domain result on both grid types.
- `tests/unit/objects/detectors/test_phasor_subsample.py` — stride resolution, scaling relations, single-tone amplitude recovery, Nyquist warning.
- `tests/simulation/fdtd/test_detector_region.py` — gradient through `reversible_fdtd` is finite and nonzero via a region-recorded detector; `dft_subsample="auto"` matches every-step recording in a full simulation (0.16% max deviation, asserted < 5%).
- `tests/unit/fdtd/test_update.py` — rewritten `TestUpdateDetectorStates` covering the interior/edge/non-exact paths, material slicing, and both safeguards.

Full suite: 2492 passed (`-m "unit or integration or docs"`), pre-commit (ruff/ty/zizmor) and `sphinx-build -W` docs build clean.

## Some future considerations for performance 

- Defer co-location interpolation for the phasor family by accumulating the DFT of raw staggered fields and interpolating the accumulated phasor once post-run (linear ops commute; same design as Meep's `add_dft_fields`).
- Formalize a postprocess stage for detector data (the natural home for the above).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable phasor DFT subsampling with automatic stride selection and Nyquist/aliasing warnings.
  * Improved detector recording to handle region-restricted updates more robustly, including edge-aware behavior.
  * Extended field interpolation to support non-uniform rectilinear grid scaling and region-slice interpolation.

* **Bug Fixes**
  * Improved detector state validation with clearer mismatch errors and context.
  * Corrected detector input handling/scaling for subsampled pulse modes and detector-specific data extraction.

* **Tests**
  * Added/expanded integration and unit tests for region parity, non-uniform interpolation correctness, subsampling behavior, and reversible autodiff gradients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->