### PR TITLE
Fix stale package version in JsonSetup exports

### DIFF
--- a/src/fdtdx/conversion/json.py
+++ b/src/fdtdx/conversion/json.py
@@ -2,6 +2,7 @@ import dataclasses
 import importlib
 import json
 from dataclasses import dataclass
+from importlib.metadata import version
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -79,7 +80,7 @@ class JsonSetup:
         """
         export_format: dict[str, Any] = {
             "__schema__": "fdtdx.place_objects.v1",
-            "__fdtdx_version__": "0.6.0",
+            "__fdtdx_version__": version("fdtdx"),
             "config": self.config,
             "object_list": self.object_list,
             "constraints": self.constraints,

--- a/tests/integration/conversion/test_json.py
+++ b/tests/integration/conversion/test_json.py
@@ -1,5 +1,8 @@
 """Integration tests for fdtdx.conversion.json module."""
 
+import json
+from importlib.metadata import version
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -291,6 +294,7 @@ def test_jsonsetup_dumps_and_loads(setup_simulation_inputs):
     )
 
     s = setup.dumps()
+    assert json.loads(s)["__fdtdx_version__"] == version("fdtdx")
     setup2 = JsonSetup.loads(s)
 
     assert isinstance(setup2, JsonSetup)


### PR DESCRIPTION
## Summary

`JsonSetup.dumps()` currently hard-codes the exported FDTDX version as `0.6.0`, while the package version is `0.6.2`. This can cause newly generated JSON files to contain incorrect version metadata.

This PR:

- Retrieves the installed FDTDX version dynamically instead of hard-coding it.
- Uses the current package version for the `__fdtdx_version__` field.
- Adds a test to verify that exported JSON contains the correct version.

This prevents the JSON metadata from becoming outdated when new package versions are released.

## Tests

Added and ran the relevant JSON conversion tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exported JSON data now reports the installed package version accurately instead of relying on a fixed value.

* **Tests**
  * Added validation to ensure serialized JSON includes the correct package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->