### PR TITLE
Small fix: Correct installation and contributing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ Also check out our [whitepaper](https://arxiv.org/abs/2412.12360) for some examp
 Install FDTDX using pip:
 
 ```bash
-pip install fdtdx  # Basic CPU-Installation
-pip install fdtdx[cuda12]  # GPU-Acceleration (Highly Recommended!)
-pip install fdtdx[rocm]   # AMD-GPU (only python<=3.12)
+pip install fdtdx
 ```
 
 For development installation, see the contributing guidelines!

--- a/docs/source/05_contributing.rst
+++ b/docs/source/05_contributing.rst
@@ -51,7 +51,7 @@ This is a checklist that you should go through before making a PR. The individua
 * [ ] Check if all unit tests run: ``pytest tests/``
 * [ ] Check if all pre-commit checks are passing: ``uv run pre-commit run --all``
 * [ ] If you added any new features, that should be top-level imported, add them to ``__all__`` in ``src/fdtdx/__init__.py``
-* [ ] If you want your new feature to be present in the documentation, add an entry to ``docs/source/api.rst``
+* [ ] If you want your new feature to be present in the documentation, add an entry to ``docs/source/07_api.rst``
 * [ ] Optional: If you want to go above and beyond, add a notebook showcasing your feature in the `notebooks repository <https://github.com/ymahlau/fdtdx-notebooks/>`__. Afterwards you can add an entry in the docs to include your new notebook.
 
 
@@ -60,9 +60,9 @@ Creating and running unit tests
 
 Testing is an important part of software development. Therefore, we ask you to create unit tests for any software that you write for this repository. Please also run all unit tests before opening a pull request to make sure that all existing test cases still work as intended. 
 
-You can run the unit tests with the ``pytest`` command in the fdtdx repository. If you want to specify a single test file to run you could specify the file after the command itself: ``pytest tests/conversion/test_export.py`` 
+You can run the unit tests with the ``pytest`` command in the fdtdx repository. If you want to specify a single test file to run you could specify the file after the command itself: ``pytest tests/unit/conversion/test_json.py``
 
-The unit tests are located in the ``/tests`` folder, which mirrors the structure of the ``/src`` folder. Therefore, if you are adding software to a file in the /src folder, please add the test cases at the corresponding location in the /test folder.
+The unit tests are located in the ``/tests`` folder, which mirrors the structure of the ``/src`` folder. Therefore, if you are adding software to a file in the /src folder, please add the test cases at the corresponding location in the /tests folder.
 
 Pull Requests
 -------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,9 +32,7 @@ Install FDTDX using pip:
 
 .. code-block:: bash
 
-   pip install fdtdx  # Basic CPU-Installation
-   pip install fdtdx[cuda12]  # GPU-Acceleration (Highly Recommended!)
-   pip install fdtdx[rocm]   # AMD-GPU (only python<=3.12)
+   pip install fdtdx
 
 
 For development installation, clone the repository and install in editable mode:
@@ -43,7 +41,7 @@ For development installation, clone the repository and install in editable mode:
 
    git clone https://github.com/ymahlau/fdtdx
    cd fdtdx
-   pip install -e . --extra dev
+   pip install -e ".[dev]"
 
 
 


### PR DESCRIPTION
This PR updates the installation and contribution instructions to match the current package configuration and repository structure.

- Removes references to the obsolete fdtdx[cuda12] and fdtdx[rocm] extra dependencies.
- Corrects the editable development installation command.
- Updates the API documentation path to `docs/source/07_api.rst`.
- Replaces invalid test file example with a valid path and corrects references from `/test` to `/tests`.

These changes are documentation-only and do not affect package behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified installation instructions to use a single `pip install fdtdx` command.
  * Updated development installation guidance to use the current extras syntax.
  * Corrected contributing links and test directory references.
  * Clarified how to run unit tests with `pytest` and where to ask project questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->