### PR TITLE
ClosedSurfacePoyntingFluxDetector / TFSFPlaneSourceRegion

### DIFF
--- a/docs/source/07_api.rst
+++ b/docs/source/07_api.rst
@@ -16,6 +16,7 @@ API
     fdtdx.calculate_sparams
     fdtdx.CCPRPole
     fdtdx.circular_brush
+    fdtdx.ClosedSurfacePhasorPoyntingFluxDetector
     fdtdx.ClosedSurfacePoyntingFluxDetector
     fdtdx.ClosestIndex
     fdtdx.Color
@@ -84,6 +85,7 @@ API
     fdtdx.PerfectlyMatchedLayer
     fdtdx.PeriodicBoundary
     fdtdx.PhasorDetector
+    fdtdx.PhasorPoyntingFluxDetector
     fdtdx.PillarDiscretization
     fdtdx.place_objects
     fdtdx.plot_field_slice

--- a/docs/source/07_api.rst
+++ b/docs/source/07_api.rst
@@ -122,6 +122,7 @@ API
     fdtdx.SubpixelSmoothedProjection
     fdtdx.TanhProjection
     fdtdx.TemporalProfile
+    fdtdx.TFSFPlaneSourceRegion
     fdtdx.TreeClass
     fdtdx.unfold_array
     fdtdx.unfold_detector_states

--- a/docs/source/07_api.rst
+++ b/docs/source/07_api.rst
@@ -16,6 +16,7 @@ API
     fdtdx.calculate_sparams
     fdtdx.CCPRPole
     fdtdx.circular_brush
+    fdtdx.ClosedSurfacePoyntingFluxDetector
     fdtdx.ClosestIndex
     fdtdx.Color
     fdtdx.compute_energy

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -117,6 +117,7 @@ from fdtdx.objects.sources.profile import (
     SingleFrequencyProfile,
     TemporalProfile,
 )
