### PR TITLE
fix: apply curl metric factor to TFSF injection on non-uniform grids

### DIFF
--- a/src/fdtdx/objects/sources/tfsf.py
+++ b/src/fdtdx/objects/sources/tfsf.py
@@ -5,6 +5,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from fdtdx.constants import c as c0
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.dispersion import (
     compute_eps_spectrum_from_coefficients,
@@ -307,6 +308,33 @@ class TFSFPlaneSource(DirectionalPlaneSourceBase, ABC):
         # the real impedance of the local medium.
         raise NotImplementedError()
 
+    def _metric_scale_at_plane(self, stencil: str) -> jax.Array | float:
+        """Computes the local derivative scale along the propagation axis at the source plane.
+
+        On non-uniform grids, spatial derivatives are scaled by the local cell width.
+        Returns 1.0 on uniform grids.
+
+        Args:
+            stencil (str): Either "backward" or "forward" difference stencil.
+
+        Returns:
+            jax.Array | float: Scalar scale factor for the injected field corrections.
+        """
+        config = self._config
+        if not config.has_nonuniform_grid:
+            return 1.0
+        grid = config.resolved_grid
+        assert grid is not None
+        widths = grid.cell_widths(self.propagation_axis)
+        start = self.grid_slice_tuple[self.propagation_axis][0]
+        width = widths[start]
+        if stencil == "backward":
+            width = 0.5 * (width + widths[max(start - 1, 0)])
+        elif stencil != "forward":
+            raise ValueError(f"Unknown derivative stencil: {stencil}")
+        reference_spacing = c0 * config.time_step_duration / config.courant_number
+        return reference_spacing / width
+
     def update_E(
         self,
         E: jax.Array,
@@ -320,7 +348,7 @@ class TFSFPlaneSource(DirectionalPlaneSourceBase, ABC):
             raise Exception("Need to apply random key before calling update")
 
         delta_t = self._config.time_step_duration
-        c = self._config.courant_number
+        c = self._config.courant_number * self._metric_scale_at_plane("backward")
 
         # Determine if fully anisotropic
         is_fully_anisotropic = inv_permittivities.ndim > 0 and inv_permittivities.shape[0] == 9
@@ -441,7 +469,7 @@ class TFSFPlaneSource(DirectionalPlaneSourceBase, ABC):
             raise Exception("Need to apply random key before calling update")
 
         delta_t = self._config.time_step_duration
-        c = self._config.courant_number
+        c = self._config.courant_number * self._metric_scale_at_plane("forward")
 
         # Determine if fully anisotropic
         is_fully_anisotropic = (

--- a/tests/simulation/physics/sources/test_tfsf_grid_normalization.py
+++ b/tests/simulation/physics/sources/test_tfsf_grid_normalization.py
@@ -7,10 +7,11 @@ by roughly (dz / dx)^2 in power.
 """
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 
 import fdtdx
-from fdtdx.core.grid import QuasiUniformGrid, UniformGrid
+from fdtdx.core.grid import QuasiUniformGrid, RectilinearGrid, UniformGrid
 
 _DX = 25e-9
 _LXY = 0.8e-6
@@ -75,4 +76,25 @@ def test_tfsf_injection_is_grid_metric_independent():
     flux_quasi = _run_flux(QuasiUniformGrid(dx=_DX, dy=_DX, dz=2 * _DX))
     ratio = flux_quasi / flux_uniform
     # Without the metric factor on the TFSF correction, the ratio is ~3 (see #392).
+    assert 0.95 < ratio < 1.05, f"TFSF injected power depends on grid metric: ratio={ratio:.3f}"
+
+
+def test_tfsf_injection_is_grid_metric_independent_on_graded_grid():
+    """Same check on a grid whose spacing varies along the propagation axis.
+
+    The source plane then sits between cells of different widths, exercising the
+    backward-stencil neighbor averaging of the injected correction.
+    """
+    nxy = round(_LXY / _DX)
+    nz = round(_LZ / _DX)
+    xy_edges = jnp.asarray(np.arange(nxy + 1) * _DX)
+    cells = np.arange(nz, dtype=float)
+    widths = _DX * (1.0 + 0.3 * np.sin(2.0 * np.pi * (cells + 0.5) / nz))
+    widths *= _LZ / widths.sum()
+    z_edges = jnp.asarray(np.concatenate([[0.0], np.cumsum(widths)]))
+    graded = RectilinearGrid(x_edges=xy_edges, y_edges=xy_edges, z_edges=z_edges)
+
+    flux_uniform = _run_flux(UniformGrid(spacing=_DX))
+    flux_graded = _run_flux(graded)
+    ratio = flux_graded / flux_uniform
     assert 0.95 < ratio < 1.05, f"TFSF injected power depends on grid metric: ratio={ratio:.3f}"

--- a/tests/simulation/physics/sources/test_tfsf_grid_normalization.py
+++ b/tests/simulation/physics/sources/test_tfsf_grid_normalization.py
@@ -1,0 +1,78 @@
+"""TFSF source normalization must be independent of the grid metric (regression for #392).
+
+A plane wave injected through a fixed physical area carries the same power regardless of how the
+domain is discretized. On a quasi-uniform grid with dz != dx, the bulk curl update is metric-aware,
+so the TFSF correction must carry the same local metric factor; without it, the source over-injects
+by roughly (dz / dx)^2 in power.
+"""
+
+import jax
+import numpy as np
+
+import fdtdx
+from fdtdx.core.grid import QuasiUniformGrid, UniformGrid
+
+_DX = 25e-9
+_LXY = 0.8e-6
+_LZ = 1.6e-6
+_WAVELENGTH = 1.0e-6
+_SIM_TIME = 40e-15
+_PML_CELLS = 8
+
+
+def _run_flux(grid) -> float:
+    config = fdtdx.SimulationConfig(time=_SIM_TIME, grid=grid, backend="cpu", gradient_config=None)
+    objects, constraints = [], []
+    volume = fdtdx.SimulationVolume(partial_real_shape=(_LXY, _LXY, _LZ))
+    objects.append(volume)
+
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+        thickness=_PML_CELLS,
+        boundary_type="pml",
+        override_types={f: "periodic" for f in ("min_x", "max_x", "min_y", "max_y")},
+    )
+    bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    objects.extend(bound_dict.values())
+    constraints.extend(c_list)
+
+    source = fdtdx.UniformPlaneSource(
+        name="src",
+        partial_grid_shape=(None, None, 1),
+        wave_character=fdtdx.WaveCharacter(wavelength=_WAVELENGTH),
+        direction="+",
+        fixed_E_polarization_vector=(1, 0, 0),
+        amplitude=1.0,
+    )
+    constraints.append(source.same_size(volume, axes=(0, 1)))
+    constraints.append(
+        source.place_relative_to(volume, axes=(2,), own_positions=(-1,), other_positions=(-1,), margins=(0.5e-6,))
+    )
+    objects.append(source)
+
+    det = fdtdx.PoyntingFluxDetector(name="flux", partial_grid_shape=(None, None, 1), direction="+", plot=False)
+    constraints.append(det.same_size(volume, axes=(0, 1)))
+    constraints.append(
+        det.place_relative_to(volume, axes=(2,), own_positions=(1,), other_positions=(1,), margins=(-0.5e-6,))
+    )
+    objects.append(det)
+
+    key = jax.random.PRNGKey(0)
+    obj, arrays, params, config, _ = fdtdx.place_objects(
+        object_list=objects, config=config, constraints=constraints, key=key
+    )
+    arrays, obj, _ = fdtdx.apply_params(arrays, obj, params, key)
+    _, out = fdtdx.run_fdtd(arrays=arrays, objects=obj, config=config, key=key, show_progress=False)
+
+    flux = np.asarray(out.detector_states["flux"]["poynting_flux"][:, 0])
+    dt = config.time_step_duration
+    steps_per_period = round(_WAVELENGTH / (fdtdx.constants.c * dt))
+    return float(np.mean(flux[-3 * steps_per_period :]))
+
+
+def test_tfsf_injection_is_grid_metric_independent():
+    """Injected plane-wave power matches between uniform and quasi-uniform (dz = 2dx) grids."""
+    flux_uniform = _run_flux(UniformGrid(spacing=_DX))
+    flux_quasi = _run_flux(QuasiUniformGrid(dx=_DX, dy=_DX, dz=2 * _DX))
+    ratio = flux_quasi / flux_uniform
+    # Without the metric factor on the TFSF correction, the ratio is ~3 (see #392).
+    assert 0.95 < ratio < 1.05, f"TFSF injected power depends on grid metric: ratio={ratio:.3f}"

--- a/tests/unit/objects/sources/test_tfsf.py
+++ b/tests/unit/objects/sources/test_tfsf.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from fdtdx.config import SimulationConfig
+from fdtdx.constants import c as c0
 from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.sources.linear_polarization import GaussianPlaneSource
@@ -153,6 +154,59 @@ class TestTFSFPlaneSourceProperties:
         assert center.shape == (2,)
         assert jnp.abs(center[0] - 1.5) <= 0.5
         assert jnp.abs(center[1] - 2.5) <= 0.5
+
+
+class TestMetricScaleAtPlane:
+    """Tests for the local derivative scale of the TFSF injection (regression for #392)."""
+
+    # Graded z widths so the backward stencil averages two differing neighbor widths.
+    Z_WIDTHS = np.array([80e-9, 90e-9, 100e-9, 110e-9, 120e-9, 130e-9, 140e-9, 150e-9])
+
+    def _place(self, config, jax_key, z_slice):
+        source = GaussianPlaneSource(
+            partial_grid_shape=(8, 8, 1),
+            wave_character=WaveCharacter(wavelength=1.55e-6),
+            direction="+",
+            radius=1e-6,
+            fixed_E_polarization_vector=(1, 0, 0),
+        )
+        return source.place_on_grid(((0, 8), (0, 8), z_slice), config, jax_key)
+
+    def _graded_config(self):
+        xy_edges = jnp.asarray(np.arange(9) * 100e-9)
+        z_edges = jnp.asarray(np.concatenate([[0.0], np.cumsum(self.Z_WIDTHS)]))
+        grid = RectilinearGrid(x_edges=xy_edges, y_edges=xy_edges, z_edges=z_edges)
+        return SimulationConfig(time=100e-15, grid=grid, backend="cpu")
+
+    def test_uniform_grid_returns_one(self, micro_config, jax_key):
+        """On uniform grids the scale is exactly 1 for both stencils."""
+        placed = self._place(micro_config, jax_key, z_slice=(4, 5))
+        assert placed._metric_scale_at_plane("backward") == 1.0
+        assert placed._metric_scale_at_plane("forward") == 1.0
+
+    def test_graded_grid_uses_local_widths(self, jax_key):
+        """Forward uses the plane's cell width; backward averages the two adjacent widths."""
+        config = self._graded_config()
+        placed = self._place(config, jax_key, z_slice=(4, 5))
+        ref = c0 * config.time_step_duration / config.courant_number
+        forward = float(placed._metric_scale_at_plane("forward"))
+        backward = float(placed._metric_scale_at_plane("backward"))
+        assert forward == pytest.approx(ref / self.Z_WIDTHS[4], rel=1e-6)
+        assert backward == pytest.approx(ref / (0.5 * (self.Z_WIDTHS[4] + self.Z_WIDTHS[3])), rel=1e-6)
+
+    def test_plane_at_domain_edge_replicates_first_width(self, jax_key):
+        """The backward stencil at index 0 has no previous cell and reuses the first width."""
+        config = self._graded_config()
+        placed = self._place(config, jax_key, z_slice=(0, 1))
+        ref = c0 * config.time_step_duration / config.courant_number
+        backward = float(placed._metric_scale_at_plane("backward"))
+        assert backward == pytest.approx(ref / self.Z_WIDTHS[0], rel=1e-6)
+
+    def test_invalid_stencil_raises(self, jax_key):
+        """An unknown stencil name is rejected."""
+        placed = self._place(self._graded_config(), jax_key, z_slice=(4, 5))
+        with pytest.raises(ValueError, match="stencil"):
+            placed._metric_scale_at_plane("centered")
 
 
 class TestTFSFPlaneSourceRandomization:


### PR DESCRIPTION
## Summary

Fixes #392. On non-uniform grids (`QuasiUniformGrid` / `RectilinearGrid`), the bulk curl updates scale each spatial derivative by the local metric factor `reference_spacing / cell_width` (`_metric_scale` in `core/physics/curl.py`), but the TFSF source correction in `TFSFPlaneSource.update_E` / `update_H` still injected with the bare scalar `courant_number`. Since the TFSF correction is a curl term at the source plane, it must carry the same local factor along the propagation axis. Without it, a source on a grid with dz != dx over-injects power by roughly `(dz/dx)^2`.

## Fix

Adds `TFSFPlaneSource._metric_scale_at_plane(stencil)`, mirroring the curl's `_metric_scale` for the single cell of the source plane, and multiplies the injected corrections by it:

- `update_E` uses the **backward** stencil (matching `curl_H`, which the E update consumes),
- `update_H` uses the **forward** stencil (matching `curl_E`).

On uniform grids the factor is exactly 1.0 and the behavior is unchanged. All TFSF-derived sources (`UniformPlaneSource`, `GaussianPlaneSource`, `LinearlyPolarizedPlaneSource`, `ModePlaneSource`) inherit the fix. The forward/backward (inverse) injection paths share the same code, so gradient runs stay consistent.

## Validation

Reproduction from the issue (vacuum, +z `UniformPlaneSource`, same physical domain and detector plane, PML z / periodic xy, steady-state flux through a fixed physical area):

| Grid | Flux ratio vs uniform (before) | (after) |
|---|---|---|
| `QuasiUniformGrid(dx=dy=25nm, dz=50nm)` | **2.98x** | **0.99** |

The above matches the ~3x predicted and ~2.8x observed in #392 (before fix).

New regression test `tests/simulation/physics/sources/test_tfsf_grid_normalization.py` asserts injected plane-wave power is grid-metric independent (ratio within 5%). Full unit+integration suite (2473 tests), pre-commit, and ty pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved total-field/scattered-field plane-wave source normalization on non-uniform grids by applying local metric scaling to the Courant-based coefficients.

* **Tests**
  * Added regression tests verifying injected wave power is consistent across uniform, quasi-uniform, and graded propagation-axis grids.
  * Added unit coverage for the new plane metric-scaling behavior, including edge handling and invalid stencil errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->