### PR TITLE
fix: global colorbar scaling for videos

### DIFF
--- a/src/fdtdx/objects/detectors/plotting/video.py
+++ b/src/fdtdx/objects/detectors/plotting/video.py
@@ -159,8 +159,8 @@ def generate_video_from_slices(
     partial_fn = partial(
         plt_fn,
         resolutions=resolutions,
-        minvals=minvals,
-        maxvals=maxvals,
+        minvals=(minlist[0], minlist[1], minlist[2]),
+        maxvals=(maxlist[0], maxlist[1], maxlist[2]),
         plot_dpi=plot_dpi,
         plot_interpolation=plot_interpolation,
         coordinate_edges_um=coordinate_edges_um,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed video rendering to consistently apply automatically calculated color scale limits.
  * Improved visualization of signed data when color bounds are missing or inferred, ensuring frame colors remain accurate throughout the generated video.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->