### PR TITLE
checkpointed time-reversed autodiff

### DIFF
--- a/src/fdtdx/config.py
+++ b/src/fdtdx/config.py
@@ -32,11 +32,25 @@ class GradientConfig(TreeClass):
     #: Needs to be provided for checkpointing gradient computation. Defaults to None.
     num_checkpoints: int | None = frozen_field(default=None)
 
+    #: Number of interior full-field checkpoints for the ``"reversible"`` method.
+    #: The reversible backward pass reconstructs the field state by running the simulation in
+    #: reverse; for lossy/dispersive materials this reverse reconstruction can accumulate numerical
+    #: error over the full trajectory. Setting this to ``k - 1`` partitions the run into ``k`` slices
+    #: and stores a full-field checkpoint at each interior slice boundary during the forward pass. The
+    #: backward pass then resets the reverse reconstruction to the exact checkpoint at every boundary,
+    #: bounding the reconstruction drift to a single slice (``~time_steps_total / k`` steps) at the
+    #: cost of O(k) field memory. The default ``0`` reproduces the classic single full reverse pass
+    #: (no interior checkpoints; only the final field, which is available for free, is used). Ignored
+    #: by the ``"checkpointed"`` method. Must not exceed ``time_steps_total - 1``.
+    num_checkpoints_reversible: int = frozen_field(default=0)
+
     def __post_init__(self):
         if self.method == "reversible" and self.recorder is None:
             raise Exception("Need Recorder in gradient config to compute reversible gradients")
         if self.method == "checkpointed" and self.num_checkpoints is None:
             raise Exception("Need Checkpoint Number in gradient config to compute checkpointed gradients")
+        if self.num_checkpoints_reversible < 0:
+            raise Exception("num_checkpoints_reversible must be >= 0")
 
 
 @autoinit

--- a/src/fdtdx/fdtd/fdtd.py
+++ b/src/fdtdx/fdtd/fdtd.py
@@ -130,29 +130,15 @@ def reversible_fdtd(
     )
     _forward_body_with_progress, _close_pbar = _wrap_body_with_progress(_forward_body, pbar)
 
-    def reversible_fdtd_base(
-        arr: ArrayContainer,
-    ) -> SimulationState:
-        state = (jnp.asarray(0, dtype=jnp.int32), arr)
-        state = eqxi.while_loop(
-            max_steps=config.time_steps_total,
-            cond_fun=lambda s: config.time_steps_total > s[0],
-            body_fun=_forward_body_with_progress,
-            init_val=state,
-            kind="lax",
-        )
-        return (state[0], state[1])
-
     def segmented_forward(
         arr: ArrayContainer,
     ) -> tuple[SimulationState, list[FieldState]]:
         """Run the forward pass in ``num_slices`` consecutive segments, capturing checkpoints.
 
-        Numerically identical to ``reversible_fdtd_base`` (same sequence of ``forward`` steps and
-        boundary recording), but after each of the first ``num_slices - 1`` segments the current
-        full ``FieldState`` at the interior boundary ``s_i`` is captured. For a single slice
-        (``num_slices == 1``) this runs exactly one while-loop over ``[0, time_steps_total]`` and
-        returns an empty checkpoint list, i.e. identical behavior to ``reversible_fdtd_base``.
+        This is the single source of truth for the reversible forward stepping. After each of the
+        first ``num_slices - 1`` segments the current full ``FieldState`` at the interior boundary
+        ``s_i`` is captured. For a single slice (``num_slices == 1``) this runs exactly one
+        while-loop over ``[0, time_steps_total]`` and returns an empty checkpoint list.
         """
         state = (jnp.asarray(0, dtype=jnp.int32), arr)
         checkpoints: list[FieldState] = []