+from fdtdx.objects.sources.tfsf_region import TFSFPlaneSourceRegion
 from fdtdx.objects.static_material.cylinder import Cylinder
 from fdtdx.objects.static_material.gds_layer_stack import (
     GDSLayerObject,
@@ -232,6 +233,7 @@ __all__ = [
     "StandardToInversePermittivityRange",
     "StandardToPlusOneMinusOneRange",
     "SubpixelSmoothedProjection",
+    "TFSFPlaneSourceRegion",
     "TanhProjection",
     "TemporalProfile",
     "TreeClass",

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -69,7 +69,7 @@ from fdtdx.objects.detectors.field_projection import (
 )
 from fdtdx.objects.detectors.mode import ModeOverlapDetector
 from fdtdx.objects.detectors.phasor import PhasorDetector
-from fdtdx.objects.detectors.poynting_flux import PoyntingFluxDetector
+from fdtdx.objects.detectors.poynting_flux import ClosedSurfacePoyntingFluxDetector, PoyntingFluxDetector
 from fdtdx.objects.device.device import Device
 from fdtdx.objects.device.parameters.continuous import (
     GaussianSmoothing2D,
@@ -162,6 +162,7 @@ __all__ = [
     "BoundaryConfig",
     "BrushConstraint2D",
     "CCPRPole",
+    "ClosedSurfacePoyntingFluxDetector",
     "ClosestIndex",
     "Color",
     "ConnectHolesAndStructures",

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -69,7 +69,12 @@ from fdtdx.objects.detectors.field_projection import (
 )
 from fdtdx.objects.detectors.mode import ModeOverlapDetector
 from fdtdx.objects.detectors.phasor import PhasorDetector
-from fdtdx.objects.detectors.poynting_flux import ClosedSurfacePoyntingFluxDetector, PoyntingFluxDetector
+from fdtdx.objects.detectors.poynting_flux import (
+    ClosedSurfacePhasorPoyntingFluxDetector,
+    ClosedSurfacePoyntingFluxDetector,
+    PhasorPoyntingFluxDetector,
+    PoyntingFluxDetector,
+)
 from fdtdx.objects.device.device import Device
 from fdtdx.objects.device.parameters.continuous import (
     GaussianSmoothing2D,
@@ -162,6 +167,7 @@ __all__ = [
     "BoundaryConfig",
     "BrushConstraint2D",
     "CCPRPole",
+    "ClosedSurfacePhasorPoyntingFluxDetector",
     "ClosedSurfacePoyntingFluxDetector",
     "ClosestIndex",
     "Color",
@@ -208,6 +214,7 @@ __all__ = [
     "PerfectlyMatchedLayer",
     "PeriodicBoundary",
     "PhasorDetector",
+    "PhasorPoyntingFluxDetector",
     "PillarDiscretization",
     "PointDipoleSource",
     "PointSymmetry2D",

--- a/src/fdtdx/conversion/json.py
+++ b/src/fdtdx/conversion/json.py
@@ -114,6 +114,8 @@ class JsonSetup:
             "UniformPlaneSource",
             "LinearlyPolarizedPlaneSource",
             # detectors
+            "ClosedSurfacePhasorPoyntingFluxDetector",
+            "ClosedSurfacePoyntingFluxDetector",
             "EnergyDetector",
             "FieldDetector",
             "FieldProjectionAngleDetector",
@@ -121,6 +123,7 @@ class JsonSetup:
             "FieldProjectionKSpaceDetector",
             "ModeOverlapDetector",
             "PhasorDetector",
+            "PhasorPoyntingFluxDetector",
             "PoyntingFluxDetector",
             # boundary
             "PerfectlyMatchedLayer",

--- a/src/fdtdx/core/physics/metrics.py
+++ b/src/fdtdx/core/physics/metrics.py
@@ -117,6 +117,46 @@ def compute_poynting_flux(E: jax.Array, H: jax.Array, axis: int = 0) -> jax.Arra
     )
 
 
+def net_poynting_flux_through_box(
+    poynting_vector: jax.Array,
+    active_axes: tuple[int, ...],
+    area_weights: tuple[jax.Array, ...],
+) -> jax.Array:
+    """Net outward Poynting flux through the faces of a rectangular box.
+
+    Integrates the outward-normal component of the Poynting vector over the six
+    (or fewer) faces of a box, accumulating **per cell** so that non-uniform
+    grids -- where the transverse cell areas differ from cell to cell within a
+    single face -- are handled exactly. For each active axis ``a`` the maximum
+    face (outward normal ``+a``) contributes ``+Sum(S_a * area)`` and the minimum
+    face (outward normal ``-a``) contributes ``-Sum(S_a * area)``.
+
+    A face pair on an axis of size one lands on the same cell and cancels to
+    zero, so thin or periodic axes may be omitted from ``active_axes`` without
+    changing the result.
+
+    Args:
+        poynting_vector (jax.Array): Real Poynting vector of shape
+            ``(3, Nx, Ny, Nz)`` sampled on the box cells (already co-located onto
+            a common Yee point by the detector interpolation).
+        active_axes (tuple[int, ...]): Axes whose two faces contribute to the sum.
+        area_weights (tuple[jax.Array, ...]): Indexed by axis; ``area_weights[a]``
+            holds the per-cell transverse face areas for a face normal to ``a``,
+            broadcastable to ``poynting_vector[a]`` (size one along axis ``a``).
+            Per-cell weighting is what makes the integral exact on non-uniform
+            grids.
+
+    Returns:
+        jax.Array: Scalar net outward flux (positive means net power leaving the
+        box).
+    """
+    net = jnp.zeros((), dtype=poynting_vector.dtype)
+    for a in active_axes:
+        weighted = poynting_vector[a] * area_weights[a]
+        net = net + jnp.take(weighted, -1, axis=a).sum() - jnp.take(weighted, 0, axis=a).sum()
+    return net
+
+
 def compute_integrated_power(
     E: jax.Array,
     H: jax.Array,

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -247,6 +247,19 @@ def place_objects(
         volume_idx=0,
     )
 
+    # Step 9b: Cross-object placement validation. Now that every object is placed and
+    # the container exists, give each object a chance to validate itself against the
+    # others (e.g. a TFSF region checking the boundaries around it). Accumulate all
+    # messages and raise once, mirroring the constraint-resolution error handling above.
+    placement_errors = {
+        obj.name: errs for obj in objects_container.objects if (errs := obj.validate_placement(objects_container))
+    }
+    if placement_errors:
+        formatted = "\n".join(
+            f"  - {name}:\n" + "\n".join(f"      * {msg}" for msg in msgs) for name, msgs in placement_errors.items()
+        )
+        raise ValueError(f"Invalid object placement:\n{formatted}")
+
     # Step 10: Initialize parameters and arrays
     assert key is not None
     key, subkey = jax.random.split(key)

--- a/src/fdtdx/objects/detectors/poynting_flux.py
+++ b/src/fdtdx/objects/detectors/poynting_flux.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Literal, Self
+from typing import ClassVar, Literal, Self, Sequence
 
 import jax
 import jax.numpy as jnp
@@ -7,6 +7,7 @@ from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.core.physics.metrics import compute_poynting_flux, net_poynting_flux_through_box
 from fdtdx.objects.detectors.detector import Detector, DetectorState
+from fdtdx.objects.detectors.phasor import PhasorDetector
 from fdtdx.typing import SliceTuple3D
 
 
@@ -40,6 +41,34 @@ def _resolve_face_area_weights(
     spacing = config.uniform_spacing()
     shape = tuple(upper - lower for lower, upper in slice_tuple)
     return jnp.ones(shape, dtype=dtype) * spacing * spacing
+
+
+def _slice_face(arr: jax.Array, axis: int, side: Literal["min", "max"]) -> jax.Array:
+    """Slice ``arr`` to a size-one face along ``axis``, keeping the dimension.
+
+    ``side="min"`` selects index 0 (the minimum face), ``side="max"`` the last
+    index (the maximum face). Used both to reduce a full-box area-weight array to
+    a single face and to pick the two boundary planes out of the phasor volume.
+    """
+    idxer: list[slice] = [slice(None)] * arr.ndim
+    idxer[axis] = slice(0, 1) if side == "min" else slice(-1, None)
+    return arr[tuple(idxer)]
+
+
+def _phasor_poynting_vector(phasors: jax.Array) -> jax.Array:
+    """Real Poynting vector ``Re(E x conj(H))`` from a phasor stack.
+
+    Args:
+        phasors (jax.Array): Complex phasors of shape ``(num_freqs, 6, *spatial)``
+            with the six components ordered ``(Ex, Ey, Ez, Hx, Hy, Hz)`` on axis 1.
+
+    Returns:
+        jax.Array: Real Poynting vector of shape ``(num_freqs, 3, *spatial)``. The
+        ``1/2`` time-average factor is *not* applied here; callers add it for the
+        continuous scaling mode (see the detector ``compute_*`` methods).
+    """
+    E_ph, H_ph = phasors[:, :3], phasors[:, 3:]
+    return compute_poynting_flux(E_ph, H_ph, axis=1).real
 
 
 @autoinit
@@ -253,3 +282,251 @@ class ClosedSurfacePoyntingFluxDetector(Detector):
         arr_idx = self._time_step_to_arr_idx[time_step]
         new_full_arr = state["poynting_flux"].at[arr_idx].set(net)
         return {"poynting_flux": new_full_arr}
+
+
+@autoinit
+class PhasorPoyntingFluxDetector(PhasorDetector):
+    """Time-averaged Poynting flux through a single plane in the frequency domain.
+
+    Frequency-domain analog of :class:`PoyntingFluxDetector`. Instead of recording
+    the instantaneous flux at every time step, it accumulates the complex field
+    phasors (inheriting all of :class:`PhasorDetector`'s DFT / subsampling /
+    scaling machinery) and forms the time-averaged Poynting flux
+    ``<S> = 1/2 Re(E(w) x H*(w))`` in the post-processing method
+    :meth:`compute_poynting_flux`. This mirrors how :class:`ModeOverlapDetector`
+    computes its (also bilinear) overlap after the run.
+
+    Because the flux is a *product* of two independently accumulated DFTs, the
+    surface integral cannot be folded into the per-step update the way the
+    time-domain detector does -- the phasors must be complete first. All six field
+    components are therefore always recorded.
+    """
+
+    #: Direction of flux measurement, either "+" for positive or "-" for negative along the propagation axis.
+    direction: Literal["+", "-"] = frozen_field()
+
+    #: By default, the propagation axis is the axis where the detector has a grid shape of 1. If the detector has
+    #: a shape of 1 in more than one axis or a different axis should be used, set this attribute. Defaults to None.
+    fixed_propagation_axis: int | None = frozen_field(default=None)
+
+    #: By default, only the Poynting flux component for the propagation axis is returned (scalar per wavelength).
+    #: If True, all three vector components are returned. Defaults to False.
+    keep_all_components: bool = frozen_field(default=False)
+
+    #: Always all six field components -- both E and H are needed for the Poynting flux. Not user-configurable.
+    components: Sequence[Literal["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]] = frozen_field(
+        default=("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"),
+        init=False,
+    )
+
+    #: Spatial phasors must be kept to perform the area integral, so volume reduction is disabled.
+    reduce_volume: bool = frozen_field(default=False, init=False)
+
+    #: Raw phasor auto-plotting is not meaningful; consume the ``compute_poynting_flux`` result instead.
+    plot: bool = frozen_field(default=False, init=False)
+
+    _cached_face_area_weights: jax.Array = private_field()
+
+    # Poynting flux magnitude is non-negative, but the signed convention matches PoyntingFluxDetector.
+    _signed_data: ClassVar[bool] = False
+
+    @property
+    def propagation_axis(self) -> int:
+        """Axis along which the Poynting flux is measured (the size-one grid dimension)."""
+        if self.fixed_propagation_axis is not None:
+            if self.fixed_propagation_axis not in [0, 1, 2]:
+                raise Exception(f"Invalid: {self.fixed_propagation_axis=}")
+            return self.fixed_propagation_axis
+        if sum([a == 1 for a in self.grid_shape]) != 1:
+            raise Exception(f"Invalid poynting flux detector shape: {self.grid_shape}")
+        return self.grid_shape.index(1)
+
+    def place_on_grid(
+        self: Self,
+        grid_slice_tuple: SliceTuple3D,
+        config: SimulationConfig,
+        key: jax.Array,
+    ) -> Self:
+        self = super().place_on_grid(grid_slice_tuple=grid_slice_tuple, config=config, key=key)
+        real_dtype = jnp.float64 if self.dtype == jnp.complex128 else jnp.float32
+        if self.keep_all_components:
+            weights = jnp.stack(
+                [_resolve_face_area_weights(self._config, self.grid_slice_tuple, axis, real_dtype) for axis in range(3)]
+            )
+        else:
+            weights = _resolve_face_area_weights(self._config, self.grid_slice_tuple, self.propagation_axis, real_dtype)
+        self = self.aset("_cached_face_area_weights", weights, create_new_ok=True)
+        return self
+
+    def compute_poynting_flux(self, state: DetectorState) -> jax.Array:
+        """Time-averaged Poynting flux through the plane at every recorded wavelength.
+
+        Args:
+            state (DetectorState): Detector state holding the accumulated phasors of
+                shape ``(1, num_freqs, 6, *grid_shape)``.
+
+        Returns:
+            jax.Array: Real flux of shape ``(num_freqs,)`` (net power through the
+            plane along the propagation axis), or ``(num_freqs, 3)`` when
+            ``keep_all_components`` is set (all three Poynting components).
+        """
+        phasors = state["phasor"][0]  # (num_freqs, 6, *grid_shape)
+        pv = _phasor_poynting_vector(phasors)  # (num_freqs, 3, *grid_shape)
+        if self.direction == "-":
+            pv = -pv
+        weights = self._cached_face_area_weights
+        if self.keep_all_components:
+            # weights: (3, *grid_shape); pv: (num_freqs, 3, *grid_shape) -> sum over spatial.
+            flux = jnp.sum(pv * weights[None, ...], axis=(2, 3, 4))
+        else:
+            # Only the propagation-axis component; weights broadcast over the frequency axis.
+            comp = pv[:, self.propagation_axis]  # (num_freqs, *grid_shape)
+            flux = jnp.sum(comp * weights, axis=(1, 2, 3))
+        if self.scaling_mode == "continuous":
+            flux = 0.5 * flux
+        return flux
+
+
+@autoinit
+class ClosedSurfacePhasorPoyntingFluxDetector(PhasorDetector):
+    """Net time-averaged Poynting flux through a closed box surface (frequency domain).
+
+    Frequency-domain analog of :class:`ClosedSurfacePoyntingFluxDetector`. It
+    accumulates field phasors and forms the net time-averaged outward flux
+    ``sum_faces 1/2 Re(E(w) x H*(w)) . dA`` in :meth:`compute_net_flux`.
+
+    Only the **hollow shell** is recorded: for each active axis just the two
+    boundary planes are stored, never the box interior. The persistent detector
+    state is therefore ``O(surface)`` rather than ``O(volume)`` -- the interior
+    phasors would be pure waste since the surface integral reads only the faces.
+
+    A face pair on an axis of size one cancels, so the default ``axes`` (every
+    axis with more than one cell) reduces to a 4-face surface for a quasi-2D setup
+    and a 6-face surface in full 3D, exactly like the time-domain version.
+    """
+
+    #: ``"outward"`` (default) counts net power leaving the box as positive.
+    #: ``"inward"`` flips the sign (net power entering, e.g. absorbed power).
+    orientation: Literal["outward", "inward"] = frozen_field(default="outward")
+
+    #: Axes whose two faces contribute to the surface integral. ``None`` (default)
+    #: uses every axis with a grid extent greater than one.
+    axes: tuple[int, ...] | None = frozen_field(default=None)
+
+    #: Always all six field components -- both E and H are needed for the Poynting flux. Not user-configurable.
+    components: Sequence[Literal["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]] = frozen_field(
+        default=("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"),
+        init=False,
+    )
+
+    #: Storage is per-face and handled explicitly, so the base volume reduction is disabled.
+    reduce_volume: bool = frozen_field(default=False, init=False)
+
+    #: Raw phasor auto-plotting is not meaningful; consume the ``compute_net_flux`` result instead.
+    plot: bool = frozen_field(default=False, init=False)
+
+    #: Per-axis face-area weights, each already reduced to a single boundary plane (size one on the normal axis).
+    _face_area_weights_per_axis: tuple | None = private_field(default=None)
+
+    # Net flux is signed (can be positive or negative).
+    _signed_data: ClassVar[bool] = True
+
+    def _resolve_active_axes(self) -> tuple[int, ...]:
+        """Return the axes whose faces contribute (validated, size-one skipped by default)."""
+        if self.axes is not None:
+            return tuple(self.axes)
+        return tuple(a for a in range(3) if self.grid_shape[a] > 1)
+
+    def place_on_grid(
+        self: Self,
+        grid_slice_tuple: SliceTuple3D,
+        config: SimulationConfig,
+        key: jax.Array,
+    ) -> Self:
+        if self.orientation not in ("outward", "inward"):
+            raise ValueError(f"orientation must be 'outward' or 'inward', got {self.orientation!r}")
+        if self.axes is not None and any(a not in (0, 1, 2) for a in self.axes):
+            raise ValueError(f"axes entries must be in (0, 1, 2), got {self.axes}")
+        self = super().place_on_grid(grid_slice_tuple=grid_slice_tuple, config=config, key=key)
+        real_dtype = jnp.float64 if self.dtype == jnp.complex128 else jnp.float32
+        # Reduce each axis' area weights to a single boundary plane (transverse area is
+        # independent of position along the normal, so either face works). This matches the
+        # hollow per-face storage below, where the field faces are already extracted.
+        weights = tuple(
+            _slice_face(_resolve_face_area_weights(self._config, self.grid_slice_tuple, axis, real_dtype), axis, "min")
+            for axis in range(3)
+        )
+        self = self.aset("_face_area_weights_per_axis", weights, create_new_ok=True)
+        return self
+
+    def _shape_dtype_single_time_step(
+        self,
+    ) -> dict[str, jax.ShapeDtypeStruct]:
+        field_dtype = jnp.complex128 if self.dtype == jnp.complex128 else jnp.complex64
+        num_components = len(self.components)
+        num_frequencies = len(self._angular_frequencies)
+        result: dict[str, jax.ShapeDtypeStruct] = {}
+        for a in self._resolve_active_axes():
+            plane_shape = tuple(1 if i == a else self.grid_shape[i] for i in range(3))
+            shape = (num_frequencies, num_components, *plane_shape)
+            result[f"phasor_axis{a}_min"] = jax.ShapeDtypeStruct(shape, field_dtype)
+            result[f"phasor_axis{a}_max"] = jax.ShapeDtypeStruct(shape, field_dtype)
+        return result
+
+    def update(
+        self,
+        time_step: jax.Array,
+        E: jax.Array,
+        H: jax.Array,
+        state: DetectorState,
+        inv_permittivity: jax.Array,
+        inv_permeability: jax.Array | float,
+    ) -> DetectorState:
+        del inv_permeability, inv_permittivity
+        time_passed = time_step * self._config.time_step_duration
+        static_scale = self._static_scale()
+
+        EH = jnp.stack([E[0], E[1], E[2], H[0], H[1], H[2]], axis=0)  # (6, nx, ny, nz)
+        phase_angles = self._angular_frequencies * time_passed  # (num_freqs,)
+        phasors = jnp.exp(1j * phase_angles).reshape((len(self._angular_frequencies),) + (1,) * EH.ndim)
+        new_phasors = EH * phasors * static_scale  # (num_freqs, 6, nx, ny, nz)
+
+        new_state = dict(state)
+        for a in self._resolve_active_axes():
+            # Spatial axis a maps to array axis a + 2 (leading freq and component axes).
+            for side in ("min", "max"):
+                key = f"phasor_axis{a}_{side}"
+                face = _slice_face(new_phasors, a + 2, side)[None, ...]  # (1, num_freqs, 6, *plane)
+                if self.inverse:
+                    new_state[key] = (state[key] - face).astype(self.dtype)
+                else:
+                    new_state[key] = (state[key] + face).astype(self.dtype)
+        return new_state
+
+    def compute_net_flux(self, state: DetectorState) -> jax.Array:
+        """Net time-averaged Poynting flux through the closed surface at every wavelength.
+
+        Args:
+            state (DetectorState): Detector state holding the per-face phasors.
+
+        Returns:
+            jax.Array: Real net flux of shape ``(num_freqs,)``. Positive means net
+            power leaving the box for ``orientation="outward"``.
+        """
+        if self._face_area_weights_per_axis is None:
+            raise Exception("Detector is not yet placed on the grid")
+        active_axes = self._resolve_active_axes()
+        num_freqs = len(self._angular_frequencies)
+        real_dtype = jnp.float64 if self.dtype == jnp.complex128 else jnp.float32
+        net = jnp.zeros((num_freqs,), dtype=real_dtype)
+        for a in active_axes:
+            area = self._face_area_weights_per_axis[a]  # (*plane) with normal axis size one
+            for side, sign in (("max", 1.0), ("min", -1.0)):
+                phasors = state[f"phasor_axis{a}_{side}"][0]  # (num_freqs, 6, *plane)
+                s_a = _phasor_poynting_vector(phasors)[:, a]  # (num_freqs, *plane)
+                net = net + sign * jnp.sum(s_a * area, axis=(1, 2, 3))
+        if self.orientation == "inward":
+            net = -net
+        if self.scaling_mode == "continuous":
+            net = 0.5 * net
+        return net

--- a/src/fdtdx/objects/detectors/poynting_flux.py
+++ b/src/fdtdx/objects/detectors/poynting_flux.py
@@ -5,9 +5,41 @@ import jax.numpy as jnp
 
 from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
-from fdtdx.core.physics.metrics import compute_poynting_flux
+from fdtdx.core.physics.metrics import compute_poynting_flux, net_poynting_flux_through_box
 from fdtdx.objects.detectors.detector import Detector, DetectorState
 from fdtdx.typing import SliceTuple3D
+
+
+def _resolve_face_area_weights(
+    config: SimulationConfig,
+    slice_tuple: SliceTuple3D,
+    axis: int,
+    dtype: jnp.dtype,
+) -> jax.Array:
+    """Per-cell face-area weights for a face normal to ``axis`` over ``slice_tuple``.
+
+    Uses the resolved grid's ``face_area`` (which returns per-cell transverse
+    areas, so non-uniform steps within a single face are captured exactly) and
+    falls back to ``spacing**2`` for a pure uniform grid with no resolved
+    rectilinear grid. Shared by :class:`PoyntingFluxDetector` (single plane) and
+    :class:`ClosedSurfacePoyntingFluxDetector` (box) so the grid/uniform handling
+    lives in one place.
+
+    Args:
+        config (SimulationConfig): Simulation config providing the resolved grid.
+        slice_tuple (SliceTuple3D): Grid slice of the detector region.
+        axis (int): Normal axis of the face.
+        dtype (jnp.dtype): Output dtype for the uniform fallback.
+
+    Returns:
+        jax.Array: Area weights broadcastable to the Poynting component on ``axis``.
+    """
+    grid = config.resolved_grid
+    if grid is not None:
+        return grid.face_area(axis=axis, slice_tuple=slice_tuple)
+    spacing = config.uniform_spacing()
+    shape = tuple(upper - lower for lower, upper in slice_tuple)
+    return jnp.ones(shape, dtype=dtype) * spacing * spacing
 
 
 @autoinit
@@ -74,18 +106,23 @@ class PoyntingFluxDetector(Detector):
             self.fixed_propagation_axis is not None or sum(a == 1 for a in self.grid_shape) == 1
         )
         if can_determine_axis:
-            grid = self._config.resolved_grid
-            if grid is not None:
-                if self.keep_all_components:
-                    weights = jnp.stack(
-                        [grid.face_area(axis=axis, slice_tuple=self.grid_slice_tuple) for axis in range(3)]
-                    )
-                else:
-                    weights = grid.face_area(axis=self.propagation_axis, slice_tuple=self.grid_slice_tuple)
+            if self.keep_all_components:
+                weights = jnp.stack(
+                    [
+                        _resolve_face_area_weights(self._config, self.grid_slice_tuple, axis, self.dtype)
+                        for axis in range(3)
+                    ]
+                )
+            elif self._config.resolved_grid is not None:
+                # Only touch propagation_axis when a rectilinear grid needs it; the uniform
+                # fallback is axis-independent, matching the legacy behavior where an invalid
+                # fixed_propagation_axis does not raise until propagation_axis is accessed.
+                weights = _resolve_face_area_weights(
+                    self._config, self.grid_slice_tuple, self.propagation_axis, self.dtype
+                )
             else:
-                spacing = self._config.uniform_spacing()
-                area = jnp.ones(self.grid_shape, dtype=self.dtype) * spacing * spacing
-                weights = jnp.stack([area, area, area]) if self.keep_all_components else area
+                # Uniform fallback: area is spacing**2 for every cell regardless of axis.
+                weights = _resolve_face_area_weights(self._config, self.grid_slice_tuple, 0, self.dtype)
             self = self.aset("_cached_face_area_weights", weights, create_new_ok=True)
         return self
 
@@ -127,3 +164,92 @@ class PoyntingFluxDetector(Detector):
         new_full_arr = state["poynting_flux"].at[arr_idx].set(pf)
         new_state = {"poynting_flux": new_full_arr}
         return new_state
+
+
+@autoinit
+class ClosedSurfacePoyntingFluxDetector(Detector):
+    """Net Poynting flux through the closed surface of a rectangular box.
+
+    Integrates the outward-normal Poynting component over all faces of the box
+    spanned by this detector's grid slice, giving a single scalar net power. It
+    is the natural probe for scattering/absorption power: a box in the pure
+    scattered-field region (outside a TFSF box) yields the scattered power, while
+    a box around an absorber yields the absorbed power (use ``orientation="inward"``).
+
+    Unlike :class:`PoyntingFluxDetector`, which measures flux through a single
+    plane, this closes the surface and sums all faces. The per-cell face-area
+    weighting makes the surface integral exact on non-uniform grids, where cell
+    areas differ across a single face.
+
+    A face pair on an axis of size one cancels to zero, so the default
+    ``axes`` (all axes with more than one cell) naturally reduces to a 4-face
+    surface for a quasi-2D / periodic setup and a 6-face surface in full 3D.
+    """
+
+    #: ``"outward"`` (default) counts net power leaving the box as positive.
+    #: ``"inward"`` flips the sign (net power entering, e.g. absorbed power).
+    orientation: Literal["outward", "inward"] = frozen_field(default="outward")
+
+    #: Axes whose two faces contribute to the surface integral. ``None`` (default)
+    #: uses every axis with a grid extent greater than one.
+    axes: tuple[int, ...] | None = frozen_field(default=None)
+
+    _face_area_weights_per_axis: tuple | None = private_field(default=None)
+
+    # Net flux is signed (can be positive or negative).
+    _signed_data: ClassVar[bool] = True
+
+    def _resolve_active_axes(self) -> tuple[int, ...]:
+        """Return the axes whose faces contribute (validated, size-one skipped by default)."""
+        if self.axes is not None:
+            return tuple(self.axes)
+        return tuple(a for a in range(3) if self.grid_shape[a] > 1)
+
+    def place_on_grid(
+        self: Self,
+        grid_slice_tuple: SliceTuple3D,
+        config: SimulationConfig,
+        key: jax.Array,
+    ) -> Self:
+        if self.orientation not in ("outward", "inward"):
+            raise ValueError(f"orientation must be 'outward' or 'inward', got {self.orientation!r}")
+        if self.axes is not None and any(a not in (0, 1, 2) for a in self.axes):
+            raise ValueError(f"axes entries must be in (0, 1, 2), got {self.axes}")
+        self = super().place_on_grid(grid_slice_tuple=grid_slice_tuple, config=config, key=key)
+        # Per-cell face-area weights for every axis (only the active ones are used
+        # at record time). Computing all three keeps this a fixed-shape pytree.
+        weights = tuple(
+            _resolve_face_area_weights(self._config, self.grid_slice_tuple, axis, self.dtype) for axis in range(3)
+        )
+        self = self.aset("_face_area_weights_per_axis", weights, create_new_ok=True)
+        return self
+
+    def _shape_dtype_single_time_step(
+        self,
+    ) -> dict[str, jax.ShapeDtypeStruct]:
+        return {"poynting_flux": jax.ShapeDtypeStruct((1,), self.dtype)}
+
+    def update(
+        self,
+        time_step: jax.Array,
+        E: jax.Array,
+        H: jax.Array,
+        state: DetectorState,
+        inv_permittivity: jax.Array,
+        inv_permeability: jax.Array | float,
+    ) -> DetectorState:
+        del inv_permeability, inv_permittivity
+        if self._face_area_weights_per_axis is None:
+            raise Exception("Detector is not yet placed on the grid")
+        pf = compute_poynting_flux(E, H).real
+        net = net_poynting_flux_through_box(
+            poynting_vector=pf,
+            active_axes=self._resolve_active_axes(),
+            area_weights=self._face_area_weights_per_axis,
+        )
+        if self.orientation == "inward":
+            net = -net
+        net = net.reshape((1,)).astype(self.dtype)
+        arr_idx = self._time_step_to_arr_idx[time_step]
+        new_full_arr = state["poynting_flux"].at[arr_idx].set(net)
+        return {"poynting_flux": new_full_arr}

--- a/src/fdtdx/objects/object.py
+++ b/src/fdtdx/objects/object.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
-from typing import Literal, Self
+from typing import TYPE_CHECKING, Literal, Self
 
 import jax
 
@@ -14,6 +14,10 @@ from fdtdx.core.jax.pytrees import (
     private_field,
 )
 from fdtdx.core.misc import ensure_slice_tuple
+
+if TYPE_CHECKING:
+    from fdtdx.fdtd.container import ObjectContainer
+
 from fdtdx.typing import (
     INVALID_SLICE_TUPLE_3D,
     UNDEFINED_SHAPE_3D,
@@ -324,6 +328,25 @@ class SimulationObject(TreeClass, ABC):
         del dispersive_c1, dispersive_c2, dispersive_c3, dispersive_c4
         del electric_conductivity
         return self
+
+    def validate_placement(self, objects: "ObjectContainer") -> list[str]:
+        """Validate this object against the fully-resolved object container.
+
+        Called once by :func:`~fdtdx.fdtd.initialization.place_objects` after every
+        object has been placed and the container built, giving cross-object checks
+        (e.g. a source verifying the boundaries around it) a place to run. Returns a
+        list of human-readable error messages; an empty list means the placement is
+        valid. The default implementation performs no checks.
+
+        Args:
+            objects (ObjectContainer): The fully-resolved container of all placed
+                objects (exposes ``.volume``, ``.boundary_objects``, ``.sources``, ...).
+
+        Returns:
+            list[str]: Error messages describing invalid placement, or ``[]``.
+        """
+        del objects
+        return []
 
     def place_relative_to(
         self,

--- a/src/fdtdx/objects/sources/linear_polarization.py
+++ b/src/fdtdx/objects/sources/linear_polarization.py
@@ -8,10 +8,10 @@ import numpy as np
 from fdtdx.core.grid import calculate_time_offset_yee
 from fdtdx.core.jax.pytrees import autoinit, frozen_field
 from fdtdx.core.linalg import get_wave_vector_raw, rotate_vector
-from fdtdx.core.misc import expand_to_3x3, linear_interpolated_indexing, normalize_polarization_for_source
+from fdtdx.core.misc import linear_interpolated_indexing, normalize_polarization_for_source
 from fdtdx.core.physics.metrics import compute_energy
 from fdtdx.dispersion import effective_inv_permittivity
-from fdtdx.objects.sources.tfsf import TFSFPlaneSource, _build_dispersive_H_filter
+from fdtdx.objects.sources.tfsf import TFSFPlaneSource, _build_dispersive_H_filter, _source_impedance
 
 
 def _linear_interpolate_rectilinear_2d(
@@ -254,33 +254,8 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
             E = E / total_energy_root
             H = H / total_energy_root
 
-        # adjust H for impedance of the medium
-        # check if fully anisotropic
-        if (
-            isinstance(inv_permittivities, jax.Array)
-            and inv_permittivities.ndim >= 1
-            and inv_permittivities.shape[0] == 9
-        ) or (
-            isinstance(inv_permeabilities, jax.Array)
-            and inv_permeabilities.ndim >= 1
-            and inv_permeabilities.shape[0] == 9
-        ):
-            # convert to 3x3 tensors
-            inv_eps_tensor = expand_to_3x3(inv_permittivities)  # shape: (3, 3, Nx, Ny, Nz)
-            inv_mu_tensor = expand_to_3x3(inv_permeabilities)  # shape: (3, 3, Nx, Ny, Nz)
-
-            # invert to get eps and mu tensors
-            perm = (2, 3, 4, 0, 1)  # (3, 3, nx, ny, nz) -> (nx, ny, nz, 3, 3)
-            inv_perm = (3, 4, 0, 1, 2)  # (nx, ny, nz, 3, 3) -> (3, 3, nx, ny, nz)
-            eps = jnp.linalg.inv(inv_eps_tensor.transpose(perm)).transpose(inv_perm)
-            mu = jnp.linalg.inv(inv_mu_tensor.transpose(perm)).transpose(inv_perm)
-
-            # compute effective permittivity and permeability along polarization directions
-            eps_eff = jnp.einsum("i,ijxyz,j->xyz", e_pol, eps, e_pol)
-            mu_eff = jnp.einsum("i,ijxyz,j->xyz", h_pol, mu, h_pol)
-            impedance = jnp.sqrt(mu_eff / eps_eff)
-        else:
-            impedance = jnp.sqrt(inv_permittivities / inv_permeabilities)
+        # adjust H for impedance of the medium (isotropic/diagonal or full-tensor)
+        impedance = _source_impedance(inv_permittivities, inv_permeabilities, e_pol, h_pol)
 
         H = H / impedance
 

--- a/src/fdtdx/objects/sources/tfsf.py
+++ b/src/fdtdx/objects/sources/tfsf.py
@@ -7,7 +7,9 @@ import numpy as np
 from loguru import logger
 
 from fdtdx.constants import c as c0
+from fdtdx.core.axis import get_oriented_transverse_axes
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
+from fdtdx.core.misc import expand_to_3x3
 from fdtdx.dispersion import (
     compute_eps_spectrum_from_coefficients,
     compute_impedance_corrected_temporal_profile,
@@ -131,6 +133,274 @@ def _build_dispersive_H_filter(
         eps_center=eps_center,
     )
     return jnp.asarray(s_H, dtype=dtype)
+
+
+def _source_impedance(
+    inv_permittivities: jax.Array,
+    inv_permeabilities: jax.Array | float,
+    e_pol: jax.Array,
+    h_pol: jax.Array,
+) -> jax.Array:
+    """Wave impedance seen by a plane-wave source along its polarization.
+
+    For isotropic / diagonally anisotropic media this is the scalar
+    ``sqrt(inv_eps / inv_mu)`` (i.e. ``sqrt(mu / eps)``). For fully anisotropic
+    media (9-component tensors) the permittivity and permeability tensors are
+    inverted and projected onto the E- and H-polarization directions before
+    taking the ratio. Shared by the single-plane source and the box region so
+    the impedance normalization is computed in exactly one place.
+
+    Args:
+        inv_permittivities: Inverse permittivity, already sliced to the source
+            cells. Scalar/1/3/9-component leading axis.
+        inv_permeabilities: Inverse permeability (same layout) or a float.
+        e_pol: Electric polarization unit vector, shape ``(3,)``.
+        h_pol: Magnetic polarization unit vector, shape ``(3,)``.
+
+    Returns:
+        The impedance array (or scalar) to divide the injected H field by.
+    """
+    if (
+        isinstance(inv_permittivities, jax.Array) and inv_permittivities.ndim >= 1 and inv_permittivities.shape[0] == 9
+    ) or (
+        isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim >= 1 and inv_permeabilities.shape[0] == 9
+    ):
+        # convert to 3x3 tensors
+        inv_eps_tensor = expand_to_3x3(inv_permittivities)  # shape: (3, 3, Nx, Ny, Nz)
+        inv_mu_tensor = expand_to_3x3(inv_permeabilities)  # shape: (3, 3, Nx, Ny, Nz)
+
+        # invert to get eps and mu tensors
+        perm = (2, 3, 4, 0, 1)  # (3, 3, nx, ny, nz) -> (nx, ny, nz, 3, 3)
+        inv_perm = (3, 4, 0, 1, 2)  # (nx, ny, nz, 3, 3) -> (3, 3, nx, ny, nz)
+        eps = jnp.linalg.inv(inv_eps_tensor.transpose(perm)).transpose(inv_perm)
+        mu = jnp.linalg.inv(inv_mu_tensor.transpose(perm)).transpose(inv_perm)
+
+        # compute effective permittivity and permeability along polarization directions
+        eps_eff = jnp.einsum("i,ijxyz,j->xyz", e_pol, eps, e_pol)
+        mu_eff = jnp.einsum("i,ijxyz,j->xyz", h_pol, mu, h_pol)
+        impedance = jnp.sqrt(mu_eff / eps_eff)
+    else:
+        impedance = jnp.sqrt(inv_permittivities / inv_permeabilities)
+    return impedance
+
+
+def _tfsf_inject_E_face(
+    E: jax.Array,
+    *,
+    grid_slice,
+    normal_axis: int,
+    sign: int,
+    incident_H: jax.Array,
+    time_offset_H: jax.Array,
+    temporal_H_filter: jax.Array | None,
+    inv_permittivities: jax.Array,
+    c: jax.Array | float,
+    time_step: jax.Array,
+    delta_t: float,
+    temporal_profile: TemporalProfile,
+    wave_character,
+    static_amplitude_factor: float,
+) -> jax.Array:
+    """Inject the incident-H TFSF correction into E on a single face.
+
+    A TFSF face couples the two field components tangential to the face
+    (``a``, ``b`` = the transverse axes of ``normal_axis``): the update of E[a]
+    is driven by the incident H[b] and E[b] by the incident H[a], with the
+    curl orientation baked into the signs (``g_H[a]=+H_b``, ``g_H[b]=-H_a``).
+    The face-normal component only picks up a correction under full anisotropy
+    (off-diagonal tensor bleed). The single-plane :class:`TFSFPlaneSource` is
+    the special case ``normal_axis == propagation_axis``; the box source calls
+    this once per active face with the face's outward-normal ``sign``.
+
+    Args:
+        E: Full-domain electric field array ``(3, Nx, Ny, Nz)``.
+        grid_slice: The face slice (size 1 along ``normal_axis``).
+        normal_axis: Axis normal to the face (0/1/2).
+        sign: Geometric injection sign (+1 min face, -1 max face; negated for
+            the reverse/adjoint update).
+        incident_H: Incident H profile on the face, shape ``(3, *face)``.
+        time_offset_H: Per-component Yee time offsets on the face ``(3, *face)``.
+        temporal_H_filter: Broadband impedance-corrected H profile (dispersive
+            media) or ``None`` to use the raw temporal profile.
+        inv_permittivities: Full-domain inverse permittivity array.
+        c: Courant number scaled by the local metric factor (backward stencil).
+        time_step: Current (possibly on/off-adjusted) time step.
+        delta_t: Simulation time-step duration (seconds).
+        temporal_profile: Source temporal profile.
+        wave_character: Source carrier WaveCharacter.
+        static_amplitude_factor: Static amplitude multiplier.
+
+    Returns:
+        The E array with the face correction added.
+    """
+    a_axis, b_axis = get_oriented_transverse_axes(normal_axis)
+
+    is_fully_anisotropic = inv_permittivities.ndim > 0 and inv_permittivities.shape[0] == 9
+    inv_permittivity_slice = inv_permittivities[:, *grid_slice]
+
+    amplitude_H = {}
+    for axis in (a_axis, b_axis):
+        if temporal_H_filter is None:
+            time_H = (time_step + time_offset_H[axis]) * delta_t
+            amplitude_H[axis] = (
+                temporal_profile.get_amplitude(
+                    time=time_H,
+                    period=wave_character.get_period(),
+                    phase_shift=wave_character.phase_shift,
+                )
+                * static_amplitude_factor
+            )
+        else:
+            idx_arr = time_step + time_offset_H[axis]
+            xp = jnp.arange(temporal_H_filter.shape[0], dtype=idx_arr.dtype)
+            amplitude_H[axis] = (
+                jnp.interp(idx_arr, xp, temporal_H_filter, left=0.0, right=0.0) * static_amplitude_factor
+            )
+
+    inject_complex_H = jnp.iscomplexobj(incident_H) and temporal_H_filter is None
+    amplitude_H_quad = {}
+    if inject_complex_H:
+        for axis in (a_axis, b_axis):
+            time_H = (time_step + time_offset_H[axis]) * delta_t
+            amplitude_H_quad[axis] = (
+                temporal_profile.get_amplitude(
+                    time=time_H,
+                    period=wave_character.get_period(),
+                    phase_shift=wave_character.phase_shift - 0.5 * np.pi,
+                )
+                * static_amplitude_factor
+            )
+
+    def incident_H_component(axis):
+        if inject_complex_H:
+            return jnp.real(incident_H[axis]) * amplitude_H[axis] + jnp.imag(incident_H[axis]) * amplitude_H_quad[axis]
+        return incident_H[axis] * amplitude_H[axis]
+
+    if is_fully_anisotropic:
+        H_b_inc = jax.lax.stop_gradient(incident_H_component(b_axis))
+        H_a_inc = jax.lax.stop_gradient(incident_H_component(a_axis))
+
+        def get_inv_eps(row, col):
+            return inv_permittivity_slice[row * 3 + col]
+
+        for row in (normal_axis, a_axis, b_axis):
+            correction = c * (get_inv_eps(row, a_axis) * (+H_b_inc) + get_inv_eps(row, b_axis) * (-H_a_inc))
+            E = E.at[row, *grid_slice].add(sign * correction)
+        return E
+
+    else:
+        H_b_inc = incident_H_component(b_axis)
+        H_b_inc = H_b_inc * c * inv_permittivity_slice[a_axis]
+        H_b_inc = jax.lax.stop_gradient(H_b_inc)
+
+        H_a_inc = incident_H_component(a_axis)
+        H_a_inc = H_a_inc * c * inv_permittivity_slice[b_axis]
+        H_a_inc = jax.lax.stop_gradient(H_a_inc)
+
+        E = E.at[a_axis, *grid_slice].add(sign * H_b_inc)
+        E = E.at[b_axis, *grid_slice].add(-sign * H_a_inc)
+        return E
+
+
+def _tfsf_inject_H_face(
+    H: jax.Array,
+    *,
+    grid_slice,
+    normal_axis: int,
+    sign: int,
+    incident_E: jax.Array,
+    time_offset_E: jax.Array,
+    inv_permeabilities: jax.Array | float,
+    c: jax.Array | float,
+    time_step: jax.Array,
+    delta_t: float,
+    temporal_profile: TemporalProfile,
+    wave_character,
+    static_amplitude_factor: float,
+) -> jax.Array:
+    """Inject the incident-E TFSF correction into H on a single face.
+
+    Symmetric counterpart of :func:`_tfsf_inject_E_face`: the tangential H
+    components are driven by the incident E of the other tangential axis
+    (``g_E[a]=-E_b``, ``g_E[b]=+E_a``). See that function for the parameter
+    conventions; ``time_offset_E``/``incident_E`` replace their H analogues and
+    ``c`` uses the forward metric stencil.
+
+    Returns:
+        The H array with the face correction added.
+    """
+    a_axis, b_axis = get_oriented_transverse_axes(normal_axis)
+
+    is_fully_anisotropic = (
+        isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0 and inv_permeabilities.shape[0] == 9
+    )
+
+    if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
+        inv_permeability_slice = inv_permeabilities[:, *grid_slice]
+    else:
+        inv_permeability_slice = inv_permeabilities
+
+    amplitude_E = {}
+    for axis in (a_axis, b_axis):
+        time_E = (time_step + time_offset_E[axis]) * delta_t
+        amplitude_E[axis] = (
+            temporal_profile.get_amplitude(
+                time=time_E,
+                period=wave_character.get_period(),
+                phase_shift=wave_character.phase_shift,
+            )
+            * static_amplitude_factor
+        )
+
+    inject_complex_E = jnp.iscomplexobj(incident_E)
+    amplitude_E_quad = {}
+    if inject_complex_E:
+        for axis in (a_axis, b_axis):
+            time_E = (time_step + time_offset_E[axis]) * delta_t
+            amplitude_E_quad[axis] = (
+                temporal_profile.get_amplitude(
+                    time=time_E,
+                    period=wave_character.get_period(),
+                    phase_shift=wave_character.phase_shift - 0.5 * np.pi,
+                )
+                * static_amplitude_factor
+            )
+
+    def incident_E_component(axis):
+        if inject_complex_E:
+            return jnp.real(incident_E[axis]) * amplitude_E[axis] + jnp.imag(incident_E[axis]) * amplitude_E_quad[axis]
+        return incident_E[axis] * amplitude_E[axis]
+
+    if is_fully_anisotropic:
+        E_a_inc = jax.lax.stop_gradient(incident_E_component(a_axis))
+        E_b_inc = jax.lax.stop_gradient(incident_E_component(b_axis))
+
+        def get_inv_mu(row, col):
+            return inv_permeability_slice[row * 3 + col]  # type: ignore
+
+        for row in (normal_axis, a_axis, b_axis):
+            correction = c * (get_inv_mu(row, a_axis) * (-E_b_inc) + get_inv_mu(row, b_axis) * (+E_a_inc))
+            H = H.at[row, *grid_slice].add(sign * correction)
+        return H
+
+    else:
+        E_a_inc = incident_E_component(a_axis)
+        if isinstance(inv_permeability_slice, jax.Array) and inv_permeability_slice.ndim > 1:
+            E_a_inc = E_a_inc * c * inv_permeability_slice[b_axis]
+        else:
+            E_a_inc = E_a_inc * c * inv_permeability_slice
+        E_a_inc = jax.lax.stop_gradient(E_a_inc)
+
+        E_b_inc = incident_E_component(b_axis)
+        if isinstance(inv_permeability_slice, jax.Array) and inv_permeability_slice.ndim > 1:
+            E_b_inc = E_b_inc * c * inv_permeability_slice[a_axis]
+        else:
+            E_b_inc = E_b_inc * c * inv_permeability_slice
+        E_b_inc = jax.lax.stop_gradient(E_b_inc)
+
+        H = H.at[b_axis, *grid_slice].add(sign * E_a_inc)
+        H = H.at[a_axis, *grid_slice].add(-sign * E_b_inc)
+        return H
 
 
 @autoinit
@@ -323,14 +593,24 @@ class TFSFPlaneSource(DirectionalPlaneSourceBase, ABC):
         # the real impedance of the local medium.
         raise NotImplementedError()
 
-    def _metric_scale_at_plane(self, stencil: str) -> jax.Array | float:
-        """Computes the local derivative scale along the propagation axis at the source plane.
+    def _metric_scale_at_plane(
+        self,
+        stencil: str,
+        normal_axis: int | None = None,
+        start_index: int | None = None,
+    ) -> jax.Array | float:
+        """Computes the local derivative scale across a face along its normal axis.
 
         On non-uniform grids, spatial derivatives are scaled by the local cell width.
         Returns 1.0 on uniform grids.
 
         Args:
             stencil (str): Either "backward" or "forward" difference stencil.
+            normal_axis (int | None): Axis normal to the face. Defaults to the
+                propagation axis (the single-plane case).
+            start_index (int | None): Grid index of the face along ``normal_axis``.
+                Defaults to this object's slice start on that axis. The box source
+                passes a per-face index so each face uses its own cell width.
 
         Returns:
             jax.Array | float: Scalar scale factor for the injected field corrections.
@@ -340,11 +620,14 @@ class TFSFPlaneSource(DirectionalPlaneSourceBase, ABC):
             return 1.0
         grid = config.resolved_grid
         assert grid is not None
-        widths = grid.cell_widths(self.propagation_axis)
-        start = self.grid_slice_tuple[self.propagation_axis][0]
-        width = widths[start]
+        if normal_axis is None:
+            normal_axis = self.propagation_axis
+        if start_index is None:
+            start_index = self.grid_slice_tuple[normal_axis][0]
+        widths = grid.cell_widths(normal_axis)
+        width = widths[start_index]
         if stencil == "backward":
-            width = 0.5 * (width + widths[max(start - 1, 0)])
+            width = 0.5 * (width + widths[max(start_index - 1, 0)])
         elif stencil != "forward":
             raise ValueError(f"Unknown derivative stencil: {stencil}")
         reference_spacing = c0 * config.time_step_duration / config.courant_number
@@ -362,114 +645,28 @@ class TFSFPlaneSource(DirectionalPlaneSourceBase, ABC):
         if self._E is None or self._H is None or self._time_offset_E is None or self._time_offset_H is None:
             raise Exception("Need to apply random key before calling update")
 
-        delta_t = self._config.time_step_duration
-        c = self._config.courant_number * self._metric_scale_at_plane("backward")
-
-        # Determine if fully anisotropic
-        is_fully_anisotropic = inv_permittivities.ndim > 0 and inv_permittivities.shape[0] == 9
-
-        # Slice the permittivity tensor at the TFSF boundary, shape: (num_components, Nx, Ny, Nz)
-        inv_permittivity_slice = inv_permittivities[:, *self.grid_slice]
-
-        # Calculate time points for H fields
-        h_axis, v_axis, p_axis = self.horizontal_axis, self.vertical_axis, self.propagation_axis
-        time_H = {}
-        amplitude_H = {}
-        for axis in [h_axis, v_axis, p_axis]:
-            time_H[axis] = (time_step + self._time_offset_H[axis]) * delta_t
-            if self._temporal_H_filter is None:
-                amplitude_H[axis] = (
-                    self.temporal_profile.get_amplitude(
-                        time=time_H[axis],
-                        period=self.wave_character.get_period(),
-                        phase_shift=self.wave_character.phase_shift,
-                    )
-                    * self.static_amplitude_factor
-                )
-            else:
-                # Dispersive background: look up the precomputed broadband
-                # impedance-corrected H profile at the Yee-offset time step.
-                # The time offset is spatially resolved — one fractional
-                # index per source cell — so use jnp.interp which preserves
-                # the array shape and zeros out-of-range samples (matching
-                # the raw profile's behavior at the source on/off boundaries).
-                idx_arr = time_step + self._time_offset_H[axis]
-                xp = jnp.arange(self._temporal_H_filter.shape[0], dtype=idx_arr.dtype)
-                amplitude_H[axis] = (
-                    jnp.interp(idx_arr, xp, self._temporal_H_filter, left=0.0, right=0.0) * self.static_amplitude_factor
-                )
-
-        # Complex (lossy) modal profile: inject the eigenmode's transverse phase
-        # via a quadrature (cos/sin) decomposition so the launched field is
-        # Re{M(x)·e^{-iθ}} rather than Re{M(x)}·cosθ. Only the get_amplitude path
-        # ever carries a complex profile (the dispersive H-filter path always sees
-        # a real profile), so the sin term reuses get_amplitude with a -pi/2 carrier
-        # shift. For a real profile the branch is skipped (bit-identical).
-        inject_complex_H = jnp.iscomplexobj(self._H) and self._temporal_H_filter is None
-        amplitude_H_quad = {}
-        if inject_complex_H:
-            for axis in [h_axis, v_axis, p_axis]:
-                amplitude_H_quad[axis] = (
-                    self.temporal_profile.get_amplitude(
-                        time=time_H[axis],
-                        period=self.wave_character.get_period(),
-                        phase_shift=self.wave_character.phase_shift - 0.5 * np.pi,
-                    )
-                    * self.static_amplitude_factor
-                )
-
-        def incident_H(axis):
-            if inject_complex_H:
-                return jnp.real(self._H[axis]) * amplitude_H[axis] + jnp.imag(self._H[axis]) * amplitude_H_quad[axis]
-            return self._H[axis] * amplitude_H[axis]
-
-        # if direction is negative, updates are reversed
+        # if direction is negative, updates are reversed; inverse update is inverted
         sign = 1 if self.direction == "+" else -1
-        # inverse update is inverted
         if inverse:
             sign = -sign
 
-        if is_fully_anisotropic:
-            # vertical incident wave part
-            H_v_inc = jax.lax.stop_gradient(incident_H(v_axis))
-            # horizontal incident wave part
-            H_h_inc = jax.lax.stop_gradient(incident_H(h_axis))
-
-            def get_inv_eps(row, col):
-                # get inverse permittivity tensor element at (row, col)
-                idx = row * 3 + col
-                return inv_permittivity_slice[idx]
-
-            # update uses -H_v, we have to subtract update, resulting in +H_v
-            # update uses +H_h, we have to subtract update, resulting in -H_h
-            E_p_correction = c * (get_inv_eps(p_axis, h_axis) * (+H_v_inc) + get_inv_eps(p_axis, v_axis) * (-H_h_inc))
-            E = E.at[p_axis, *self.grid_slice].add(sign * E_p_correction)
-            E_h_correction = c * (get_inv_eps(h_axis, h_axis) * (+H_v_inc) + get_inv_eps(h_axis, v_axis) * (-H_h_inc))
-            E = E.at[h_axis, *self.grid_slice].add(sign * E_h_correction)
-            E_v_correction = c * (get_inv_eps(v_axis, h_axis) * (+H_v_inc) + get_inv_eps(v_axis, v_axis) * (-H_h_inc))
-            E = E.at[v_axis, *self.grid_slice].add(sign * E_v_correction)
-
-            return E
-
-        else:
-            # vertical incident wave part
-            H_v_inc = incident_H(v_axis)
-            # Use horizontal component of inv_permittivity for H_v calculation
-            H_v_inc = H_v_inc * c * inv_permittivity_slice[h_axis]
-            H_v_inc = jax.lax.stop_gradient(H_v_inc)
-
-            # horizontal incident wave part
-            H_h_inc = incident_H(h_axis)
-            # Use vertical component of inv_permittivity for H_h calculation
-            H_h_inc = H_h_inc * c * inv_permittivity_slice[v_axis]
-            H_h_inc = jax.lax.stop_gradient(H_h_inc)
-
-            # update uses -H_v, we have to subtract update, resulting in +H_v
-            E = E.at[h_axis, *self.grid_slice].add(sign * H_v_inc)
-            # update uses +H_h, we have to subtract update, resulting in -H_h
-            E = E.at[v_axis, *self.grid_slice].add(-sign * H_h_inc)
-
-            return E
+        c = self._config.courant_number * self._metric_scale_at_plane("backward")
+        return _tfsf_inject_E_face(
+            E,
+            grid_slice=self.grid_slice,
+            normal_axis=self.propagation_axis,
+            sign=sign,
+            incident_H=self._H,
+            time_offset_H=self._time_offset_H,
+            temporal_H_filter=self._temporal_H_filter,
+            inv_permittivities=inv_permittivities,
+            c=c,
+            time_step=time_step,
+            delta_t=self._config.time_step_duration,
+            temporal_profile=self.temporal_profile,
+            wave_character=self.wave_character,
+            static_amplitude_factor=self.static_amplitude_factor,
+        )
 
     def update_H(
         self,
@@ -483,108 +680,24 @@ class TFSFPlaneSource(DirectionalPlaneSourceBase, ABC):
         if self._E is None or self._H is None or self._time_offset_E is None or self._time_offset_H is None:
             raise Exception("Need to apply random key before calling update")
 
-        delta_t = self._config.time_step_duration
-        c = self._config.courant_number * self._metric_scale_at_plane("forward")
-
-        # Determine if fully anisotropic
-        is_fully_anisotropic = (
-            isinstance(inv_permeabilities, jax.Array)
-            and inv_permeabilities.ndim > 0
-            and inv_permeabilities.shape[0] == 9
-        )
-
-        if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
-            # Slice the permeability tensor at the TFSF boundary, shape: (num_components, Nx, Ny, Nz)
-            inv_permeability_slice = inv_permeabilities[:, *self.grid_slice]
-        else:
-            inv_permeability_slice = inv_permeabilities
-
-        # Calculate time points for E fields
-        h_axis, v_axis, p_axis = self.horizontal_axis, self.vertical_axis, self.propagation_axis
-        time_E = {}
-        amplitude_E = {}
-        for axis in [h_axis, v_axis, p_axis]:
-            time_E[axis] = (time_step + self._time_offset_E[axis]) * delta_t
-            amplitude_E[axis] = (
-                self.temporal_profile.get_amplitude(
-                    time=time_E[axis],
-                    period=self.wave_character.get_period(),
-                    phase_shift=self.wave_character.phase_shift,
-                )
-                * self.static_amplitude_factor
-            )
-
-        # Complex (lossy) modal profile: inject the eigenmode's transverse phase
-        # via a quadrature (cos/sin) decomposition (see update_E). Bit-identical
-        # for a real profile.
-        inject_complex_E = jnp.iscomplexobj(self._E)
-        amplitude_E_quad = {}
-        if inject_complex_E:
-            for axis in [h_axis, v_axis, p_axis]:
-                amplitude_E_quad[axis] = (
-                    self.temporal_profile.get_amplitude(
-                        time=time_E[axis],
-                        period=self.wave_character.get_period(),
-                        phase_shift=self.wave_character.phase_shift - 0.5 * np.pi,
-                    )
-                    * self.static_amplitude_factor
-                )
-
-        def incident_E(axis):
-            if inject_complex_E:
-                return jnp.real(self._E[axis]) * amplitude_E[axis] + jnp.imag(self._E[axis]) * amplitude_E_quad[axis]
-            return self._E[axis] * amplitude_E[axis]
-
-        # if direction is negative, updates are reversed
+        # if direction is negative, updates are reversed; inverse update is inverted
         sign = 1 if self.direction == "+" else -1
-        # inverse update is inverted
         if inverse:
             sign = -sign
 
-        if is_fully_anisotropic:
-            # horizontal incident wave part
-            E_h_inc = jax.lax.stop_gradient(incident_E(h_axis))
-            # vertical incident wave part
-            E_v_inc = jax.lax.stop_gradient(incident_E(v_axis))
-
-            def get_inv_mu(row, col):
-                # get inverse permeability tensor element at (row, col)
-                idx = row * 3 + col
-                return inv_permeability_slice[idx]  # type: ignore
-
-            # update uses +E_h, we have to add update, resulting in +E_h
-            # update uses -E_v, we have to add update, resulting in -E_v
-            H_p_correction = c * (get_inv_mu(p_axis, h_axis) * (-E_v_inc) + get_inv_mu(p_axis, v_axis) * (+E_h_inc))
-            H = H.at[p_axis, *self.grid_slice].add(sign * H_p_correction)
-            H_h_correction = c * (get_inv_mu(h_axis, h_axis) * (-E_v_inc) + get_inv_mu(h_axis, v_axis) * (+E_h_inc))
-            H = H.at[h_axis, *self.grid_slice].add(sign * H_h_correction)
-            H_v_correction = c * (get_inv_mu(v_axis, h_axis) * (-E_v_inc) + get_inv_mu(v_axis, v_axis) * (+E_h_inc))
-            H = H.at[v_axis, *self.grid_slice].add(sign * H_v_correction)
-
-            return H
-
-        else:
-            # horizontal incident wave part
-            E_h_inc = incident_E(h_axis)
-            # Use vertical component of inv_permeability for E_h calculation
-            if isinstance(inv_permeability_slice, jax.Array) and inv_permeability_slice.ndim > 1:
-                E_h_inc = E_h_inc * c * inv_permeability_slice[v_axis]
-            else:
-                E_h_inc = E_h_inc * c * inv_permeability_slice
-            E_h_inc = jax.lax.stop_gradient(E_h_inc)
-
-            # vertical incident wave part
-            E_v_inc = incident_E(v_axis)
-            # Use horizontal component of inv_permeability for E_v calculation
-            if isinstance(inv_permeability_slice, jax.Array) and inv_permeability_slice.ndim > 1:
-                E_v_inc = E_v_inc * c * inv_permeability_slice[h_axis]
-            else:
-                E_v_inc = E_v_inc * c * inv_permeability_slice
-            E_v_inc = jax.lax.stop_gradient(E_v_inc)
-
-            # update used +E_h, we have to add update, resulting in +E_h
-            H = H.at[v_axis, *self.grid_slice].add(sign * E_h_inc)
-            # update used -E_v, we have to add update, resulting in -E_v
-            H = H.at[h_axis, *self.grid_slice].add(-sign * E_v_inc)
-
-            return H
+        c = self._config.courant_number * self._metric_scale_at_plane("forward")
+        return _tfsf_inject_H_face(
+            H,
+            grid_slice=self.grid_slice,
+            normal_axis=self.propagation_axis,
+            sign=sign,
+            incident_E=self._E,
+            time_offset_E=self._time_offset_E,
+            inv_permeabilities=inv_permeabilities,
+            c=c,
+            time_step=time_step,
+            delta_t=self._config.time_step_duration,
+            temporal_profile=self.temporal_profile,
+            wave_character=self.wave_character,
+            static_amplitude_factor=self.static_amplitude_factor,
+        )

--- a/src/fdtdx/objects/sources/tfsf_region.py
+++ b/src/fdtdx/objects/sources/tfsf_region.py
@@ -1,0 +1,438 @@
+from typing import TYPE_CHECKING, Literal, Self
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from fdtdx.core.axis import get_oriented_transverse_axes
+from fdtdx.core.grid import calculate_time_offset_yee
+from fdtdx.core.jax.pytrees import autoinit, frozen_field, frozen_private_field, private_field
+from fdtdx.core.linalg import get_wave_vector_raw, rotate_vector
+from fdtdx.core.misc import normalize_polarization_for_source
+from fdtdx.dispersion import effective_inv_permittivity
+from fdtdx.objects.boundaries.bloch import BlochBoundary
+from fdtdx.objects.sources.tfsf import (
+    TFSFPlaneSource,
+    _build_dispersive_H_filter,
+    _source_impedance,
+    _tfsf_inject_E_face,
+    _tfsf_inject_H_face,
+)
+
+if TYPE_CHECKING:
+    from fdtdx.fdtd.container import ObjectContainer
+
+
+@autoinit
+class TFSFPlaneSourceRegion(TFSFPlaneSource):
+    """Total-Field/Scattered-Field (TFSF) *box* source.
+
+    A uniform plane wave is injected on the bounding faces of a rectangular
+    box so that the **total field lives inside** the box and **only the
+    scattered field exists outside**. A scatterer placed inside the box sees a
+    clean incident plane wave; the scattered field radiates outward into the
+    scattered-field region where it can be absorbed by PML or measured.
+
+    Unlike :class:`~fdtdx.objects.sources.tfsf.TFSFPlaneSource` (a single-plane,
+    one-way launcher), this is a volume object with an explicit
+    :attr:`propagation_axis`. Every active face evaluates *one coherent* plane
+    wave sharing a single spatial phase origin (the box lower corner): the
+    entry faces launch the wave and the exit faces terminate it (sign-flipped),
+    keeping the propagation direction of ``k = E x H`` intact.
+
+    Faces are injected on the propagation axis (always, both caps) and on each
+    transverse axis that is *confined*. A transverse axis listed in
+    :attr:`periodic_axes` is treated as "wrap-around": no correction is applied
+    on its faces and the periodic boundaries close the total-field region in
+    that direction. A wrap axis must have periodic/Bloch boundaries on both
+    sides and the box must span the full domain along it (validated at
+    placement time).
+
+    Media parity: the field injection handles isotropic, diagonally
+    anisotropic, and fully anisotropic tensors as well as dispersive
+    backgrounds — the same code paths as ``TFSFPlaneSource``. As with the
+    single-plane source, the propagation time-of-flight requires the material
+    at the source faces to be locally isotropic (a genuinely anisotropic face
+    raises ``NotImplementedError`` from ``calculate_time_offset_yee``).
+    """
+
+    #: the propagation axis (0=x, 1=y, 2=z). Overrides the size-1-axis inference
+    #: of :class:`DirectionalPlaneSourceBase`, which does not apply to a box.
+    propagation_axis: int = frozen_field()
+
+    #: transverse axes treated as periodic/wrap (no TFSF correction on their
+    #: faces). Must be a subset of the two transverse axes; the propagation axis
+    #: may never appear here.
+    periodic_axes: tuple[int, ...] = frozen_field(default=())
+
+    #: the amplitude of the uniform plane wave
+    amplitude: float = frozen_field(default=1.0)
+
+    #: the electric polarization vector
+    fixed_E_polarization_vector: tuple[float, float, float] | None = frozen_field(default=None)
+
+    #: the magnetic polarization vector
+    fixed_H_polarization_vector: tuple[float, float, float] | None = frozen_field(default=None)
+
+    # Per-face static metadata (excluded from pytree traversal).
+    _face_normal_axes: tuple[int, ...] | None = frozen_private_field(default=None)
+    _face_signs: tuple[int, ...] | None = frozen_private_field(default=None)
+    _face_slice_tuples: tuple | None = frozen_private_field(default=None)
+
+    # Per-face traced leaves (parallel to the metadata tuples above).
+    _face_incident_E: tuple | None = private_field(default=None)
+    _face_incident_H: tuple | None = private_field(default=None)
+    _face_time_offset_E: tuple | None = private_field(default=None)
+    _face_time_offset_H: tuple | None = private_field(default=None)
+    _face_H_filter: tuple | None = private_field(default=None)
+
+    def _region_resolution(self) -> float:
+        config = self._config
+        if config.has_nonuniform_grid:
+            assert config.resolved_grid is not None
+            return config.resolved_grid.min_spacing
+        return config.uniform_spacing()
+
+    def _box_edges(self) -> tuple[jax.Array, jax.Array, jax.Array]:
+        """Physical edge coordinates spanning the box, origin at the box corner.
+
+        Returns three 1-D arrays (one per axis) shifted so the box lower corner
+        is the local origin. This is the coherent coordinate system shared by
+        every face so a single plane-wave phase sweeps the whole box.
+        """
+        config = self._config
+        if config.has_nonuniform_grid:
+            grid = config.resolved_grid
+            assert grid is not None
+            edges = []
+            for axis in range(3):
+                lower, upper = self.grid_slice_tuple[axis]
+                e = grid.edges(axis)[lower : upper + 1]
+                edges.append(e - e[0])
+            return edges[0], edges[1], edges[2]
+        spacing = config.uniform_spacing()
+        edges = [jnp.arange(self.grid_shape[axis] + 1, dtype=config.dtype) * spacing for axis in range(3)]
+        return edges[0], edges[1], edges[2]
+
+    def _active_faces(self) -> list[tuple[int, Literal["-", "+"]]]:
+        """Enumerate ``(normal_axis, side)`` for every injected face.
+
+        Always both propagation caps; both faces of each confined transverse
+        axis; nothing for a transverse axis listed in ``periodic_axes``.
+        """
+        faces: list[tuple[int, Literal["-", "+"]]] = [
+            (self.propagation_axis, "-"),
+            (self.propagation_axis, "+"),
+        ]
+        for t_axis in get_oriented_transverse_axes(self.propagation_axis):
+            if t_axis in tuple(self.periodic_axes):
+                continue
+            faces.append((t_axis, "-"))
+            faces.append((t_axis, "+"))
+        return faces
+
+    def apply(
+        self: Self,
+        key: jax.Array,
+        inv_permittivities: jax.Array,
+        inv_permeabilities: jax.Array | float,
+        dispersive_c1: jax.Array | None = None,
+        dispersive_c2: jax.Array | None = None,
+        dispersive_c3: jax.Array | None = None,
+        electric_conductivity: jax.Array | None = None,
+        dispersive_c4: jax.Array | None = None,
+    ) -> Self:
+        del electric_conductivity
+        config = self._config
+        p_axis = self.propagation_axis
+        axes_tpl = (self.horizontal_axis, self.vertical_axis, self.propagation_axis)
+
+        # polarization and (possibly tilted) wave vector — shared by all faces
+        e_pol_raw, h_pol_raw = normalize_polarization_for_source(
+            direction=self.direction,
+            propagation_axis=p_axis,
+            fixed_E_polarization_vector=self.fixed_E_polarization_vector,
+            fixed_H_polarization_vector=self.fixed_H_polarization_vector,
+            dtype=config.dtype,
+        )
+        wave_vector_raw = get_wave_vector_raw(direction=self.direction, propagation_axis=p_axis, dtype=config.dtype)
+
+        key, subkey = jax.random.split(key)
+        azimuth, elevation = self._get_azimuth_elevation(subkey)
+        wave_vector = rotate_vector(wave_vector_raw, azimuth, elevation, axes_tpl)
+        e_pol = rotate_vector(e_pol_raw, azimuth, elevation, axes_tpl)
+        h_pol = rotate_vector(h_pol_raw, azimuth, elevation, axes_tpl)
+
+        box_edges = self._box_edges()
+        # Single coherent phase origin (box lower corner) reused for every face.
+        center_physical = jnp.zeros(3, dtype=config.dtype)
+        resolution = self._region_resolution()
+        omega_c = 2.0 * np.pi * self.wave_character.get_frequency()
+
+        box_slice = self.grid_slice_tuple
+
+        normal_axes: list[int] = []
+        signs: list[int] = []
+        slice_tuples: list = []
+        inc_E_list: list = []
+        inc_H_list: list = []
+        toff_E_list: list = []
+        toff_H_list: list = []
+        filt_list: list = []
+
+        for normal_axis, side in self._active_faces():
+            lower, upper = box_slice[normal_axis]
+            if side == "-":
+                face_norm_slice = (lower, lower + 1)
+                sign = 1  # min face
+                normal_edges = box_edges[normal_axis][0:2]
+            else:
+                face_norm_slice = (upper - 1, upper)
+                sign = -1  # max face
+                normal_edges = box_edges[normal_axis][-2:]
+
+            face_slice_tuple = list(box_slice)
+            face_slice_tuple[normal_axis] = face_norm_slice
+            face_slice_tuple = tuple(face_slice_tuple)
+            face_slice = tuple(slice(a, b) for (a, b) in face_slice_tuple)
+            face_shape = tuple(b - a for (a, b) in face_slice_tuple)
+
+            coord_edges = list(box_edges)
+            coord_edges[normal_axis] = normal_edges
+            coord_edges = (coord_edges[0], coord_edges[1], coord_edges[2])
+
+            # material at this face
+            inv_eps_face = inv_permittivities[:, *face_slice]
+            if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:
+                inv_mu_face = inv_permeabilities[:, *face_slice]
+            else:
+                inv_mu_face = inv_permeabilities
+            inv_eps_inf_face = inv_eps_face  # raw ε∞ before any carrier correction
+
+            # dispersive carrier-frequency correction (matches the single-plane source)
+            c1_s = c2_s = c3_s = c4_s = None
+            if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
+                c1_s = dispersive_c1[:, :, *face_slice]
+                c2_s = dispersive_c2[:, :, *face_slice]
+                c3_s = dispersive_c3[:, :, *face_slice]
+                c4_s = None if dispersive_c4 is None else dispersive_c4[:, :, *face_slice]
+                inv_eps_face = effective_inv_permittivity(
+                    inv_eps=inv_eps_face,
+                    c1=c1_s,
+                    c2=c2_s,
+                    c3=c3_s,
+                    omega=omega_c,
+                    dt=config.time_step_duration,
+                    c4=c4_s,
+                )
+
+            impedance = _source_impedance(inv_eps_face, inv_mu_face, e_pol, h_pol)
+
+            E_inc = jnp.broadcast_to(self.amplitude * e_pol[:, None, None, None], (3, *face_shape)).astype(config.dtype)
+            H_face = self.amplitude * h_pol[:, None, None, None] / impedance
+            H_inc = jnp.broadcast_to(H_face, (3, *face_shape)).astype(config.dtype)
+
+            time_offset_E, time_offset_H = calculate_time_offset_yee(
+                center=jnp.zeros(2, dtype=config.dtype),
+                wave_vector=wave_vector,
+                inv_permittivities=inv_eps_face,
+                inv_permeabilities=inv_mu_face,
+                resolution=resolution,
+                time_step_duration=config.time_step_duration,
+                e_polarization=e_pol,
+                h_polarization=h_pol,
+                coordinate_edges=coord_edges,
+                center_physical=center_physical,
+            )
+
+            filt = None
+            if c1_s is not None and c2_s is not None and c3_s is not None:
+                filt = _build_dispersive_H_filter(
+                    temporal_profile=self.temporal_profile,
+                    wave_character=self.wave_character,
+                    dt=config.time_step_duration,
+                    num_time_steps=config.time_steps_total,
+                    c1_slice=c1_s,
+                    c2_slice=c2_s,
+                    c3_slice=c3_s,
+                    inv_eps_inf_slice=inv_eps_inf_face,
+                    dtype=config.dtype,
+                    c4_slice=c4_s,
+                )
+
+            normal_axes.append(normal_axis)
+            signs.append(sign)
+            slice_tuples.append(face_slice_tuple)
+            inc_E_list.append(E_inc)
+            inc_H_list.append(H_inc)
+            toff_E_list.append(time_offset_E)
+            toff_H_list.append(time_offset_H)
+            filt_list.append(filt)
+
+        self = self.aset("_face_normal_axes", tuple(normal_axes), create_new_ok=True)
+        self = self.aset("_face_signs", tuple(signs), create_new_ok=True)
+        self = self.aset("_face_slice_tuples", tuple(slice_tuples), create_new_ok=True)
+        self = self.aset("_face_incident_E", tuple(inc_E_list), create_new_ok=True)
+        self = self.aset("_face_incident_H", tuple(inc_H_list), create_new_ok=True)
+        self = self.aset("_face_time_offset_E", tuple(toff_E_list), create_new_ok=True)
+        self = self.aset("_face_time_offset_H", tuple(toff_H_list), create_new_ok=True)
+        self = self.aset("_face_H_filter", tuple(filt_list), create_new_ok=True)
+        return self
+
+    def update_E(
+        self,
+        E: jax.Array,
+        inv_permittivities: jax.Array,
+        inv_permeabilities: jax.Array | float,
+        time_step: jax.Array,
+        inverse: bool,
+    ) -> jax.Array:
+        del inv_permeabilities
+        normal_axes = self._face_normal_axes
+        signs = self._face_signs
+        slice_tuples = self._face_slice_tuples
+        incident_H = self._face_incident_H
+        time_offset_H = self._face_time_offset_H
+        h_filter = self._face_H_filter
+        if (
+            normal_axes is None
+            or signs is None
+            or slice_tuples is None
+            or incident_H is None
+            or time_offset_H is None
+            or h_filter is None
+        ):
+            raise Exception("Need to apply random key before calling update")
+
+        delta_t = self._config.time_step_duration
+        for i, normal_axis in enumerate(normal_axes):
+            sign = -signs[i] if inverse else signs[i]
+            face_slice_tuple = slice_tuples[i]
+            grid_slice = tuple(slice(a, b) for (a, b) in face_slice_tuple)
+            start_index = face_slice_tuple[normal_axis][0]
+            c = self._config.courant_number * self._metric_scale_at_plane("backward", normal_axis, start_index)
+            E = _tfsf_inject_E_face(
+                E,
+                grid_slice=grid_slice,
+                normal_axis=normal_axis,
+                sign=sign,
+                incident_H=incident_H[i],
+                time_offset_H=time_offset_H[i],
+                temporal_H_filter=h_filter[i],
+                inv_permittivities=inv_permittivities,
+                c=c,
+                time_step=time_step,
+                delta_t=delta_t,
+                temporal_profile=self.temporal_profile,
+                wave_character=self.wave_character,
+                static_amplitude_factor=self.static_amplitude_factor,
+            )
+        return E
+
+    def update_H(
+        self,
+        H: jax.Array,
+        inv_permittivities: jax.Array,
+        inv_permeabilities: jax.Array | float,
+        time_step: jax.Array,
+        inverse: bool,
+    ) -> jax.Array:
+        del inv_permittivities
+        normal_axes = self._face_normal_axes
+        signs = self._face_signs
+        slice_tuples = self._face_slice_tuples
+        incident_E = self._face_incident_E
+        time_offset_E = self._face_time_offset_E
+        if normal_axes is None or signs is None or slice_tuples is None or incident_E is None or time_offset_E is None:
+            raise Exception("Need to apply random key before calling update")
+
+        delta_t = self._config.time_step_duration
+        for i, normal_axis in enumerate(normal_axes):
+            sign = -signs[i] if inverse else signs[i]
+            face_slice_tuple = slice_tuples[i]
+            grid_slice = tuple(slice(a, b) for (a, b) in face_slice_tuple)
+            start_index = face_slice_tuple[normal_axis][0]
+            c = self._config.courant_number * self._metric_scale_at_plane("forward", normal_axis, start_index)
+            H = _tfsf_inject_H_face(
+                H,
+                grid_slice=grid_slice,
+                normal_axis=normal_axis,
+                sign=sign,
+                incident_E=incident_E[i],
+                time_offset_E=time_offset_E[i],
+                inv_permeabilities=inv_permeabilities,
+                c=c,
+                time_step=time_step,
+                delta_t=delta_t,
+                temporal_profile=self.temporal_profile,
+                wave_character=self.wave_character,
+                static_amplitude_factor=self.static_amplitude_factor,
+            )
+        return H
+
+    def validate_placement(self, objects: "ObjectContainer") -> list[str]:
+        """Validate the box against the surrounding boundaries after placement.
+
+        For every axis marked periodic/wrap: it must be a transverse axis (not
+        the propagation axis), have periodic/Bloch boundaries on both sides, and
+        the box must span the full simulation domain on that axis. Tilted
+        incidence with a nonzero wavevector component along a periodic axis is
+        rejected in v1 (it would require a matching Bloch phase).
+        """
+        errors: list[str] = []
+        p_axis = self.propagation_axis
+        transverse = get_oriented_transverse_axes(p_axis)
+        periodic = tuple(self.periodic_axes)
+
+        if p_axis in periodic:
+            errors.append(f"propagation axis {p_axis} cannot be a periodic/wrap axis; it always needs TFSF correction")
+        for a in periodic:
+            if a not in (0, 1, 2):
+                errors.append(f"periodic/wrap axis {a} is not a valid axis (must be 0, 1 or 2)")
+            elif a != p_axis and a not in transverse:
+                errors.append(f"periodic/wrap axis {a} must be one of the transverse axes {transverse}")
+
+        box_slice = self.grid_slice_tuple
+        volume_slice = objects.volume.grid_slice_tuple
+        for a in periodic:
+            if a == p_axis or a not in (0, 1, 2):
+                continue
+            wrap_boundaries = [b for b in objects.boundary_objects if b.axis == a and isinstance(b, BlochBoundary)]
+            periodic_sides = {b.direction for b in wrap_boundaries}
+            if periodic_sides != {"-", "+"}:
+                errors.append(
+                    f"axis {a} is marked periodic/wrap but does not have periodic (Bloch) boundaries on both "
+                    f"sides; add periodic boundaries on axis {a} or make it a confined TFSF axis"
+                )
+            elif any(b.needs_complex_fields for b in wrap_boundaries):
+                errors.append(
+                    f"axis {a} uses a phase-shifted Bloch boundary; the TFSF box supports only plain periodic "
+                    f"(zero Bloch phase) wrap axes in v1 (matched oblique incidence is not yet supported)"
+                )
+            if box_slice[a] != volume_slice[a]:
+                errors.append(
+                    f"axis {a} is marked periodic/wrap but the TFSF box does not span the full simulation domain "
+                    f"on that axis (box {box_slice[a]} vs volume {volume_slice[a]}); a wrap axis must span the domain"
+                )
+
+        if len(periodic) > 0:
+            if self.max_angle_random_offset != 0.0:
+                errors.append(
+                    "random angle offset (max_angle_random_offset) is not supported together with periodic/wrap "
+                    "axes in v1; set max_angle_random_offset=0 (normal or in-plane incidence only)"
+                )
+            axes_tpl = (self.horizontal_axis, self.vertical_axis, self.propagation_axis)
+            wave_vector = rotate_vector(
+                get_wave_vector_raw(self.direction, p_axis, dtype=self._config.dtype),
+                self.azimuth_radians,
+                self.elevation_radians,
+                axes_tpl,
+            )
+            for a in periodic:
+                if a in (0, 1, 2) and a != p_axis and abs(float(wave_vector[a])) > 1e-6:
+                    errors.append(
+                        f"tilted incidence produces a nonzero wavevector component along periodic axis {a}; "
+                        f"this requires a matching Bloch vector and is not supported in v1 (use incidence with "
+                        f"zero component along that axis, or make it a confined TFSF axis)"
+                    )
+        return errors

--- a/tests/simulation/physics/sources/test_tfsf_region.py
+++ b/tests/simulation/physics/sources/test_tfsf_region.py
@@ -1,0 +1,198 @@
+"""Simulation tests for the TFSF box source ``TFSFPlaneSourceRegion``.
+
+The defining property of a TFSF box is that the *total* field lives inside the
+box and only the *scattered* field exists outside. In empty vacuum there is no
+scatterer, so the field outside the box must cancel to near zero while the clean
+incident plane wave fills the interior. These tests exercise that cancellation
+for a fully confined 6-face box, for a periodic/wrap transverse configuration
+(2-cap slab), for a confined transverse face, and check gradient finiteness.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import fdtdx
+
+_WAVELENGTH = 1.0e-6
+_SPACING = 50e-9
+
+
+def _build(periodic_axes=(), prop=0, box_cells=24, domain=2.5e-6, pml=8, confined_narrow=None):
+    config = fdtdx.SimulationConfig(
+        time=60e-15,
+        grid=fdtdx.UniformGrid(spacing=_SPACING),
+        backend="cpu",
+        dtype=jnp.float32,
+        gradient_config=None,
+    )
+    volume = fdtdx.SimulationVolume(partial_real_shape=(domain, domain, domain))
+
+    def _shape(a):
+        if a in periodic_axes:
+            return None
+        if confined_narrow is not None and a == confined_narrow:
+            return box_cells // 2
+        return box_cells
+
+    pol = (0, 1, 0) if prop == 0 else (1, 0, 0)
+    region = fdtdx.TFSFPlaneSourceRegion(
+        name="src",
+        partial_grid_shape=tuple(_shape(a) for a in range(3)),
+        propagation_axis=prop,
+        direction="+",
+        wave_character=fdtdx.WaveCharacter(wavelength=_WAVELENGTH),
+        fixed_E_polarization_vector=pol,
+        periodic_axes=periodic_axes,
+    )
+    constraints = [region.place_at_center(volume)]
+    for a in periodic_axes:
+        constraints.append(region.same_size(volume, axes=(a,)))
+
+    override = {}
+    for a in periodic_axes:
+        ax = "xyz"[a]
+        override[f"min_{ax}"] = "periodic"
+        override[f"max_{ax}"] = "periodic"
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(boundary_type="pml", thickness=pml, override_types=override)
+    bd, bc = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    constraints += bc
+
+    key = jax.random.PRNGKey(0)
+    objects, arrays, params, config, key = fdtdx.place_objects(
+        object_list=[volume, region, *bd.values()], config=config, constraints=constraints, key=key
+    )
+    arrays, objects, _ = fdtdx.apply_params(arrays, objects, params, key)
+    return objects, arrays, params, config, key
+
+
+def _run_E(objects, arrays, config, key):
+    _, out = fdtdx.run_fdtd(arrays=arrays, objects=objects, config=config, key=key, show_progress=False)
+    return np.array(out.fields.E), out
+
+
+def _energy(E, sl):
+    return float(np.mean((E[:, sl[0], sl[1], sl[2]] ** 2).sum(0)))
+
+
+def _region_slices(objects, prop):
+    region = next(o for o in objects.objects if isinstance(o, fdtdx.TFSFPlaneSourceRegion))
+    box = [region.grid_slice_tuple[i] for i in range(3)]
+    inside = tuple(slice(b[0] + 3, b[1] - 3) for b in box)
+    outside = list(inside)
+    b = box[prop]
+    outside[prop] = slice(b[0] - 5, b[0] - 2)  # scattered slab just outside the min cap
+    return inside, tuple(outside)
+
+
+def test_empty_box_cancellation_six_faces():
+    """A fully confined vacuum box: strong field inside, near-zero scattered field outside."""
+    objects, arrays, _params, config, key = _build(periodic_axes=(), prop=0)
+    E, _ = _run_E(objects, arrays, config, key)
+    assert np.all(np.isfinite(E))
+    inside_sl, outside_sl = _region_slices(objects, 0)
+    inside = _energy(E, inside_sl)
+    outside = _energy(E, outside_sl)
+    assert inside > 1e-3, "incident wave should fill the box interior"
+    assert outside / inside < 0.05, f"scattered field outside box too large: {outside / inside:.3e}"
+
+
+def test_periodic_slab_cancellation():
+    """Periodic on both transverse axes (2-cap slab): confinement along propagation axis."""
+    objects, arrays, _params, config, key = _build(periodic_axes=(1, 2), prop=0)
+    E, _ = _run_E(objects, arrays, config, key)
+    assert np.all(np.isfinite(E))
+    inside_sl, outside_sl = _region_slices(objects, 0)
+    inside = _energy(E, inside_sl)
+    outside = _energy(E, outside_sl)
+    assert inside > 1e-3
+    assert outside / inside < 1e-2, f"scattered field leaked past the caps: {outside / inside:.3e}"
+
+
+def test_confined_transverse_face():
+    """Box narrower than the domain along a transverse axis with PML there.
+
+    The transverse side faces must confine the total field: the region beside
+    the box (along the narrow transverse axis) should carry only scattered field.
+    """
+    objects, arrays, _params, config, key = _build(periodic_axes=(), prop=0, confined_narrow=1)
+    E, _ = _run_E(objects, arrays, config, key)
+    assert np.all(np.isfinite(E))
+    region = next(o for o in objects.objects if isinstance(o, fdtdx.TFSFPlaneSourceRegion))
+    box = [region.grid_slice_tuple[i] for i in range(3)]
+    inside = tuple(slice(b[0] + 3, b[1] - 3) for b in box)
+    beside = list(inside)
+    beside[1] = slice(box[1][0] - 5, box[1][0] - 2)  # just outside the min-y face
+    beside = tuple(beside)
+    e_in = _energy(E, inside)
+    e_side = _energy(E, beside)
+    assert e_in > 1e-3
+    assert e_side / e_in < 0.1, f"total field leaked past the transverse face: {e_side / e_in:.3e}"
+
+
+def test_dispersive_background_filter_and_run():
+    """Box in a broadband Lorentz medium: each face builds an H-side impedance
+    filter and the simulation stays finite (dispersive parity with the plane source)."""
+    config = fdtdx.SimulationConfig(
+        time=40e-15,
+        grid=fdtdx.UniformGrid(spacing=_SPACING),
+        backend="cpu",
+        dtype=jnp.float32,
+        gradient_config=None,
+    )
+    volume = fdtdx.SimulationVolume(partial_real_shape=(1.8e-6, 1.8e-6, 1.8e-6))
+
+    center_freq = fdtdx.constants.c / _WAVELENGTH
+    profile = fdtdx.GaussianPulseProfile(
+        spectral_width=fdtdx.WaveCharacter(frequency=0.15 * center_freq),
+        center_wave=fdtdx.WaveCharacter(wavelength=_WAVELENGTH),
+    )
+    region = fdtdx.TFSFPlaneSourceRegion(
+        name="src",
+        partial_grid_shape=(16, 16, 16),
+        propagation_axis=0,
+        direction="+",
+        wave_character=fdtdx.WaveCharacter(wavelength=_WAVELENGTH),
+        fixed_E_polarization_vector=(0, 1, 0),
+        temporal_profile=profile,
+    )
+    material = fdtdx.Material(
+        permittivity=1.0,
+        dispersion=fdtdx.DispersionModel(
+            poles=(
+                fdtdx.LorentzPole(resonance_frequency=1.4 * 2 * np.pi * center_freq, damping=5e12, delta_epsilon=1.5),
+            )
+        ),
+    )
+    background = fdtdx.UniformMaterialObject(material=material)
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(boundary_type="pml", thickness=6)
+    bd, bc = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    constraints = [background.same_size(volume), region.place_at_center(volume), *bc]
+
+    key = jax.random.PRNGKey(0)
+    objects, arrays, params, config, key = fdtdx.place_objects(
+        object_list=[volume, background, region, *bd.values()], config=config, constraints=constraints, key=key
+    )
+    arrays, objects, _ = fdtdx.apply_params(arrays, objects, params, key)
+
+    placed = next(o for o in objects.objects if isinstance(o, fdtdx.TFSFPlaneSourceRegion))
+    assert len(placed._face_H_filter) == 6
+    assert all(f is not None for f in placed._face_H_filter), "dispersive background must populate per-face H filters"
+
+    _, out = fdtdx.run_fdtd(arrays=arrays, objects=objects, config=config, key=key, show_progress=False)
+    assert np.all(np.isfinite(np.array(out.fields.E)))
+
+
+def test_region_gradient_finite():
+    """Differentiate a field-energy loss through the box source (checkpointed path)."""
+    objects, arrays, _params, config, key = _build(periodic_axes=(), prop=0, box_cells=12, domain=1.4e-6, pml=5)
+    config = config.aset("gradient_config", fdtdx.GradientConfig(method="checkpointed", num_checkpoints=3))
+
+    def loss_fn(inv_perm):
+        a = arrays.aset("inv_permittivities", inv_perm)
+        _, out = fdtdx.run_fdtd(arrays=a, objects=objects, config=config, key=key, show_progress=False)
+        return jnp.sum(out.fields.E**2)
+
+    val, grad = jax.value_and_grad(loss_fn)(arrays.inv_permittivities)
+    assert jnp.isfinite(val)
+    assert jnp.all(jnp.isfinite(grad))

--- a/tests/simulation/physics/test_mie_scattering.py
+++ b/tests/simulation/physics/test_mie_scattering.py
@@ -1,0 +1,183 @@
+"""2D Mie scattering validation: a dielectric cylinder vs. the analytical series.
+
+An infinite dielectric cylinder (modelled as a 2D circle with a periodic, 2-cell
+z axis) is illuminated by a plane wave whose E field is parallel to the cylinder
+axis (TM polarization). The plane wave is launched with a :class:`TFSFPlaneSourceRegion`
+box that confines the total field to its interior and leaves only the scattered
+field outside; the z axis is excluded from the box and closed by periodic
+boundaries. PML terminates x and y.
+
+Two closed-surface Poynting detectors measure power:
+  * ``outside`` -- in the scattered-field region (outside the TFSF box): the net
+    outward flux is the scattered power, giving the scattering cross section.
+  * ``inside``  -- in the total-field region (around the cylinder): the net
+    inward flux is the absorbed power, which must be ~0 for a lossless dielectric.
+
+The scattering efficiency ``Q_sca = sigma_sca / (2a)`` is compared against the
+analytical 2D Mie series. The incident irradiance used to normalize the FDTD
+cross section is measured with a plane Poynting detector in a reference run
+without the cylinder (which also confirms the TFSF cancellation).
+
+This is a deliberately small/coarse simulation (staircased circle, ~7-cell
+radius), so the agreement tolerance is loose (~15%). Calibrated result:
+Q_sca_fdtd/Q_sca_analytical ~ 1.08, absorbed/scattered ~ 0.01.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from scipy.special import h1vp, hankel1, jv, jvp
+
+import fdtdx
+
+_SPACING = 25e-9
+_WAVELENGTH = 1000e-9
+_EPS = 4.0  # dielectric, n = 2
+_RADIUS = 175e-9
+_DOMAIN = 1600e-9
+_LZ = 2 * _SPACING
+_PML = 8
+_SIM_TIME = 55e-15
+_AVG_PERIODS = 6
+
+
+def _a_n(n: int, x: float, m: float) -> complex:
+    """TM (E parallel to axis) 2D scattering coefficient for a dielectric cylinder."""
+    j_x, jp_x = jv(n, x), jvp(n, x)
+    j_mx, jp_mx = jv(n, m * x), jvp(n, m * x)
+    h_x, hp_x = hankel1(n, x), h1vp(n, x)
+    num = m * jp_mx * j_x - jp_x * j_mx
+    den = m * jp_mx * h_x - hp_x * j_mx
+    return num / den
+
+
+def _analytical_q_sca_tm(x: float, m: float, nmax: int = 10) -> float:
+    """Analytical 2D scattering efficiency Q_sca for TM polarization."""
+    total = abs(_a_n(0, x, m)) ** 2
+    for n in range(1, nmax + 1):
+        total += 2 * abs(_a_n(n, x, m)) ** 2
+    return (2.0 / x) * total
+
+
+def _build(with_cylinder: bool):
+    config = fdtdx.SimulationConfig(
+        time=_SIM_TIME,
+        grid=fdtdx.UniformGrid(spacing=_SPACING),
+        backend="cpu",
+        dtype=jnp.float32,
+        gradient_config=None,
+    )
+    volume = fdtdx.SimulationVolume(partial_real_shape=(_DOMAIN, _DOMAIN, _LZ))
+    objects = [volume]
+    constraints = []
+
+    # TFSF box: plane wave propagating +x, E along z (TM), z axis periodic/wrap.
+    source = fdtdx.TFSFPlaneSourceRegion(
+        name="src",
+        partial_real_shape=(700e-9, 700e-9, None),
+        propagation_axis=0,
+        direction="+",
+        wave_character=fdtdx.WaveCharacter(wavelength=_WAVELENGTH),
+        fixed_E_polarization_vector=(0, 0, 1),
+        periodic_axes=(2,),
+    )
+    constraints += [source.place_at_center(volume), source.same_size(volume, axes=(2,))]
+    objects.append(source)
+
+    # Absorbed power (total-field region, encloses the cylinder, inside the TFSF box).
+    inside = fdtdx.ClosedSurfacePoyntingFluxDetector(
+        name="inside", partial_real_shape=(500e-9, 500e-9, None), orientation="inward", axes=(0, 1), plot=False
+    )
+    constraints += [inside.place_at_center(volume), inside.same_size(volume, axes=(2,))]
+    objects.append(inside)
+
+    # Scattered power (scattered-field region, encloses the TFSF box).
+    outside = fdtdx.ClosedSurfacePoyntingFluxDetector(
+        name="outside", partial_real_shape=(900e-9, 900e-9, None), orientation="outward", axes=(0, 1), plot=False
+    )
+    constraints += [outside.place_at_center(volume), outside.same_size(volume, axes=(2,))]
+    objects.append(outside)
+
+    # Incident irradiance probe: a +x flux plane inside the TFSF box (pure incident
+    # field in the reference run).
+    inc = fdtdx.PoyntingFluxDetector(
+        name="inc",
+        direction="+",
+        partial_grid_shape=(1, None, None),
+        partial_real_shape=(None, 600e-9, None),
+        reduce_volume=True,
+        plot=False,
+    )
+    constraints += [
+        inc.place_at_center(volume, axes=(1, 2)),
+        inc.same_size(volume, axes=(2,)),
+        inc.place_relative_to(volume, axes=(0,), own_positions=(0,), other_positions=(0,), margins=(-250e-9,)),
+    ]
+    objects.append(inc)
+
+    if with_cylinder:
+        cylinder = fdtdx.Cylinder(
+            name="cyl",
+            radius=_RADIUS,
+            axis=2,
+            materials={"vac": fdtdx.Material(permittivity=1.0), "diel": fdtdx.Material(permittivity=_EPS)},
+            material_name="diel",
+        )
+        constraints += [cylinder.place_at_center(volume), cylinder.same_size(volume, axes=(2,))]
+        objects.append(cylinder)
+
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+        boundary_type="pml", thickness=_PML, override_types={"min_z": "periodic", "max_z": "periodic"}
+    )
+    bd, bc = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    constraints += bc
+    objects += list(bd.values())
+    return objects, constraints, config
+
+
+def _run(with_cylinder: bool) -> dict[str, float]:
+    objects, constraints, config = _build(with_cylinder)
+    key = jax.random.PRNGKey(0)
+    objects, arrays, params, config, key = fdtdx.place_objects(
+        object_list=objects, config=config, constraints=constraints, key=key
+    )
+    arrays, objects, _ = fdtdx.apply_params(arrays, objects, params, key)
+    _, arrays = fdtdx.run_fdtd(arrays=arrays, objects=objects, config=config, key=key, show_progress=False)
+
+    dt = config.time_step_duration
+    steps_per_period = round(_WAVELENGTH / (fdtdx.constants.c * dt))
+    n_avg = _AVG_PERIODS * steps_per_period
+
+    def steady(name: str) -> float:
+        series = np.array(arrays.detector_states[name]["poynting_flux"])[:, 0]
+        return float(np.mean(series[-n_avg:]))
+
+    return {"inside": steady("inside"), "outside": steady("outside"), "inc": steady("inc")}
+
+
+def test_mie_scattering_dielectric_cylinder_2d():
+    x = 2 * np.pi * _RADIUS / _WAVELENGTH
+    m = np.sqrt(_EPS)
+    q_sca_analytical = _analytical_q_sca_tm(x, m)
+
+    reference = _run(with_cylinder=False)
+    scene = _run(with_cylinder=True)
+
+    # Incident irradiance from the reference run (pure incident field in the TFSF box).
+    incident_irradiance = reference["inc"] / (600e-9 * _LZ)
+    assert incident_irradiance > 0
+
+    # Without a scatterer the scattered-field region must be ~0 (TFSF cancellation).
+    p_scat = scene["outside"]
+    assert abs(reference["outside"]) < 0.05 * abs(p_scat)
+
+    # Lossless dielectric: absorbed power (inward net through the total-field box) ~ 0.
+    p_abs = scene["inside"]
+    assert abs(p_abs) < 0.1 * abs(p_scat)
+
+    # Scattering efficiency vs. the analytical 2D Mie series (per unit z-length; the
+    # z-extent cancels between the box power and the incident irradiance).
+    sigma_sca = (p_scat / _LZ) / incident_irradiance
+    q_sca_fdtd = sigma_sca / (2 * _RADIUS)
+    assert q_sca_fdtd == pytest.approx(q_sca_analytical, rel=0.15)

--- a/tests/simulation/physics/test_phasor_poynting_flux.py
+++ b/tests/simulation/physics/test_phasor_poynting_flux.py
@@ -1,0 +1,145 @@
+"""Physics simulation test: frequency-domain Poynting flux detectors.
+
+Validates the two phasor-based (frequency-domain) Poynting flux detectors against
+their time-domain counterparts in a single CW plane-wave run:
+
+* ``PhasorPoyntingFluxDetector.compute_poynting_flux`` must equal the steady-state
+  time-average of a co-located ``PoyntingFluxDetector`` (both give
+  ``<S> = 1/2 Re(E x H*)`` integrated over the plane).
+* ``ClosedSurfacePhasorPoyntingFluxDetector.compute_net_flux`` must equal the
+  time-average of a co-located ``ClosedSurfacePoyntingFluxDetector`` -- here the
+  box straddles a lossy slab so the net flux is a genuine (nonzero) absorbed power.
+
+All detectors are gated to the SAME integer-periods steady-state window so the
+phasor DFT and the time-domain average cover identical steps; otherwise the DFT
+would integrate the source turn-on transient and the two would disagree.
+
+Domain (50 nm resolution, z is propagation axis, periodic x/y, PML in z):
+  80 cells in z; source at z=12; measurement plane at z=20; lossy slab at z=22-25;
+  closed-surface box spans z=20-27 (faces in vacuum on either side of the slab).
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import fdtdx
+
+_WAVELENGTH = 1e-6
+_RESOLUTION = 50e-9
+_PML_CELLS = 10
+_DOMAIN_XY = 3 * _RESOLUTION
+_DOMAIN_Z = 4e-6
+_SIM_TIME = 120e-15
+
+_SOURCE_Z = _PML_CELLS + 2  # 12
+_PLANE_Z = _SOURCE_Z + 8  # 20 (measurement plane / box min-z face)
+_SLAB_Z = _PLANE_Z + 2  # 22 (lossy slab, 4 cells thick, inside the box)
+
+_PERIOD = _WAVELENGTH / fdtdx.constants.c
+_SWITCH = fdtdx.OnOffSwitch(start_after_periods=25, on_for_periods=10, period=_PERIOD)
+
+_PLANE_TOL = 0.02  # 2 % (observed ~0.02 %)
+_BOX_TOL = 0.03  # 3 % (observed ~0.3 %; net flux is a small difference of two faces)
+
+
+def _build():
+    config = fdtdx.SimulationConfig(grid=fdtdx.UniformGrid(spacing=_RESOLUTION), time=_SIM_TIME, dtype=jnp.float32)
+    objects, constraints = [], []
+
+    volume = fdtdx.SimulationVolume(partial_real_shape=(_DOMAIN_XY, _DOMAIN_XY, _DOMAIN_Z))
+    objects.append(volume)
+
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+        thickness=_PML_CELLS,
+        override_types={"min_x": "periodic", "max_x": "periodic", "min_y": "periodic", "max_y": "periodic"},
+    )
+    bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    constraints.extend(c_list)
+    objects.extend(bound_dict.values())
+
+    wave = fdtdx.WaveCharacter(wavelength=_WAVELENGTH)
+    source = fdtdx.UniformPlaneSource(
+        partial_grid_shape=(None, None, 1),
+        wave_character=wave,
+        direction="+",
+        fixed_E_polarization_vector=(1, 0, 0),
+    )
+    constraints += [
+        source.same_size(volume, axes=(0, 1)),
+        source.place_at_center(volume, axes=(0, 1)),
+        source.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_SOURCE_Z,)),
+    ]
+    objects.append(source)
+
+    # lossy slab so the closed surface encloses a real absorbed power
+    slab = fdtdx.UniformMaterialObject(
+        partial_grid_shape=(None, None, 4),
+        material=fdtdx.Material(permittivity=4.0, electric_conductivity=300.0),
+    )
+    constraints += [
+        slab.same_size(volume, axes=(0, 1)),
+        slab.place_at_center(volume, axes=(0, 1)),
+        slab.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_SLAB_Z,)),
+    ]
+    objects.append(slab)
+
+    def _at_plane(det):
+        # all detectors share the same transverse extent and z-min face at _PLANE_Z
+        constraints.extend(
+            [
+                det.same_size(volume, axes=(0, 1)),
+                det.place_at_center(volume, axes=(0, 1)),
+                det.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_PLANE_Z,)),
+            ]
+        )
+        objects.append(det)
+
+    _at_plane(
+        fdtdx.PoyntingFluxDetector(name="td_plane", partial_grid_shape=(None, None, 1), direction="+", switch=_SWITCH)
+    )
+    _at_plane(
+        fdtdx.PhasorPoyntingFluxDetector(
+            name="fd_plane", partial_grid_shape=(None, None, 1), direction="+", wave_characters=(wave,), switch=_SWITCH
+        )
+    )
+    _at_plane(
+        fdtdx.ClosedSurfacePoyntingFluxDetector(
+            name="td_box", partial_grid_shape=(None, None, 8), axes=(2,), switch=_SWITCH
+        )
+    )
+    _at_plane(
+        fdtdx.ClosedSurfacePhasorPoyntingFluxDetector(
+            name="fd_box", partial_grid_shape=(None, None, 8), axes=(2,), wave_characters=(wave,), switch=_SWITCH
+        )
+    )
+    return objects, constraints, config
+
+
+def test_phasor_poynting_matches_time_domain():
+    objects, constraints, config = _build()
+    key = jax.random.PRNGKey(0)
+    obj_container, arrays, params, config, _ = fdtdx.place_objects(
+        object_list=objects, config=config, constraints=constraints, key=key
+    )
+    arrays, obj_container, _ = fdtdx.apply_params(arrays, obj_container, params, key)
+    _, arrays = fdtdx.run_fdtd(arrays=arrays, objects=obj_container, config=config, key=key)
+
+    dets = {d.name: d for d in obj_container.detectors}
+
+    def td_avg(name):
+        # every recorded step is inside the gated steady-state window
+        return float(np.mean(np.asarray(arrays.detector_states[name]["poynting_flux"][:, 0])))
+
+    # --- single plane ---
+    td_plane = td_avg("td_plane")
+    fd_plane = float(dets["fd_plane"].compute_poynting_flux(arrays.detector_states["fd_plane"])[0])
+    assert abs(td_plane) > 0
+    assert abs(fd_plane - td_plane) / abs(td_plane) < _PLANE_TOL
+
+    # --- closed surface (net absorbed power across the lossy slab) ---
+    td_box = td_avg("td_box")
+    fd_box = float(dets["fd_box"].compute_net_flux(arrays.detector_states["fd_box"])[0])
+    # the enclosed slab absorbs power -> net outward flux is negative and nonzero
+    assert td_box < 0
+    assert abs(fd_box - td_box) / abs(td_box) < _BOX_TOL

--- a/tests/unit/objects/detectors/test_closed_surface_poynting.py
+++ b/tests/unit/objects/detectors/test_closed_surface_poynting.py
@@ -1,0 +1,213 @@
+"""Unit tests for the closed-surface Poynting flux detector.
+
+Covers the pure reduction primitive ``net_poynting_flux_through_box`` (constant
+field -> zero net flux, linear field -> analytic divergence, per-cell area
+weighting, thin-axis cancellation, axis selection) and the
+``ClosedSurfacePoyntingFluxDetector`` end to end -- including a genuinely
+non-uniform rectilinear grid where cell areas differ across a single face.
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
+from fdtdx.core.physics.metrics import net_poynting_flux_through_box
+from fdtdx.objects.detectors.poynting_flux import ClosedSurfacePoyntingFluxDetector, PoyntingFluxDetector
+
+_KEY = jax.random.PRNGKey(0)
+
+
+def _unit_area_weights(shape):
+    """Per-axis area weights of 1 per cell, broadcastable to each Poynting component."""
+    nx, ny, nz = shape
+    return (
+        jnp.ones((1, ny, nz)),
+        jnp.ones((nx, 1, nz)),
+        jnp.ones((nx, ny, 1)),
+    )
+
+
+def _x_ramp(shape):
+    """Field varying as the x cell index, broadcast over the box."""
+    nx = shape[0]
+    return jnp.broadcast_to(jnp.arange(nx, dtype=jnp.float32).reshape(nx, 1, 1), shape)
+
+
+class TestNetFluxPrimitive:
+    def test_constant_field_is_divergence_free(self):
+        shape = (4, 5, 6)
+        pf = jnp.ones((3, *shape), dtype=jnp.float32)
+        net = net_poynting_flux_through_box(pf, (0, 1, 2), _unit_area_weights(shape))
+        assert abs(float(net)) < 1e-5
+
+    def test_linear_field_matches_divergence(self):
+        shape = (4, 3, 2)
+        pf = jnp.stack([_x_ramp(shape), jnp.zeros(shape), jnp.zeros(shape)])
+        net = net_poynting_flux_through_box(pf, (0, 1, 2), _unit_area_weights(shape))
+        # Only the x-faces differ: max face S_x = (nx-1), min face S_x = 0.
+        expected = (shape[0] - 1) * shape[1] * shape[2]
+        assert abs(float(net) - expected) < 1e-4
+
+    def test_per_cell_area_weights_are_summed(self):
+        shape = (3, 2, 2)
+        pf = jnp.stack([_x_ramp(shape), jnp.zeros(shape), jnp.zeros(shape)])
+        # Non-uniform per-(y,z)-cell areas on the x-face.
+        area_x = jnp.asarray([[1.0, 2.0], [3.0, 4.0]], dtype=jnp.float32).reshape(1, 2, 2)
+        aw = (area_x, jnp.ones((3, 1, 2)), jnp.ones((3, 2, 1)))
+        net = net_poynting_flux_through_box(pf, (0,), aw)
+        expected = (shape[0] - 1) * float(area_x.sum())
+        assert abs(float(net) - expected) < 1e-4
+
+    def test_thin_axis_faces_cancel(self):
+        shape = (4, 4, 1)
+        pf = jnp.stack([_x_ramp(shape), jnp.ones(shape), jnp.ones(shape)])
+        aw = _unit_area_weights(shape)
+        with_z = net_poynting_flux_through_box(pf, (0, 1, 2), aw)
+        without_z = net_poynting_flux_through_box(pf, (0, 1), aw)
+        assert abs(float(with_z) - float(without_z)) < 1e-6
+
+    def test_axis_selection(self):
+        shape = (3, 3, 3)
+        # Divergence on both x and y.
+        pf = jnp.stack([_x_ramp(shape), jnp.swapaxes(_x_ramp(shape), 0, 1), jnp.zeros(shape)])
+        aw = _unit_area_weights(shape)
+        only_x = net_poynting_flux_through_box(pf, (0,), aw)
+        both = net_poynting_flux_through_box(pf, (0, 1), aw)
+        assert abs(float(only_x) - (shape[0] - 1) * shape[1] * shape[2]) < 1e-4
+        assert float(both) > float(only_x)  # the y faces add positive divergence
+
+
+def _place(config, slice_tuple, **kwargs):
+    det = ClosedSurfacePoyntingFluxDetector(name="box", **kwargs)
+    return det.place_on_grid(grid_slice_tuple=slice_tuple, config=config, key=_KEY)
+
+
+def _fields_for_Sx(ramp, shape):
+    """E/H such that the Poynting vector is S = (ramp, 0, 0)."""
+    E = jnp.stack([jnp.zeros(shape), ramp, jnp.zeros(shape)])  # E_y
+    H = jnp.stack([jnp.zeros(shape), jnp.zeros(shape), jnp.ones(shape)])  # H_z
+    return E, H
+
+
+class TestClosedSurfaceDetector:
+    def test_uniform_grid_constant_field_net_zero(self):
+        config = SimulationConfig(
+            time=20e-15, grid=UniformGrid(spacing=1e-7), backend="cpu", dtype=jnp.float32, gradient_config=None
+        )
+        placed = _place(config, ((0, 4), (0, 4), (0, 4)))
+        shape = (4, 4, 4)
+        E, H = _fields_for_Sx(jnp.ones(shape), shape)  # constant S_x
+        state = placed.init_state()
+        new_state = placed.update(jnp.asarray(0), E, H, state, jnp.ones((1, *shape)), 1.0)
+        assert abs(float(new_state["poynting_flux"][0, 0])) < 1e-5
+
+    def test_nonuniform_grid_per_cell_area_end_to_end(self):
+        # Deliberately unequal cell widths (at a physical nm scale so the sim has
+        # time steps), so areas differ across a single face.
+        s = 1e-7
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0, 10.0]) * s,  # nx=4
+            y_edges=jnp.asarray([0.0, 1.0, 3.0, 4.0]) * s,  # ny=3, widths 1,2,1
+            z_edges=jnp.asarray([0.0, 2.0, 3.0]) * s,  # nz=2, widths 2,1
+        )
+        config = SimulationConfig(time=20e-15, grid=grid, backend="cpu", dtype=jnp.float32, gradient_config=None)
+        shape = (4, 3, 2)
+        placed = _place(config, ((0, 4), (0, 3), (0, 2)))
+        E, H = _fields_for_Sx(_x_ramp(shape), shape)  # S_x = x cell index
+        state = placed.init_state()
+        new_state = placed.update(jnp.asarray(0), E, H, state, jnp.ones((1, *shape)), 1.0)
+        net = float(new_state["poynting_flux"][0, 0])
+        # Net = (S_x@max - S_x@min) * sum(dy_j * dz_k) = (nx-1) * A_x, using per-cell areas.
+        dy = jnp.diff(grid.y_edges)
+        dz = jnp.diff(grid.z_edges)
+        area_x = float((dy[:, None] * dz[None, :]).sum())
+        assert net == pytest.approx((shape[0] - 1) * area_x, rel=1e-4)
+
+    def test_orientation_inward_negates(self):
+        config = SimulationConfig(
+            time=20e-15, grid=UniformGrid(spacing=1e-7), backend="cpu", dtype=jnp.float32, gradient_config=None
+        )
+        shape = (4, 3, 3)
+        E, H = _fields_for_Sx(_x_ramp(shape), shape)
+        out = _place(config, ((0, 4), (0, 3), (0, 3)), orientation="outward")
+        inw = _place(config, ((0, 4), (0, 3), (0, 3)), orientation="inward")
+        net_out = float(
+            out.update(jnp.asarray(0), E, H, out.init_state(), jnp.ones((1, *shape)), 1.0)["poynting_flux"][0, 0]
+        )
+        net_in = float(
+            inw.update(jnp.asarray(0), E, H, inw.init_state(), jnp.ones((1, *shape)), 1.0)["poynting_flux"][0, 0]
+        )
+        # (nx-1) * ny * nz * spacing**2 is the outward net for S_x = x cell index.
+        expected = (shape[0] - 1) * shape[1] * shape[2] * (1e-7) ** 2
+        assert net_out == pytest.approx(expected, rel=1e-4)
+        assert net_in == pytest.approx(-net_out, rel=1e-5)
+
+    def test_matches_poynting_flux_detector_convention(self):
+        """Same normalization as PoyntingFluxDetector: same Poynting vector and physical
+        face area, no extra scaling. A one-sided field makes the box's single active face
+        equal a plane PoyntingFluxDetector reading of that face."""
+        config = SimulationConfig(
+            time=20e-15, grid=UniformGrid(spacing=1e-7), backend="cpu", dtype=jnp.float32, gradient_config=None
+        )
+        ny, nz = 3, 4
+        c = 2.0
+        # Box of depth 2 along x: S_x = 0 on the min layer, S_x = c on the max layer.
+        ey = jnp.stack([jnp.zeros((ny, nz)), c * jnp.ones((ny, nz))], axis=0)  # E_y per x-layer
+        zeros2 = jnp.zeros((2, ny, nz))
+        E = jnp.stack([zeros2, ey, zeros2])
+        H = jnp.stack([zeros2, zeros2, jnp.ones((2, ny, nz))])  # H_z = 1 -> S_x = E_y
+
+        box = _place(config, ((0, 2), (0, ny), (0, nz)), axes=(0,))
+        net = float(
+            box.update(jnp.asarray(0), E, H, box.init_state(), jnp.ones((1, 2, ny, nz)), 1.0)["poynting_flux"][0, 0]
+        )
+
+        # Plane detector reading the max-x face (S_x = c there).
+        plane = PoyntingFluxDetector(name="plane", direction="+", fixed_propagation_axis=0).place_on_grid(
+            grid_slice_tuple=((1, 2), (0, ny), (0, nz)), config=config, key=_KEY
+        )
+        p_plane = float(
+            plane.update(jnp.asarray(0), E[:, 1:2], H[:, 1:2], plane.init_state(), jnp.ones((1, 1, ny, nz)), 1.0)[
+                "poynting_flux"
+            ][0, 0]
+        )
+        # min face has S_x = 0, so the box net equals the plane detector's max-face reading.
+        assert net == pytest.approx(p_plane, rel=1e-6)
+
+    def test_default_active_axes_skips_thin_axis(self):
+        config = SimulationConfig(
+            time=20e-15, grid=UniformGrid(spacing=1e-7), backend="cpu", dtype=jnp.float32, gradient_config=None
+        )
+        placed = _place(config, ((0, 5), (0, 5), (0, 1)))  # thin z
+        assert placed._resolve_active_axes() == (0, 1)
+
+    def test_explicit_axes(self):
+        config = SimulationConfig(
+            time=20e-15, grid=UniformGrid(spacing=1e-7), backend="cpu", dtype=jnp.float32, gradient_config=None
+        )
+        placed = _place(config, ((0, 4), (0, 4), (0, 4)), axes=(0,))
+        assert placed._resolve_active_axes() == (0,)
+
+    def test_state_shape_is_scalar(self):
+        config = SimulationConfig(
+            time=20e-15, grid=UniformGrid(spacing=1e-7), backend="cpu", dtype=jnp.float32, gradient_config=None
+        )
+        placed = _place(config, ((0, 4), (0, 4), (0, 4)))
+        state = placed.init_state()
+        assert state["poynting_flux"].shape[1:] == (1,)
+
+    def test_invalid_orientation_raises(self):
+        config = SimulationConfig(
+            time=20e-15, grid=UniformGrid(spacing=1e-7), backend="cpu", dtype=jnp.float32, gradient_config=None
+        )
+        with pytest.raises(ValueError, match="orientation"):
+            _place(config, ((0, 4), (0, 4), (0, 4)), orientation="sideways")
+
+    def test_invalid_axes_raises(self):
+        config = SimulationConfig(
+            time=20e-15, grid=UniformGrid(spacing=1e-7), backend="cpu", dtype=jnp.float32, gradient_config=None
+        )
+        with pytest.raises(ValueError, match="axes"):
+            _place(config, ((0, 4), (0, 4), (0, 4)), axes=(0, 3))

--- a/tests/unit/objects/detectors/test_phasor_poynting.py
+++ b/tests/unit/objects/detectors/test_phasor_poynting.py
@@ -1,0 +1,259 @@
+"""Unit tests for the frequency-domain (phasor-based) Poynting flux detectors.
+
+Covers ``PhasorPoyntingFluxDetector`` (single plane) and
+``ClosedSurfacePhasorPoyntingFluxDetector`` (hollow closed surface). The
+time-averaged flux ``<S> = 1/2 Re(E(w) x H*(w))`` is bilinear in the fields, so
+these detectors accumulate phasors during the run and reduce afterwards via
+``compute_poynting_flux`` / ``compute_net_flux``. Most tests construct a known
+phasor *state* directly (independent of the DFT accumulation) so the reduction
+math is checked exactly, plus a full-box parity check that guards the hollow
+face-accounting reimplementation and a hollow-storage check.
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
+from fdtdx.core.physics.metrics import net_poynting_flux_through_box
+from fdtdx.core.wavelength import WaveCharacter
+from fdtdx.objects.detectors.poynting_flux import (
+    ClosedSurfacePhasorPoyntingFluxDetector,
+    PhasorPoyntingFluxDetector,
+    _resolve_face_area_weights,
+)
+
+_KEY = jax.random.PRNGKey(0)
+_SPACING = 1e-7
+_WC = [WaveCharacter(wavelength=1.55e-6)]
+_WC3 = [WaveCharacter(wavelength=1.0e-6), WaveCharacter(wavelength=1.55e-6), WaveCharacter(frequency=3e14)]
+
+# component order in the phasor stack: (Ex, Ey, Ez, Hx, Hy, Hz)
+_EY, _HZ = 1, 5
+
+
+def _uniform_config():
+    return SimulationConfig(
+        time=20e-15, grid=UniformGrid(spacing=_SPACING), backend="cpu", dtype=jnp.float32, gradient_config=None
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Single-plane detector
+# --------------------------------------------------------------------------- #
+
+
+def _place_plane(config, slice_tuple, **kwargs):
+    det = PhasorPoyntingFluxDetector(
+        name="plane", direction=kwargs.pop("direction", "+"), wave_characters=_WC, **kwargs
+    )
+    return det.place_on_grid(grid_slice_tuple=slice_tuple, config=config, key=_KEY)
+
+
+def _plane_state_ey_hz(det, ey, hz):
+    """A phasor state with constant E_y and H_z over the plane (all frequencies)."""
+    ph = det.init_state()["phasor"]  # (1, num_freqs, 6, *plane)
+    ph = ph.at[:, :, _EY].set(ey)
+    ph = ph.at[:, :, _HZ].set(hz)
+    return {"phasor": ph}
+
+
+class TestPhasorPlaneDetector:
+    def test_state_shape(self):
+        det = _place_plane(_uniform_config(), ((0, 1), (0, 4), (0, 5)))
+        state = det.init_state()
+        # 1 latent time step, 1 frequency, 6 components, plane 1x4x5
+        assert state["phasor"].shape == (1, 1, 6, 1, 4, 5)
+        assert state["phasor"].dtype == jnp.complex64
+
+    def test_constant_cw_flux(self):
+        ny, nz = 4, 5
+        det = _place_plane(_uniform_config(), ((0, 1), (0, ny), (0, nz)))
+        ey, hz = 2.0, 1.0
+        flux = det.compute_poynting_flux(_plane_state_ey_hz(det, ey, hz))
+        # continuous scaling applies the 1/2 time-average factor
+        expected = 0.5 * (ey * hz) * _SPACING**2 * ny * nz
+        assert flux.shape == (1,)
+        assert float(flux[0]) == pytest.approx(expected, rel=1e-5)
+
+    def test_direction_negative_flips_sign(self):
+        ny, nz = 4, 5
+        cfg = _uniform_config()
+        pos = _place_plane(cfg, ((0, 1), (0, ny), (0, nz)), direction="+")
+        neg = _place_plane(cfg, ((0, 1), (0, ny), (0, nz)), direction="-")
+        f_pos = float(pos.compute_poynting_flux(_plane_state_ey_hz(pos, 2.0, 1.0))[0])
+        f_neg = float(neg.compute_poynting_flux(_plane_state_ey_hz(neg, 2.0, 1.0))[0])
+        assert f_neg == pytest.approx(-f_pos, rel=1e-6)
+
+    def test_multi_wavelength_shape(self):
+        det = PhasorPoyntingFluxDetector(name="plane", direction="+", wave_characters=_WC3)
+        det = det.place_on_grid(grid_slice_tuple=((0, 1), (0, 4), (0, 5)), config=_uniform_config(), key=_KEY)
+        ph = det.init_state()["phasor"]
+        ph = ph.at[:, :, _EY].set(2.0).at[:, :, _HZ].set(1.0)
+        flux = det.compute_poynting_flux({"phasor": ph})
+        assert flux.shape == (3,)
+        # identical phasors across frequencies -> identical flux
+        assert jnp.allclose(flux, flux[0])
+
+    def test_pulse_mode_skips_half_factor(self):
+        ny, nz = 4, 5
+        det = _place_plane(_uniform_config(), ((0, 1), (0, ny), (0, nz)), scaling_mode="pulse")
+        flux = det.compute_poynting_flux(_plane_state_ey_hz(det, 2.0, 1.0))
+        # pulse mode returns the raw bilinear product without the 1/2 average factor
+        expected = (2.0 * 1.0) * _SPACING**2 * ny * nz
+        assert float(flux[0]) == pytest.approx(expected, rel=1e-5)
+
+    def test_nonuniform_grid_area_weighting(self):
+        s = _SPACING
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0]) * s,  # thin x (propagation axis)
+            y_edges=jnp.asarray([0.0, 1.0, 3.0, 4.0]) * s,  # widths 1, 2, 1
+            z_edges=jnp.asarray([0.0, 2.0, 3.0]) * s,  # widths 2, 1
+        )
+        config = SimulationConfig(time=20e-15, grid=grid, backend="cpu", dtype=jnp.float32, gradient_config=None)
+        det = _place_plane(config, ((0, 1), (0, 3), (0, 2)))
+        ey, hz = 2.0, 1.0
+        flux = det.compute_poynting_flux(_plane_state_ey_hz(det, ey, hz))
+        dy = jnp.diff(grid.y_edges)
+        dz = jnp.diff(grid.z_edges)
+        area = float((dy[:, None] * dz[None, :]).sum())  # exact per-cell transverse area sum
+        assert float(flux[0]) == pytest.approx(0.5 * ey * hz * area, rel=1e-5)
+
+
+# --------------------------------------------------------------------------- #
+# Closed-surface (hollow) detector
+# --------------------------------------------------------------------------- #
+
+
+def _place_box(config, slice_tuple, **kwargs):
+    det = ClosedSurfacePhasorPoyntingFluxDetector(name="box", wave_characters=_WC, **kwargs)
+    return det.place_on_grid(grid_slice_tuple=slice_tuple, config=config, key=_KEY)
+
+
+def _hollow_state_from_full(box, full):
+    """Build the per-face detector state by slicing a full-box phasor array.
+
+    Args:
+        full: complex phasors of shape ``(num_freqs, 6, nx, ny, nz)``.
+    """
+    state = box.init_state()
+    for a in box._resolve_active_axes():
+        for side in ("min", "max"):
+            sl = [slice(None)] * full.ndim
+            sl[a + 2] = slice(0, 1) if side == "min" else slice(-1, None)
+            state[f"phasor_axis{a}_{side}"] = full[tuple(sl)][None, ...]
+    return state
+
+
+def _ref_net_flux(full, config, box, active_axes):
+    """Reference net flux via the tested full-box primitive on the same phasors."""
+    E, H = full[:, :3], full[:, 3:]
+    pv = 0.5 * jnp.cross(E, jnp.conj(H), axisa=1, axisb=1, axisc=1).real  # (num_freqs, 3, nx, ny, nz)
+    aw = tuple(_resolve_face_area_weights(config, box.grid_slice_tuple, a, jnp.float32) for a in range(3))
+    return jnp.stack([net_poynting_flux_through_box(pv[f], active_axes, aw) for f in range(full.shape[0])])
+
+
+class TestClosedSurfacePhasorDetector:
+    def test_hollow_state_stores_only_faces(self):
+        box = _place_box(_uniform_config(), ((0, 6), (0, 6), (0, 6)))
+        state = box.init_state()
+        # exactly two keys per active axis, and nothing that spans the full box interior
+        assert set(state.keys()) == {f"phasor_axis{a}_{s}" for a in (0, 1, 2) for s in ("min", "max")}
+        for key, arr in state.items():
+            spatial = arr.shape[3:]  # (nx-ish, ny-ish, nz-ish)
+            # a genuine face has exactly one collapsed (size-one) spatial dimension
+            assert sum(d == 1 for d in spatial) == 1, f"{key} is not a hollow face: {arr.shape}"
+
+    def test_default_active_axes_skips_thin_axis(self):
+        box = _place_box(_uniform_config(), ((0, 5), (0, 5), (0, 1)))  # thin z
+        assert box._resolve_active_axes() == (0, 1)
+        assert "phasor_axis2_min" not in box.init_state()
+
+    def test_explicit_axes_limits_stored_faces(self):
+        box = _place_box(_uniform_config(), ((0, 4), (0, 4), (0, 4)), axes=(0,))
+        assert set(box.init_state().keys()) == {"phasor_axis0_min", "phasor_axis0_max"}
+
+    def test_constant_field_net_zero(self):
+        box = _place_box(_uniform_config(), ((0, 4), (0, 4), (0, 4)))
+        shape = (1, 6, 4, 4, 4)
+        full = jnp.zeros(shape, dtype=jnp.complex64)
+        full = full.at[:, _EY].set(2.0).at[:, _HZ].set(1.0)  # constant S_x, zero elsewhere
+        net = box.compute_net_flux(_hollow_state_from_full(box, full))
+        assert abs(float(net[0])) < 1e-18
+
+    def test_one_sided_matches_plane_detector(self):
+        cfg = _uniform_config()
+        ny, nz = 3, 4
+        # depth-2 box along x: S_x = 0 on the min layer, S_x = c on the max layer.
+        c = 2.0
+        full = jnp.zeros((1, 6, 2, ny, nz), dtype=jnp.complex64)
+        full = full.at[:, _EY, 1].set(c).at[:, _HZ].set(1.0)  # E_y only on the max-x layer, H_z = 1 everywhere
+        box = _place_box(cfg, ((0, 2), (0, ny), (0, nz)), axes=(0,))
+        net = float(box.compute_net_flux(_hollow_state_from_full(box, full))[0])
+
+        plane = _place_plane(cfg, ((1, 2), (0, ny), (0, nz)), fixed_propagation_axis=0)
+        ph = plane.init_state()["phasor"]
+        ph = ph.at[:, :, _EY].set(c).at[:, :, _HZ].set(1.0)
+        p_plane = float(plane.compute_poynting_flux({"phasor": ph})[0])
+        assert net == pytest.approx(p_plane, rel=1e-6)
+
+    def test_orientation_inward_negates(self):
+        cfg = _uniform_config()
+        full = jnp.zeros((1, 6, 4, 4, 4), dtype=jnp.complex64)
+        # a divergent field: S_x grows along x -> nonzero outward net
+        ramp = jnp.arange(4, dtype=jnp.float32).reshape(1, 4, 1, 1)
+        full = full.at[:, _EY].set(ramp).at[:, _HZ].set(1.0)
+        out = _place_box(cfg, ((0, 4), (0, 4), (0, 4)), orientation="outward")
+        inw = _place_box(cfg, ((0, 4), (0, 4), (0, 4)), orientation="inward")
+        net_out = float(out.compute_net_flux(_hollow_state_from_full(out, full))[0])
+        net_in = float(inw.compute_net_flux(_hollow_state_from_full(inw, full))[0])
+        assert abs(net_out) > 0
+        assert net_in == pytest.approx(-net_out, rel=1e-6)
+
+    def test_parity_with_full_box_uniform(self):
+        cfg = _uniform_config()
+        box = _place_box(cfg, ((0, 4), (0, 5), (0, 3)))
+        active = box._resolve_active_axes()
+        k1, k2 = jax.random.split(_KEY)
+        full = jax.random.normal(k1, (1, 6, 4, 5, 3)) + 1j * jax.random.normal(k2, (1, 6, 4, 5, 3))
+        full = full.astype(jnp.complex64)
+        net = box.compute_net_flux(_hollow_state_from_full(box, full))
+        ref = _ref_net_flux(full, cfg, box, active)
+        assert jnp.allclose(net, ref, rtol=1e-4, atol=1e-6)
+
+    def test_parity_with_full_box_nonuniform(self):
+        s = _SPACING
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([0.0, 1.0, 3.0, 6.0, 10.0]) * s,  # nx=4
+            y_edges=jnp.asarray([0.0, 1.0, 3.0, 4.0]) * s,  # ny=3
+            z_edges=jnp.asarray([0.0, 2.0, 3.0]) * s,  # nz=2
+        )
+        cfg = SimulationConfig(time=20e-15, grid=grid, backend="cpu", dtype=jnp.float32, gradient_config=None)
+        box = _place_box(cfg, ((0, 4), (0, 3), (0, 2)))
+        active = box._resolve_active_axes()
+        k1, k2 = jax.random.split(jax.random.PRNGKey(7))
+        full = jax.random.normal(k1, (1, 6, 4, 3, 2)) + 1j * jax.random.normal(k2, (1, 6, 4, 3, 2))
+        full = full.astype(jnp.complex64)
+        net = box.compute_net_flux(_hollow_state_from_full(box, full))
+        ref = _ref_net_flux(full, cfg, box, active)
+        assert jnp.allclose(net, ref, rtol=1e-4, atol=1e-6)
+
+    def test_update_accumulates_into_faces(self):
+        box = _place_box(_uniform_config(), ((0, 4), (0, 4), (0, 4)))
+        shape = (4, 4, 4)
+        E = jnp.stack([jnp.zeros(shape), jnp.ones(shape), jnp.zeros(shape)])
+        H = jnp.stack([jnp.zeros(shape), jnp.zeros(shape), jnp.ones(shape)])
+        s1 = box.update(jnp.asarray(0), E, H, box.init_state(), jnp.ones((1, *shape)), 1.0)
+        s2 = box.update(jnp.asarray(0), E, H, s1, jnp.ones((1, *shape)), 1.0)
+        # two updates at the same time step exactly double every stored face
+        for key in s1:
+            assert jnp.allclose(s2[key], 2 * s1[key], atol=1e-6)
+
+    def test_invalid_orientation_raises(self):
+        with pytest.raises(ValueError, match="orientation"):
+            _place_box(_uniform_config(), ((0, 4), (0, 4), (0, 4)), orientation="sideways")
+
+    def test_invalid_axes_raises(self):
+        with pytest.raises(ValueError, match="axes"):
+            _place_box(_uniform_config(), ((0, 4), (0, 4), (0, 4)), axes=(0, 3))

--- a/tests/unit/objects/sources/test_tfsf_region.py
+++ b/tests/unit/objects/sources/test_tfsf_region.py
@@ -1,0 +1,222 @@
+"""Unit / integration tests for objects/sources/tfsf_region.py.
+
+Covers face enumeration, per-face descriptors populated by ``apply``, and the
+cross-object placement validation (periodic/wrap axes must have periodic
+boundaries on both sides and span the full domain; the propagation axis can
+never be periodic).
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import fdtdx
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
+from fdtdx.core.wavelength import WaveCharacter
+from fdtdx.objects.sources.tfsf_region import TFSFPlaneSourceRegion
+
+
+@pytest.fixture
+def micro_config():
+    return SimulationConfig(
+        time=20e-15,
+        grid=UniformGrid(spacing=100e-9),
+        backend="cpu",
+        dtype=jnp.float32,
+        gradient_config=None,
+    )
+
+
+def _make_region(propagation_axis=0, periodic_axes=(), grid_shape=(6, 6, 6)):
+    return TFSFPlaneSourceRegion(
+        name="src",
+        partial_grid_shape=grid_shape,
+        propagation_axis=propagation_axis,
+        direction="+",
+        wave_character=WaveCharacter(wavelength=1.0e-6),
+        fixed_E_polarization_vector=(0, 1, 0),
+        periodic_axes=periodic_axes,
+    )
+
+
+class TestActiveFaces:
+    def test_default_box_has_six_faces(self):
+        region = _make_region(propagation_axis=0)
+        faces = region._active_faces()
+        assert len(faces) == 6
+        # both propagation caps always present
+        assert (0, "-") in faces and (0, "+") in faces
+        # both transverse axes confined
+        assert (1, "-") in faces and (1, "+") in faces
+        assert (2, "-") in faces and (2, "+") in faces
+
+    def test_one_periodic_axis_drops_two_faces(self):
+        region = _make_region(propagation_axis=0, periodic_axes=(2,))
+        faces = region._active_faces()
+        assert len(faces) == 4
+        assert all(normal != 2 for normal, _ in faces)
+        assert (0, "-") in faces and (0, "+") in faces
+        assert (1, "-") in faces and (1, "+") in faces
+
+    def test_two_periodic_axes_leaves_only_caps(self):
+        region = _make_region(propagation_axis=0, periodic_axes=(1, 2))
+        faces = region._active_faces()
+        assert faces == [(0, "-"), (0, "+")]
+
+    def test_propagation_axis_selects_transverse(self):
+        region = _make_region(propagation_axis=2)
+        assert region.horizontal_axis == 0
+        assert region.vertical_axis == 1
+        faces = region._active_faces()
+        assert (2, "-") in faces and (2, "+") in faces
+
+
+def _place(objects, constraints, config):
+    key = jax.random.PRNGKey(0)
+    return fdtdx.place_objects(object_list=objects, config=config, constraints=constraints, key=key)
+
+
+def _pml_only(volume):
+    cfg = fdtdx.BoundaryConfig.from_uniform_bound(boundary_type="pml", thickness=2)
+    return fdtdx.boundary_objects_from_config(cfg, volume)
+
+
+class TestApplyPopulatesFaces:
+    def test_faces_and_signs(self, micro_config):
+        volume = fdtdx.SimulationVolume(partial_real_shape=(1.2e-6, 1.2e-6, 1.2e-6))
+        region = _make_region(propagation_axis=0, grid_shape=(6, 6, 6))
+        bd, bc = _pml_only(volume)
+        constraints = [region.place_at_center(volume), *bc]
+        objects, arrays, params, _config, key = _place([volume, region, *bd.values()], constraints, micro_config)
+        arrays, objects, _ = fdtdx.apply_params(arrays, objects, params, key)
+        placed = next(o for o in objects.objects if isinstance(o, TFSFPlaneSourceRegion))
+
+        assert len(placed._face_normal_axes) == 6
+        assert len(placed._face_incident_E) == 6
+        assert len(placed._face_incident_H) == 6
+        # min faces +1, max faces -1
+        for i, (normal, sign) in enumerate(zip(placed._face_normal_axes, placed._face_signs)):
+            lo, hi = placed._face_slice_tuples[i][normal]
+            assert hi - lo == 1  # face is one cell thick along its normal
+            box_lo, box_hi = placed.grid_slice_tuple[normal]
+            if lo == box_lo:
+                assert sign == 1
+            else:
+                assert lo == box_hi - 1 and sign == -1
+        # no dispersion -> no H filters
+        assert all(f is None for f in placed._face_H_filter)
+
+
+class TestValidatePlacement:
+    def test_propagation_axis_periodic_raises(self, micro_config):
+        volume = fdtdx.SimulationVolume(partial_real_shape=(1.2e-6, 1.2e-6, 1.2e-6))
+        region = _make_region(propagation_axis=0, periodic_axes=(0,), grid_shape=(6, 6, 6))
+        bd, bc = _pml_only(volume)
+        constraints = [region.place_at_center(volume), *bc]
+        with pytest.raises(ValueError, match="propagation axis"):
+            _place([volume, region, *bd.values()], constraints, micro_config)
+
+    def test_periodic_axis_without_periodic_boundary_raises(self, micro_config):
+        volume = fdtdx.SimulationVolume(partial_real_shape=(1.2e-6, 1.2e-6, 1.2e-6))
+        # axis 1 marked periodic but boundaries are PML -> error. Box spans axis 1.
+        region = _make_region(propagation_axis=0, periodic_axes=(1,), grid_shape=(6, None, 6))
+        bd, bc = _pml_only(volume)
+        constraints = [
+            region.place_at_center(volume),
+            region.same_size(volume, axes=(1,)),
+            *bc,
+        ]
+        with pytest.raises(ValueError, match=r"periodic \(Bloch\) boundaries on both"):
+            _place([volume, region, *bd.values()], constraints, micro_config)
+
+    def test_periodic_axis_not_spanning_domain_raises(self, micro_config):
+        volume = fdtdx.SimulationVolume(partial_real_shape=(1.2e-6, 1.2e-6, 1.2e-6))
+        # axis 1 periodic boundaries present, but box does NOT span axis 1 -> error.
+        region = _make_region(propagation_axis=0, periodic_axes=(1,), grid_shape=(6, 4, 6))
+        cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+            boundary_type="pml", thickness=2, override_types={"min_y": "periodic", "max_y": "periodic"}
+        )
+        bd, bc = fdtdx.boundary_objects_from_config(cfg, volume)
+        constraints = [region.place_at_center(volume), *bc]
+        with pytest.raises(ValueError, match="span the full simulation domain"):
+            _place([volume, region, *bd.values()], constraints, micro_config)
+
+    def test_periodic_axis_phase_shifted_bloch_raises(self, micro_config):
+        volume = fdtdx.SimulationVolume(partial_real_shape=(1.2e-6, 1.2e-6, 1.2e-6))
+        region = _make_region(propagation_axis=0, periodic_axes=(1,), grid_shape=(6, None, 6))
+        cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+            boundary_type="pml", thickness=2, override_types={"min_y": "bloch", "max_y": "bloch"}
+        )
+        cfg = cfg.aset("bloch_vector", (0.0, 0.5, 0.0))
+        bd, bc = fdtdx.boundary_objects_from_config(cfg, volume)
+        constraints = [region.place_at_center(volume), region.same_size(volume, axes=(1,)), *bc]
+        with pytest.raises(ValueError, match="phase-shifted Bloch"):
+            _place([volume, region, *bd.values()], constraints, micro_config)
+
+    def test_valid_periodic_placement_succeeds(self, micro_config):
+        volume = fdtdx.SimulationVolume(partial_real_shape=(1.2e-6, 1.2e-6, 1.2e-6))
+        region = _make_region(propagation_axis=0, periodic_axes=(1, 2), grid_shape=(6, None, None))
+        cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+            boundary_type="pml",
+            thickness=2,
+            override_types={f: "periodic" for f in ("min_y", "max_y", "min_z", "max_z")},
+        )
+        bd, bc = fdtdx.boundary_objects_from_config(cfg, volume)
+        constraints = [
+            region.place_at_center(volume),
+            region.same_size(volume, axes=(1, 2)),
+            *bc,
+        ]
+        # Should not raise.
+        objects, _arrays, _params, _config, _key = _place([volume, region, *bd.values()], constraints, micro_config)
+        placed = next(o for o in objects.objects if isinstance(o, TFSFPlaneSourceRegion))
+        assert placed._active_faces() == [(0, "-"), (0, "+")]
+
+
+@pytest.fixture
+def placed_vacuum_region(micro_config):
+    """A fully-confined vacuum box, placed and applied, plus the domain shape."""
+    volume = fdtdx.SimulationVolume(partial_real_shape=(1.2e-6, 1.2e-6, 1.2e-6))
+    region = _make_region(propagation_axis=0, grid_shape=(6, 6, 6))
+    bd, bc = _pml_only(volume)
+    constraints = [region.place_at_center(volume), *bc]
+    objects, arrays, params, config, key = _place([volume, region, *bd.values()], constraints, micro_config)
+    arrays, objects, _ = fdtdx.apply_params(arrays, objects, params, key)
+    placed = next(o for o in objects.objects if isinstance(o, TFSFPlaneSourceRegion))
+    return placed, config.grid.shape
+
+
+class TestInjectionBranches:
+    def test_update_E_fully_anisotropic_runs(self, placed_vacuum_region):
+        region, shape = placed_vacuum_region
+        E = jnp.zeros((3, *shape), dtype=jnp.float32)
+        inv_eps9 = jnp.ones((9, *shape), dtype=jnp.float32)
+        out = region.update_E(E, inv_eps9, 1.0, jnp.asarray(5), inverse=False)
+        assert out.shape == E.shape
+        assert jnp.all(jnp.isfinite(out))
+        assert not jnp.allclose(out, E)  # something was injected
+
+    def test_update_H_fully_anisotropic_runs(self, placed_vacuum_region):
+        region, shape = placed_vacuum_region
+        H = jnp.zeros((3, *shape), dtype=jnp.float32)
+        inv_mu9 = jnp.ones((9, *shape), dtype=jnp.float32)
+        out = region.update_H(H, jnp.ones((1, *shape)), inv_mu9, jnp.asarray(5), inverse=False)
+        assert out.shape == H.shape
+        assert jnp.all(jnp.isfinite(out))
+        assert not jnp.allclose(out, H)
+
+    def test_forward_then_inverse_is_identity(self, placed_vacuum_region):
+        """The reverse (adjoint) update must exactly undo the forward injection."""
+        region, shape = placed_vacuum_region
+        inv_eps = jnp.ones((1, *shape), dtype=jnp.float32)
+        E0 = jax.random.normal(jax.random.PRNGKey(1), (3, *shape), dtype=jnp.float32)
+        ts = jnp.asarray(7)
+        E_fwd = region.update_E(E0, inv_eps, 1.0, ts, inverse=False)
+        E_back = region.update_E(E_fwd, inv_eps, 1.0, ts, inverse=True)
+        assert jnp.allclose(E0, E_back, atol=1e-6)
+
+        H0 = jax.random.normal(jax.random.PRNGKey(2), (3, *shape), dtype=jnp.float32)
+        H_fwd = region.update_H(H0, inv_eps, 1.0, ts, inverse=False)
+        H_back = region.update_H(H_fwd, inv_eps, 1.0, ts, inverse=True)
+        assert jnp.allclose(H0, H_back, atol=1e-6)


### PR DESCRIPTION
Implemented TFSFPlaneSourceRegion as well as ClosedSurfacePoyntingFluxDetector, enabling scattering simulations of nanoparticles. Also added a simulation test comparing fdtdx to analytical mie scattering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added closed-surface Poynting flux detectors (time-domain and phasor variants) to measure net power through selectable box faces, with support for non-uniform grids and inward/outward orientation.
  * Added a TFSF plane-source region for box-based wave injection, including periodic configurations and dispersive injection.
  * Publicly exposed the new detectors and TFSF region.
* **Bug Fixes**
  * Added cross-object placement validation to detect incompatible configurations earlier.
* **Documentation**
  * Updated API documentation to include the newly public entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->