@@ -168,6 +154,14 @@ def reversible_fdtd(
             if seg < num_slices - 1:
                 checkpoints.append(state[1].fields)
         return (state[0], state[1]), checkpoints
+
+    def reversible_fdtd_base(
+        arr: ArrayContainer,
+    ) -> SimulationState:
+        # Delegates to segmented_forward (single source of truth for the forward stepping) and
+        # discards the checkpoints - the non-gradient primal path needs only the final state.
+        state, _ = segmented_forward(arr)
+        return state
 
     @jax.custom_vjp
     def reversible_fdtd_primal(

--- a/src/fdtdx/fdtd/fdtd.py
+++ b/src/fdtdx/fdtd/fdtd.py
@@ -17,6 +17,25 @@ from fdtdx.interfaces.state import RecordingState
 from fdtdx.objects.detectors.detector import DetectorState
 
 
+def _reversible_slice_boundaries(time_steps_total: int, num_slices: int) -> list[int]:
+    """Compute the time-step boundaries partitioning a run into ``num_slices`` slices.
+
+    Returns ``[s_0, s_1, ..., s_k]`` with ``k = num_slices``, ``s_0 = 0`` and
+    ``s_k = time_steps_total``. The boundaries are strictly increasing and every slice
+    ``[s_i, s_{i+1}]`` has length ``>= 1`` provided ``1 <= num_slices <= time_steps_total``.
+    The interior boundaries ``s_1 .. s_{k-1}`` are the times at which a full-field checkpoint
+    is taken for the sliced reversible backward pass.
+
+    Args:
+        time_steps_total (int): Total number of forward time steps ``T``.
+        num_slices (int): Number of slices ``k`` (``= num_checkpoints_reversible + 1``).
+
+    Returns:
+        list[int]: The ``num_slices + 1`` boundary time steps.
+    """
+    return [round(i * time_steps_total / num_slices) for i in range(num_slices + 1)]
+
+
 def reversible_fdtd(
     arrays: ArrayContainer,
     objects: ObjectContainer,
@@ -74,6 +93,23 @@ def reversible_fdtd(
     if arrays.dispersive_inv_c2 is not None:
         arrays = arrays.at["dispersive_inv_c2"].set(jax.lax.stop_gradient(arrays.dispersive_inv_c2))
 
+    # Sliced reversible backward pass: partition the run into ``num_slices`` slices and store a
+    # full-field checkpoint at each interior boundary during the forward pass, so the reverse
+    # reconstruction can be reset to the exact field at every boundary (bounding reconstruction
+    # drift for lossy/dispersive materials). ``num_checkpoints_reversible == 0`` (the default)
+    # gives a single slice and reproduces the classic full reverse pass exactly.
+    num_ckpt = 0 if config.gradient_config is None else config.gradient_config.num_checkpoints_reversible
+    num_slices = num_ckpt + 1
+    # Only the interior checkpoints (num_ckpt >= 1) impose the slice-length constraint; the default
+    # single slice (num_ckpt == 0) is always valid, including the ``time_steps_total == 0`` edge case.
+    if num_ckpt > 0 and num_slices > config.time_steps_total:
+        raise Exception(
+            "num_checkpoints_reversible must be <= time_steps_total - 1 "
+            f"(got num_checkpoints_reversible={num_ckpt}, time_steps_total={config.time_steps_total})"
+        )
+    slice_boundaries = _reversible_slice_boundaries(config.time_steps_total, num_slices)
+    checkpoint_times = slice_boundaries[1:-1]  # interior boundaries s_1 .. s_{k-1}
+
     pbar = _make_pbar(
         show_progress=show_progress,
         total_steps=config.time_steps_total,
@@ -106,6 +142,32 @@ def reversible_fdtd(
             kind="lax",
         )
         return (state[0], state[1])
+
+    def segmented_forward(
+        arr: ArrayContainer,
+    ) -> tuple[SimulationState, list[FieldState]]:
+        """Run the forward pass in ``num_slices`` consecutive segments, capturing checkpoints.
+
+        Numerically identical to ``reversible_fdtd_base`` (same sequence of ``forward`` steps and
+        boundary recording), but after each of the first ``num_slices - 1`` segments the current
+        full ``FieldState`` at the interior boundary ``s_i`` is captured. For a single slice
+        (``num_slices == 1``) this runs exactly one while-loop over ``[0, time_steps_total]`` and
+        returns an empty checkpoint list, i.e. identical behavior to ``reversible_fdtd_base``.
+        """
+        state = (jnp.asarray(0, dtype=jnp.int32), arr)
+        checkpoints: list[FieldState] = []
+        for seg in range(num_slices):
+            hi = slice_boundaries[seg + 1]
+            state = eqxi.while_loop(
+                max_steps=hi - slice_boundaries[seg],
+                cond_fun=lambda s, _hi=hi: _hi > s[0],
+                body_fun=_forward_body_with_progress,
+                init_val=state,
+                kind="lax",
+            )
+            if seg < num_slices - 1:
+                checkpoints.append(state[1].fields)
+        return (state[0], state[1]), checkpoints
 
     @jax.custom_vjp
     def reversible_fdtd_primal(
@@ -223,6 +285,7 @@ def reversible_fdtd(
         residual,
         cot,
     ):
+        primal_out, checkpoints = residual
         (
             res_time_step,
             res_E,
@@ -239,7 +302,7 @@ def reversible_fdtd(
             res_dispersive_c4,
             res_detector_states,
             res_recording_state,
-        ) = residual
+        ) = primal_out
 
         s_k = ArrayContainer(
             fields=FieldState(
@@ -264,9 +327,32 @@ def reversible_fdtd(
             initial_inv_permittivities=arrays.initial_inv_permittivities,
         )
 
+        # For a single slice ``checkpoints`` is empty and the reverse loop runs the unmodified
+        # ``body_fn`` (bit-identical to the classic full reverse pass). Otherwise, wrap ``body_fn``
+        # so that at each interior boundary ``s_i`` the reconstructed primal field is reset to the
+        # exact stored checkpoint before the reverse step, bounding reconstruction drift. The
+        # cotangent carry is threaded through untouched, keeping the field adjoint continuous.
+        if checkpoints:
+
+            def reverse_body(sr_tuple):
+                state, running_cot = sr_tuple
+                time_step, arrs = state
+                for ckpt_fields, s_i in zip(checkpoints, checkpoint_times):
+                    cur_fields = arrs.fields
+                    new_fields = jax.lax.cond(
+                        time_step == s_i,
+                        lambda cf=ckpt_fields: cf,
+                        lambda cf=cur_fields: cf,
+                    )
+                    arrs = arrs.aset("fields", new_fields)
+                return body_fn(((time_step, arrs), running_cot))
+
+        else:
+            reverse_body = body_fn
+
         _, cot = eqxi.while_loop(
             cond_fun=partial(cond_fun, start_time_step=0),
-            body_fun=body_fn,
+            body_fun=reverse_body,
             init_val=((res_time_step, s_k), cot),
             kind="lax",
         )
@@ -325,7 +411,7 @@ def reversible_fdtd(
             dispersive_inv_c2=arrays.dispersive_inv_c2,
             initial_inv_permittivities=arrays.initial_inv_permittivities,
         )
-        s_k = reversible_fdtd_base(arr)
+        s_k, checkpoints = segmented_forward(arr)
 
         primal_out = (
             s_k[0],
@@ -344,7 +430,10 @@ def reversible_fdtd(
             s_k[1].detector_states,
             s_k[1].recording_state,  # None
         )
-        residual = primal_out
+        # ``checkpoints`` holds the interior full-field snapshots (empty for a single slice); they
+        # are threaded to ``fdtd_bwd`` via the residual so the reverse reconstruction can be reset
+        # to the exact field at each boundary.
+        residual = (primal_out, checkpoints)
         return primal_out, residual
 
     reversible_fdtd_primal.defvjp(fdtd_fwd, fdtd_bwd)

--- a/tests/simulation/fdtd/test_fdtd.py
+++ b/tests/simulation/fdtd/test_fdtd.py
@@ -9,6 +9,7 @@ autodiff). Float64 sharpens the precision floor so an algebraic bug in either
 path produces visible disagreement.
 """
 
+import itertools
 from contextlib import contextmanager
 
 import jax
@@ -348,8 +349,13 @@ def _build_magnetic_lossy_scene(dtype):
     return obj, arrays, config
 
 
-def _attach_gradient(arrays, config, obj, method, num_checkpoints=8):
-    """Attach a fresh gradient_config + recording_state to the scene."""
+def _attach_gradient(arrays, config, obj, method, num_checkpoints=8, num_checkpoints_reversible=0):
+    """Attach a fresh gradient_config + recording_state to the scene.
+
+    ``num_checkpoints_reversible`` selects the number of interior full-field checkpoints for the
+    sliced reversible backward pass (0 = classic single full reverse pass); it is ignored by the
+    checkpointed method.
+    """
     input_shape_dtypes = {}
     field_dtype = arrays.fields.E.dtype
     for boundary in obj.pml_objects:
@@ -364,7 +370,9 @@ def _attach_gradient(arrays, config, obj, method, num_checkpoints=8):
         backend="cpu",
     )
     if method == "reversible":
-        grad_cfg = GradientConfig(method="reversible", recorder=recorder)
+        grad_cfg = GradientConfig(
+            method="reversible", recorder=recorder, num_checkpoints_reversible=num_checkpoints_reversible
+        )
     else:
         grad_cfg = GradientConfig(method="checkpointed", num_checkpoints=num_checkpoints)
     config = config.aset("gradient_config", grad_cfg)
@@ -600,3 +608,140 @@ class TestReversibleVsCheckpointedGradient:
             gx = float(jnp.max(jnp.abs(grad_rev[:, 0])))
             gy = float(jnp.max(jnp.abs(grad_rev[:, 1])))
             assert gx != gy
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Sliced reversible backward pass (num_checkpoints_reversible)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestSlicedReversibleGradient:
+    """The sliced reversible backward pass partitions the run into ``k`` slices and stores a
+    full-field checkpoint at each interior boundary, resetting the reverse reconstruction to the
+    exact field there. Two properties must hold:
+
+    1. In a numerically benign (lossless, exactly reversible) regime, adding checkpoints must not
+       change a correct gradient — the reset lands on the same field the reverse pass would have
+       reconstructed anyway.
+    2. In a lossy/dispersive regime where the reverse reconstruction drifts, more checkpoints must
+       drive the reversible gradient toward the checkpointed reference (exact autodiff) — never
+       away from it.
+    """
+
+    @staticmethod
+    def _field_loss_inv_eps(arrays, obj, config):
+        def loss_fn(inv_eps):
+            arr = ArrayContainer(
+                fields=FieldState(
+                    E=arrays.fields.E,
+                    H=arrays.fields.H,
+                    psi_E=arrays.fields.psi_E,
+                    psi_H=arrays.fields.psi_H,
+                    dispersive_P_curr=arrays.fields.dispersive_P_curr,
+                    dispersive_P_prev=arrays.fields.dispersive_P_prev,
+                ),
+                inv_permittivities=inv_eps,
+                inv_permeabilities=arrays.inv_permeabilities,
+                detector_states=arrays.detector_states,
+                recording_state=arrays.recording_state,
+                electric_conductivity=arrays.electric_conductivity,
+                magnetic_conductivity=arrays.magnetic_conductivity,
+                dispersive_c1=arrays.dispersive_c1,
+                dispersive_c2=arrays.dispersive_c2,
+                dispersive_c3=arrays.dispersive_c3,
+                dispersive_inv_c2=arrays.dispersive_inv_c2,
+            )
+            _, out = reversible_fdtd(arr, obj, config, jax.random.PRNGKey(99), show_progress=False)
+            return jnp.sum(jnp.real(out.fields.E) ** 2)
+
+        return loss_fn
+
+    def test_checkpoints_do_not_change_gradient_benign_float64(self):
+        """Lossless dielectric scene (float64): gradients for 0, 3 and T-1 interior checkpoints
+        must agree to ~machine precision. Lossless dynamics are exactly time-reversible, so the
+        reverse reconstruction does not drift and the checkpoint resets are no-ops on the gradient.
+        """
+        lossless_material = fdtdx.Material(permittivity=2.0)  # no loss, no dispersion
+        with _x64_enabled():
+            obj, arrays, config = _build_lossy_dispersive_scene(dtype=jnp.float64, material=lossless_material)
+            t_total = config.time_steps_total
+
+            def grad_for(num_ckpt):
+                arr, cfg = _attach_gradient(
+                    arrays, config, obj, method="reversible", num_checkpoints_reversible=num_ckpt
+                )
+                loss_fn = self._field_loss_inv_eps(arr, obj, cfg)
+                return jax.value_and_grad(loss_fn)(arr.inv_permittivities)
+
+            loss0, grad0 = grad_for(0)
+            assert jnp.isfinite(loss0) and jnp.all(jnp.isfinite(grad0))
+            for num_ckpt in (3, t_total - 1):
+                loss_k, grad_k = grad_for(num_ckpt)
+                assert jnp.allclose(loss_k, loss0, rtol=1e-12, atol=1e-14)
+                max_abs = float(jnp.max(jnp.abs(grad0) + jnp.abs(grad_k)))
+                max_diff = float(jnp.max(jnp.abs(grad0 - grad_k)))
+                rel = max_diff / (max_abs + 1e-30)
+                assert rel < 1e-8, f"checkpoints changed benign gradient (num_ckpt={num_ckpt}): rel={rel:.3e}"
+
+    def test_checkpoints_converge_to_checkpointed_reference_lossy(self):
+        """Lossy + dispersive scene: the reversible gradient with checkpoints must converge to the
+        checkpointed-autodiff reference. More checkpoints must not increase the relative error, and
+        enough checkpoints must bring it below tolerance. Float32 is used because that is where the
+        reverse-reconstruction drift (lossy forward = gain in reverse) is numerically visible."""
+        dtype = jnp.float32
+
+        # Reference: exact autodiff through the checkpointed loop.
+        obj_r, arrays_r, config_r = _build_lossy_dispersive_scene(dtype=dtype)
+        arrays_r, config_r = _attach_gradient(arrays_r, config_r, obj_r, method="checkpointed")
+
+        def ref_loss(inv_eps):
+            arr = ArrayContainer(
+                fields=FieldState(
+                    E=arrays_r.fields.E,
+                    H=arrays_r.fields.H,
+                    psi_E=arrays_r.fields.psi_E,
+                    psi_H=arrays_r.fields.psi_H,
+                    dispersive_P_curr=arrays_r.fields.dispersive_P_curr,
+                    dispersive_P_prev=arrays_r.fields.dispersive_P_prev,
+                ),
+                inv_permittivities=inv_eps,
+                inv_permeabilities=arrays_r.inv_permeabilities,
+                detector_states=arrays_r.detector_states,
+                recording_state=arrays_r.recording_state,
+                electric_conductivity=arrays_r.electric_conductivity,
+                magnetic_conductivity=arrays_r.magnetic_conductivity,
+                dispersive_c1=arrays_r.dispersive_c1,
+                dispersive_c2=arrays_r.dispersive_c2,
+                dispersive_c3=arrays_r.dispersive_c3,
+                dispersive_inv_c2=arrays_r.dispersive_inv_c2,
+            )
+            _, out = checkpointed_fdtd(arr, obj_r, config_r, jax.random.PRNGKey(99), show_progress=False)
+            return jnp.sum(jnp.real(out.fields.E) ** 2)
+
+        _, grad_ref = jax.value_and_grad(ref_loss)(arrays_r.inv_permittivities)
+        ref_norm = float(jnp.max(jnp.abs(grad_ref))) + 1e-30
+
+        def reversible_rel_err(num_ckpt):
+            obj, arrays, config = _build_lossy_dispersive_scene(dtype=dtype)
+            arrays, config = _attach_gradient(
+                arrays, config, obj, method="reversible", num_checkpoints_reversible=num_ckpt
+            )
+            loss_fn = self._field_loss_inv_eps(arrays, obj, config)
+            _, grad = jax.value_and_grad(loss_fn)(arrays.inv_permittivities)
+            assert jnp.all(jnp.isfinite(grad)), f"non-finite reversible gradient at num_ckpt={num_ckpt}"
+            return float(jnp.max(jnp.abs(grad - grad_ref))) / ref_norm
+
+        checkpoint_counts = [0, 8, 32]
+        rel_errs = [reversible_rel_err(n) for n in checkpoint_counts]
+
+        # More checkpoints must never make the reversible gradient meaningfully worse (the
+        # multiplicative slack absorbs float32 noise when the error is already near the floor).
+        for lo, hi in itertools.pairwise(rel_errs):
+            assert hi <= lo * 1.5 + 1e-6, f"adding checkpoints increased the error: {rel_errs}"
+
+        # With the most checkpoints the reversible gradient must match the checkpointed reference.
+        # (Tolerance is generous for float32; tighten in a faster environment if desired.)
+        assert rel_errs[-1] < 1e-2, (
+            f"sliced reversible gradient did not converge to the checkpointed reference: "
+            f"rel_errs={rel_errs} for num_checkpoints_reversible={checkpoint_counts}"
+        )

--- a/tests/unit/fdtd/test_fdtd.py
+++ b/tests/unit/fdtd/test_fdtd.py
@@ -7,8 +7,9 @@ import pytest
 from fdtdx.config import GradientConfig, SimulationConfig
 from fdtdx.core.grid import UniformGrid
 from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer
-from fdtdx.fdtd.fdtd import checkpointed_fdtd, custom_fdtd_forward, reversible_fdtd
+from fdtdx.fdtd.fdtd import _reversible_slice_boundaries, checkpointed_fdtd, custom_fdtd_forward, reversible_fdtd
 from fdtdx.fdtd.stop_conditions import TimeStepCondition
+from fdtdx.interfaces.recorder import Recorder
 from fdtdx.objects.object import SimulationObject
 
 
@@ -86,6 +87,81 @@ def config_checkpointed():
 @pytest.fixture
 def key():
     return jax.random.PRNGKey(0)
+
+
+class TestReversibleSliceBoundaries:
+    """Tests for the slice-boundary helper of the sliced reversible backward pass."""
+
+    @pytest.mark.parametrize(
+        "time_steps_total,num_slices",
+        [(10, 1), (10, 2), (10, 3), (10, 7), (10, 10), (37, 5), (420, 4), (5, 5), (1, 1)],
+    )
+    def test_boundaries_are_valid_partition(self, time_steps_total, num_slices):
+        b = _reversible_slice_boundaries(time_steps_total, num_slices)
+        # k + 1 boundaries, from 0 to T inclusive
+        assert len(b) == num_slices + 1
+        assert b[0] == 0
+        assert b[-1] == time_steps_total
+        # strictly increasing (distinct) and every slice has length >= 1
+        assert b == sorted(b)
+        assert len(set(b)) == len(b)
+        assert all(b[i + 1] - b[i] >= 1 for i in range(num_slices))
+
+    def test_single_slice_is_full_range(self):
+        """num_slices == 1 (num_checkpoints_reversible == 0) yields no interior boundaries."""
+        b = _reversible_slice_boundaries(123, 1)
+        assert b == [0, 123]
+        assert b[1:-1] == []  # no interior checkpoints
+
+    def test_every_step_checkpointed(self):
+        """num_slices == T yields a boundary at every integer time step."""
+        b = _reversible_slice_boundaries(6, 6)
+        assert b == [0, 1, 2, 3, 4, 5, 6]
+
+
+def _reversible_grad_config(config, num_ckpt):
+    """Attach a reversible GradientConfig (empty recorder) with the given interior-checkpoint count.
+
+    Returns the updated config and the matching zero-initialized recording_state. The dummy scene
+    has no PML, so the recorder needs no interface buffers (``input_shape_dtypes={}``).
+    """
+    recorder = Recorder(modules=[])
+    recorder, recording_state = recorder.init_state(
+        input_shape_dtypes={},
+        max_time_steps=config.time_steps_total,
+        backend="cpu",
+    )
+    config = config.aset(
+        "gradient_config",
+        GradientConfig(method="reversible", recorder=recorder, num_checkpoints_reversible=num_ckpt),
+    )
+    return config, recording_state
+
+
+class TestSlicedReversibleFdtd:
+    """Smoke tests exercising the segmented forward + checkpoint-reset backward under jax.grad."""
+
+    def test_grad_runs_with_interior_checkpoints(self, dummy_arrays, dummy_objects, config_few_steps, key):
+        config, recording_state = _reversible_grad_config(config_few_steps, num_ckpt=2)
+        arrays = dummy_arrays.aset("recording_state", recording_state)
+
+        def loss(inv_eps):
+            a = arrays.aset("inv_permittivities", inv_eps)
+            _, out = reversible_fdtd(a, dummy_objects, config, key, show_progress=False)
+            return jnp.sum(out.fields.E**2) + jnp.sum(out.fields.H**2)
+
+        val, grad = jax.value_and_grad(loss)(arrays.inv_permittivities)
+        assert jnp.isfinite(val)
+        assert jnp.all(jnp.isfinite(grad))
+        assert grad.shape == arrays.inv_permittivities.shape
+
+    def test_too_many_checkpoints_raises(self, dummy_arrays, dummy_objects, config_few_steps, key):
+        # num_checkpoints_reversible == time_steps_total means num_slices == T + 1 > T.
+        num_ckpt = config_few_steps.time_steps_total
+        config, recording_state = _reversible_grad_config(config_few_steps, num_ckpt=num_ckpt)
+        arrays = dummy_arrays.aset("recording_state", recording_state)
+        with pytest.raises(Exception, match="num_checkpoints_reversible must be <="):
+            reversible_fdtd(arrays, dummy_objects, config, key, show_progress=False)
 
 
 class TestReversibleFdtd:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -39,6 +39,21 @@ class TestGradientConfigConstruction:
         with pytest.raises(Exception, match="Need Checkpoint Number in gradient config"):
             GradientConfig(method="checkpointed")
 
+    def test_num_checkpoints_reversible_defaults_to_zero(self):
+        """The sliced-reversible checkpoint count defaults to 0 (classic full reverse pass)."""
+        config = GradientConfig(method="reversible", recorder=MagicMock())
+        assert config.num_checkpoints_reversible == 0
+
+    def test_num_checkpoints_reversible_accepts_positive(self):
+        """A positive interior-checkpoint count is stored as given."""
+        config = GradientConfig(method="reversible", recorder=MagicMock(), num_checkpoints_reversible=3)
+        assert config.num_checkpoints_reversible == 3
+
+    def test_num_checkpoints_reversible_negative_raises(self):
+        """A negative interior-checkpoint count is rejected."""
+        with pytest.raises(Exception, match="num_checkpoints_reversible must be >= 0"):
+            GradientConfig(method="reversible", recorder=MagicMock(), num_checkpoints_reversible=-1)
+
 
 def _create_mock_backend(platform="cpu"):
     """Helper to create mock backend for SimulationConfig tests."""


### PR DESCRIPTION
Implementation of a time-reversed autodiff which splits the forward/backward pass into multiple smaller segments, in between which are checkpoints used. This is currently a simple linear approach (one could also combine forward/backward in a dynamic way similar to the existing checkpointing), and one could also use compression on the checkpoints. Both of these points are deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new reversible-gradient checkpoint option (`num_checkpoints_reversible`) to control sliced reversible backpropagation.
  * Reversible backpropagation can now capture and reconstruct interior simulation states using these reversible-specific checkpoints.
  * Supports validation for reversible checkpoint settings and provides an accuracy–performance tradeoff.

* **Bug Fixes**
  * Improved gradient quality in lossy/dispersive regimes: increasing reversible checkpoints drives results toward the checkpointed-reference behavior without worsening error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->