### PR TITLE
better dispersion instability warnings

### DIFF
--- a/src/fdtdx/dispersion.py
+++ b/src/fdtdx/dispersion.py
@@ -44,10 +44,26 @@ step ``dt``:
     c_2 = -\\frac{1 - \\gamma \\Delta t / 2}{1 + \\gamma \\Delta t / 2}, \\quad
     c_3 = \\frac{K \\Delta t^2}{1 + \\gamma \\Delta t / 2}
 
-Stability requires :math:`\\gamma \\Delta t < 2`; in the physical regime
-of interest :math:`\\gamma \\Delta t \\ll 1`, so :math:`c_2 \\approx -1`,
-which makes the backward (reverse-time) recurrence numerically stable
-after algebraic inversion.
+Stability of the polarization recurrence requires both roots of
+:math:`z^2 - c_1 z - c_2 = 0` to lie inside the unit circle, which (via the
+Jury conditions) reduces to the two per-pole bounds
+:math:`\\gamma \\Delta t < 2` and :math:`\\omega_0 \\Delta t < 2`. In the
+physical regime of interest both products are :math:`\\ll 1`, so
+:math:`c_2 \\approx -1`, which makes the backward (reverse-time) recurrence
+numerically stable after algebraic inversion. Both bounds are enforced in
+:func:`compute_pole_coefficients_per_axis`.
+
+For CCPR poles the polarization couples to :math:`E^{n+1}` through
+:math:`c_4`, so the E-field update divides by a per-cell implicit factor
+:math:`1 + \\varepsilon_\\infty^{-1} \\sum_p c_{4,p}\\ (+\\ c\\,\\sigma\\,\\eta_0\\,\\varepsilon_\\infty^{-1} / 2)`.
+This must stay positive in every cell; as it approaches :math:`0^+` the
+transient gain (:math:`\\approx 1/\\text{divisor}`) explodes and accuracy
+collapses. Since :math:`c_4 \\propto \\Delta t \\propto` ``courant_factor``,
+the divisor can be kept safe by lowering ``courant_factor``. This per-cell
+condition is checked at initialization by
+:func:`fdtdx.materials.validate_dispersive_divisor_stability` (Lorentz and
+Drude poles have :math:`c_4 = 0`, so their divisor is always
+:math:`\\geq 1`).
 
 Anisotropic (per-axis) dispersion
 ---------------------------------
@@ -551,6 +567,14 @@ def compute_pole_coefficients_per_axis(
                     f"Pole {i} ({type(p).__name__}) has gamma * dt = {gamma_dt:.4g} >= 2{axis_note}; "
                     "the reversible ADE update requires gamma * dt < 2 (physically gamma * dt << 1). "
                     "Lower the damping or reduce the time step."
+                )
+            omega0_dt = omega_0[ax] * dt
+            if omega0_dt >= 2.0:
+                axis_note = "" if p.is_isotropic else f" on axis {'xyz'[ax]}"
+                raise ValueError(
+                    f"Pole {i} ({type(p).__name__}) has omega_0 * dt = {omega0_dt:.4g} >= 2{axis_note}; "
+                    "the ADE recurrence roots leave the unit circle (requires omega_0 * dt < 2, "
+                    "physically omega_0 * dt << 1). Lower the resonance frequency or reduce the time step."
                 )
             denom = 1.0 + 0.5 * gamma_dt
             c1[i, ax] = (2.0 - (omega_0[ax] ** 2) * (dt**2)) / denom

--- a/src/fdtdx/dispersion.py
+++ b/src/fdtdx/dispersion.py
@@ -44,14 +44,26 @@ step ``dt``:
     c_2 = -\\frac{1 - \\gamma \\Delta t / 2}{1 + \\gamma \\Delta t / 2}, \\quad
     c_3 = \\frac{K \\Delta t^2}{1 + \\gamma \\Delta t / 2}
 
-Stability of the polarization recurrence requires both roots of
-:math:`z^2 - c_1 z - c_2 = 0` to lie inside the unit circle, which (via the
-Jury conditions) reduces to the two per-pole bounds
-:math:`\\gamma \\Delta t < 2` and :math:`\\omega_0 \\Delta t < 2`. In the
-physical regime of interest both products are :math:`\\ll 1`, so
-:math:`c_2 \\approx -1`, which makes the backward (reverse-time) recurrence
-numerically stable after algebraic inversion. Both bounds are enforced in
-:func:`compute_pole_coefficients_per_axis`.
+Two *independent* conditions constrain the coefficients; both are enforced in
+:func:`compute_pole_coefficients_per_axis` (only on axes where the pole
+actually couples, since a zero-coupling axis keeps its polarization
+identically zero):
+
+* **Forward unit-circle (Jury) stability.** The roots of
+  :math:`z^2 - c_1 z - c_2 = 0` lie inside the unit circle iff
+  :math:`|c_2| < 1` *and* :math:`|c_1| < 1 - c_2`. The first holds for every
+  :math:`\\gamma \\Delta t > 0` (:math:`c_2 = 0` at :math:`\\gamma \\Delta t = 2`
+  and :math:`|c_2| \\to 1` only as :math:`\\gamma \\Delta t \\to 0` or
+  :math:`\\infty`), so it is not the binding constraint. The second is
+  algebraically equivalent to :math:`\\omega_0 \\Delta t < 2` (independent of
+  :math:`\\gamma`), which is therefore the forward-stability bound.
+* **Reverse-update conditioning.** The backward (reverse-time) recurrence is
+  formed by dividing through by :math:`c_2`, so :math:`c_2` must stay bounded
+  away from zero. This is a *separate* requirement, :math:`\\gamma \\Delta t < 2`
+  (:math:`c_2 = 0` exactly at :math:`\\gamma \\Delta t = 2`); in the physical
+  regime :math:`\\gamma \\Delta t \\ll 1` so :math:`c_2 \\approx -1` and the
+  inversion is well conditioned. It is a conditioning bound for reversibility,
+  not a forward unit-circle criterion.
 
 For CCPR poles the polarization couples to :math:`E^{n+1}` through
 :math:`c_4`, so the E-field update divides by a per-cell implicit factor
@@ -561,15 +573,21 @@ def compute_pole_coefficients_per_axis(
         coupling_edot = p.coupling_edot_axes
         for ax in range(3):
             gamma_dt = gamma[ax] * dt
-            if gamma_dt >= 2.0:
+            omega0_dt = omega_0[ax] * dt
+            # The stability bounds only bind on axes where the pole actually
+            # couples. A zero-coupling axis (e.g. a Lorentz pole with
+            # delta_epsilon = 0 there, the documented way to express an absent
+            # resonance) has c3 = c4 = 0, so its polarization stays identically
+            # zero and its unused omega_0 / gamma are irrelevant.
+            axis_active = coupling_sq[ax] != 0.0 or coupling_edot[ax] != 0.0
+            if axis_active and gamma_dt >= 2.0:
                 axis_note = "" if p.is_isotropic else f" on axis {'xyz'[ax]}"
                 raise ValueError(
                     f"Pole {i} ({type(p).__name__}) has gamma * dt = {gamma_dt:.4g} >= 2{axis_note}; "
                     "the reversible ADE update requires gamma * dt < 2 (physically gamma * dt << 1). "
                     "Lower the damping or reduce the time step."
                 )
-            omega0_dt = omega_0[ax] * dt
-            if omega0_dt >= 2.0:
+            if axis_active and omega0_dt >= 2.0:
                 axis_note = "" if p.is_isotropic else f" on axis {'xyz'[ax]}"
                 raise ValueError(
                     f"Pole {i} ({type(p).__name__}) has omega_0 * dt = {omega0_dt:.4g} >= 2{axis_note}; "

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -17,11 +17,13 @@ from fdtdx.dispersion import compute_pole_coefficients_per_axis
 from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer, ParameterContainer
 from fdtdx.fdtd.symmetry import apply_mode_symmetry, make_symmetry_walls, reduce_resolved_slices
 from fdtdx.materials import (
+    Material,
     compute_allowed_dispersive_coefficients,
     compute_allowed_electric_conductivities,
     compute_allowed_magnetic_conductivities,
     compute_allowed_permeabilities,
     compute_allowed_permittivities,
+    validate_dispersive_divisor_stability,
 )
 from fdtdx.objects.boundaries.bloch import BlochBoundary
 from fdtdx.objects.device.parameters.transform import ParameterType
@@ -508,6 +510,34 @@ def apply_params(
     )
 
     return arrays, new_objects, info
+
+
+def _collect_labeled_materials(objects: ObjectContainer) -> dict[str, Material]:
+    """Collect every material in the simulation, labeled for diagnostics.
+
+    Single-material objects (``UniformMaterialObject``) are keyed by the object
+    name; multi-material objects (``Device``, ``StaticMultiMaterialObject``) by
+    ``"<object name>:<material key>"``. Duck-typed on ``material`` / ``materials``
+    to avoid importing every object subclass.
+
+    Args:
+        objects (ObjectContainer): Container with the placed simulation objects.
+
+    Returns:
+        dict[str, Material]: Mapping of label to material.
+    """
+    labeled: dict[str, Material] = {}
+    for o in objects.objects:
+        mat = getattr(o, "material", None)
+        if isinstance(mat, Material):
+            labeled[o.name] = mat
+            continue
+        mats = getattr(o, "materials", None)
+        if isinstance(mats, dict):
+            for key, m in mats.items():
+                if isinstance(m, Material):
+                    labeled[f"{o.name}:{key}"] = m
+    return labeled
 
 
 def _init_arrays(
@@ -1058,6 +1088,19 @@ def _init_arrays(
     dispersive_inv_c2 = None
     if dispersive_c2 is not None:
         dispersive_inv_c2 = jnp.where(dispersive_c2 == 0, 0.0, 1.0 / dispersive_c2)
+
+    # Validate CCPR dispersive stability once, on concrete host values. Only CCPR
+    # (non-zero dE/dt coupling) poles have a non-trivial implicit divisor, so the
+    # gate keeps Lorentz/Drude-only sims free of this cost. The full-tensor path
+    # (which has no ADE block) is already rejected for any dispersive material by
+    # the NotImplementedError guard above, so this only runs on the ADE-active
+    # 1/3-component paths whose divisor is exactly what update_E computes.
+    if objects.has_dispersive_edot:
+        validate_dispersive_divisor_stability(
+            _collect_labeled_materials(objects),
+            dt=config.time_step_duration,
+            courant_factor=config.courant_factor,
+        )
 
     # Save backup of initial inv_permittivities when using etched_devices
     using_etching = any(d.use_etching for d in objects.devices)

--- a/src/fdtdx/materials.py
+++ b/src/fdtdx/materials.py
@@ -936,26 +936,57 @@ def _min_dispersive_divisor(mat: Material, dt: float) -> tuple[float, int]:
     return min_div, worst_ax
 
 
-def _max_safe_courant_factor(mat: Material, dt: float, courant_factor: float, threshold: float) -> float:
-    """Largest ``courant_factor`` keeping ``mat``'s implicit divisor ``>= threshold``.
+def _max_safe_courant_factor(
+    mat: Material,
+    dt: float,
+    courant_factor: float,
+    threshold: float,
+    scan_steps: int = 512,
+) -> float:
+    """Largest ``courant_factor`` below which ``mat`` stays stable at every step.
 
-    ``dt`` is proportional to ``courant_factor`` on every grid type, so scaling the
-    time step by ``s`` scales the divisor correction (``~ dt``) by ``s``. As
-    ``s -> 0`` the divisor tends to ``1`` (safe) and at ``s = 1`` it is below the
-    threshold (why we are here), so a simple bisection on ``s`` brackets the
-    crossing. Recomputing ``c4`` at each ``s * dt`` handles the weak
-    ``D = 1 + gamma * dt / 2`` nonlinearity exactly rather than assuming strict
-    linearity.
+    ``dt`` is proportional to ``courant_factor`` on every grid type, so scaling
+    the time step by ``s`` scales directly to a ``courant_factor``. Each pole's
+    ``c4_p(s) = b_p * (s * dt) / (1 + gamma_p * s * dt / 2)`` is individually
+    monotonic in ``s`` (its sign is that of ``b_p``), but the *sum* over poles
+    with mixed ``b_p`` signs and dampings — plus the linearly growing
+    conductivity term — is not necessarily monotonic and may cross ``threshold``
+    several times. To keep it genuinely safe (every value below ``X``
+    stable), we search for the *first* crossing from ``s = 0`` (where the
+    divisor is ``~ 1``): a forward scan brackets it, then bisection refines.
+    Recomputing the divisor at each ``s * dt`` handles the weak
+    ``D = 1 + gamma * dt / 2`` nonlinearity exactly.
     """
-    lo, hi = 0.0, 1.0  # lo: safe scale (divisor -> 1), hi: current (unsafe) scale
-    for _ in range(60):
+    n = max(1, scan_steps)
+    prev = 0.0  # last safe scale (divisor >= threshold); s = 0 gives divisor ~ 1
+    hi = None
+    for k in range(1, n + 1):
+        s = k / n
+        div, _ = _min_dispersive_divisor(mat, s * dt)
+        if div < threshold:
+            hi = s
+            break
+        prev = s
+    if hi is None:
+        # No sub-threshold scan point found. Unreachable via the validator (it
+        # only calls this when the divisor at s = 1 is already below threshold),
+        # but stay conservative if invoked directly.
+        return 0.5 * courant_factor
+    lo = prev  # bracket [lo, hi]: divisor(lo) >= threshold, divisor(hi) < threshold
+    for _ in range(50):
         mid = 0.5 * (lo + hi)
         div, _ = _min_dispersive_divisor(mat, mid * dt)
         if div >= threshold:
             lo = mid
         else:
             hi = mid
-    return lo * courant_factor
+    result = lo * courant_factor
+    if result <= 0.0:
+        return 0.0
+    # Floor to 3 significant figures so the reported "<= X" is never rounded
+    # ABOVE the true first-crossing boundary (nearest-rounding could over-promise).
+    scale = 10.0 ** (math.floor(math.log10(result)) - 2)
+    return math.floor(result / scale) * scale
 
 
 def validate_dispersive_divisor_stability(

--- a/src/fdtdx/materials.py
+++ b/src/fdtdx/materials.py
@@ -897,6 +897,124 @@ def compute_allowed_dispersive_coefficients(
     return c1, c2, c3, c4
 
 
+def _min_dispersive_divisor(mat: Material, dt: float) -> tuple[float, int]:
+    r"""Minimum per-cell implicit-update divisor for a dispersive material.
+
+    Mirrors the ``divisor`` computed in :func:`fdtdx.fdtd.update.update_E` for a
+    cell fully occupied by ``mat``:
+
+    .. math::
+        \text{divisor}_a = 1 + \varepsilon_{\infty,a}^{-1} \sum_p c_{4,p,a}
+        + \tfrac{1}{2}\, \sigma_a\, c_0\, \Delta t\, \eta_0\, \varepsilon_{\infty,a}^{-1}
+
+    per axis ``a``. The ``courant_number`` that scales both the conductivity term
+    and the (resolution-scaled) conductivity array cancels, so the divisor depends
+    only on ``dt``, the diagonal ``eps_inf``, the physical conductivity, and the
+    pole ``c4`` coefficients. The conductivity term is always ``>= 0``, so the
+    binding constraint is ``1 + inv_eps * sum(c4)``.
+
+    Args:
+        mat: A dispersive material (``mat.dispersion`` must not be ``None``).
+        dt: Simulation time step (seconds).
+
+    Returns:
+        tuple: ``(min_divisor, worst_axis)`` — the smallest divisor over the three
+        grid axes and the axis index at which it occurs.
+    """
+    assert mat.dispersion is not None
+    _, _, _, c4 = compute_pole_coefficients_per_axis(mat.dispersion.poles, dt)
+    sum_c4 = c4.sum(axis=0)  # (3,) sum over poles, per axis
+    eps_inf = (mat.permittivity[0], mat.permittivity[4], mat.permittivity[8])
+    sigma = (mat.electric_conductivity[0], mat.electric_conductivity[4], mat.electric_conductivity[8])
+    min_div, worst_ax = math.inf, 0
+    for ax in range(3):
+        inv_eps = 1.0 / eps_inf[ax]
+        cond = 0.5 * sigma[ax] * constants.c * dt * constants.eta0 * inv_eps  # >= 0
+        div = 1.0 + inv_eps * float(sum_c4[ax]) + cond
+        if div < min_div:
+            min_div, worst_ax = div, ax
+    return min_div, worst_ax
+
+
+def _max_safe_courant_factor(mat: Material, dt: float, courant_factor: float, threshold: float) -> float:
+    """Largest ``courant_factor`` keeping ``mat``'s implicit divisor ``>= threshold``.
+
+    ``dt`` is proportional to ``courant_factor`` on every grid type, so scaling the
+    time step by ``s`` scales the divisor correction (``~ dt``) by ``s``. As
+    ``s -> 0`` the divisor tends to ``1`` (safe) and at ``s = 1`` it is below the
+    threshold (why we are here), so a simple bisection on ``s`` brackets the
+    crossing. Recomputing ``c4`` at each ``s * dt`` handles the weak
+    ``D = 1 + gamma * dt / 2`` nonlinearity exactly rather than assuming strict
+    linearity.
+    """
+    lo, hi = 0.0, 1.0  # lo: safe scale (divisor -> 1), hi: current (unsafe) scale
+    for _ in range(60):
+        mid = 0.5 * (lo + hi)
+        div, _ = _min_dispersive_divisor(mat, mid * dt)
+        if div >= threshold:
+            lo = mid
+        else:
+            hi = mid
+    return lo * courant_factor
+
+
+def validate_dispersive_divisor_stability(
+    materials: dict[str, Material],
+    dt: float,
+    courant_factor: float,
+    near_zero_threshold: float = 0.01,
+) -> None:
+    r"""Validate the per-cell implicit-update divisor of CCPR dispersive materials.
+
+    For CCPR poles (non-zero ``dE/dt`` coupling) the E-field update divides by a
+    per-cell factor ``1 + inv_eps * sum(c4) [+ conductivity term]`` (see
+    :func:`fdtdx.fdtd.update.update_E`). This must stay positive; as it approaches
+    ``0^+`` the transient gain (``~ 1/divisor``) explodes and accuracy collapses.
+    Lorentz and Drude poles have ``c4 = 0``, so their divisor is always ``>= 1``
+    and they are skipped.
+
+    Checked per distinct material rather than per assembled cell: a cell holds one
+    material's coefficients, so this covers every static cell, names the offending
+    material, and — because a CONTINUOUS device's interpolated divisor
+    ``1 + sum(c4)(t) / eps(t)`` is a monotonic (Moebius) function of the mix ``t``
+    — the bracketing materials bound the device-interpolated cells too.
+
+    Args:
+        materials: Mapping of label -> :class:`Material` for every material in the
+            simulation. Labels appear verbatim in the error/warning messages.
+        dt: Simulation time step (seconds).
+        courant_factor: The configured ``courant_factor`` (for the remediation hint).
+        near_zero_threshold: Warn when ``0 < divisor < near_zero_threshold``; raise
+            when ``divisor <= 0``.
+
+    Raises:
+        ValueError: If any material's divisor is non-positive (unconditionally
+            unstable / NaN).
+    """
+    for name, mat in materials.items():
+        if mat.dispersion is None:
+            continue
+        # c4 != 0 only for CCPR / non-zero dE/dt coupling; Lorentz & Drude are safe.
+        if not any(b != 0.0 for p in mat.dispersion.poles for b in p.coupling_edot_axes):
+            continue
+        min_div, worst_ax = _min_dispersive_divisor(mat, dt)
+        if min_div >= near_zero_threshold:
+            continue
+        cf_max = _max_safe_courant_factor(mat, dt, courant_factor, near_zero_threshold)
+        axis_note = f" on axis {'xyz'[worst_ax]}" if not (mat.is_all_isotropic and mat.dispersion.is_isotropic) else ""
+        detail = (
+            f"Dispersive material '{name}' has an implicit E-update divisor = {min_div:.4g}{axis_note} "
+            "(1 + inv_eps * sum(c4) [+ conductivity term]); this factor divides the E-field update, so as "
+            "it approaches 0 the transient gain (~1/divisor) explodes and accuracy collapses. The divisor "
+            f"scales with the time step, so lower courant_factor to <= {cf_max:.3g} (currently {courant_factor:.3g})."
+        )
+        if min_div <= 0.0:
+            raise ValueError(
+                detail + " The divisor is non-positive, which makes the ADE update unconditionally unstable (NaN)."
+            )
+        warnings.warn(detail, UserWarning, stacklevel=2)
+
+
 def compute_ordered_names(
     materials: dict[str, Material],
 ) -> list[str]:

--- a/tests/integration/fdtd/test_dispersive_init.py
+++ b/tests/integration/fdtd/test_dispersive_init.py
@@ -11,7 +11,7 @@ import pytest
 
 from fdtdx.config import SimulationConfig
 from fdtdx.constants import c as c0
-from fdtdx.dispersion import DispersionModel, DrudePole, LorentzPole, compute_pole_coefficients
+from fdtdx.dispersion import CCPRPole, DispersionModel, DrudePole, LorentzPole, compute_pole_coefficients
 from fdtdx.fdtd.initialization import apply_params, place_objects
 from fdtdx.materials import Material
 from fdtdx.objects.device.device import Device
@@ -403,6 +403,65 @@ def test_fully_anisotropic_plus_dispersive_raises(simple_config, simple_volume):
     key = jax.random.PRNGKey(0)
     with pytest.raises(NotImplementedError, match="fully anisotropic"):
         place_objects([simple_volume, obj1, obj2], simple_config, constraints, key)
+
+
+def _unstable_ccpr_material(eps_inf=2.0):
+    """CCPR material whose implicit-update divisor goes non-positive at the
+    ``simple_config`` time step (~1.9e-16 s), i.e. large negative Re(residue)."""
+    pole = CCPRPole(pole=complex(-1e13, -2e15), residue=complex(-6e15, 1e15))
+    return Material(permittivity=eps_inf, dispersion=DispersionModel(poles=(pole,)))
+
+
+def test_unstable_ccpr_material_raises_at_placement(simple_config, simple_volume):
+    """A CCPR material with a non-positive implicit divisor must be rejected by
+    place_objects (via _init_arrays -> validate_dispersive_divisor_stability)."""
+    obj = UniformMaterialObject(name="gold", partial_grid_shape=(10, 10, 10), material=_unstable_ccpr_material())
+    constraint = GridCoordinateConstraint(
+        object="gold", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[10, 10, 10]
+    )
+    key = jax.random.PRNGKey(0)
+    with pytest.raises(ValueError, match="gold"):
+        place_objects([simple_volume, obj], simple_config, [constraint], key)
+
+
+def test_lowering_courant_factor_stabilizes_ccpr(simple_config, simple_volume):
+    """The remediation actually works: the same material places cleanly once the
+    courant_factor is lowered below the value reported in the error message."""
+    obj = UniformMaterialObject(name="gold", partial_grid_shape=(10, 10, 10), material=_unstable_ccpr_material())
+    constraint = GridCoordinateConstraint(
+        object="gold", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[10, 10, 10]
+    )
+    key = jax.random.PRNGKey(0)
+    with pytest.raises(ValueError) as exc:
+        place_objects([simple_volume, obj], simple_config, [constraint], key)
+    cf_max = float(str(exc.value).split("lower courant_factor to <= ")[1].split(" ")[0])
+    safe_config = simple_config.aset("courant_factor", 0.9 * cf_max)
+    # Must not raise now.
+    place_objects([simple_volume, obj], safe_config, [constraint], key)
+
+
+def test_stable_ccpr_material_places_cleanly(simple_config, simple_volume):
+    """A CCPR material with a comfortably positive divisor places without error."""
+    pole = CCPRPole(pole=complex(-1e13, -2e15), residue=complex(-2e15, 1e15))
+    mat = Material(permittivity=2.0, dispersion=DispersionModel(poles=(pole,)))
+    obj = UniformMaterialObject(name="metal", partial_grid_shape=(10, 10, 10), material=mat)
+    constraint = GridCoordinateConstraint(
+        object="metal", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[10, 10, 10]
+    )
+    key = jax.random.PRNGKey(0)
+    _, arrays, _, _, _ = place_objects([simple_volume, obj], simple_config, [constraint], key)
+    assert arrays.dispersive_c4 is not None
+
+
+def test_lorentz_material_unaffected_by_ccpr_validation(simple_config, simple_volume):
+    """A Lorentz-only sim (c4 = 0) is not subject to the divisor validation and
+    places cleanly even at the default courant_factor."""
+    obj = UniformMaterialObject(name="slab", partial_grid_shape=(10, 10, 10), material=_lorentz_material(eps_inf=2.0))
+    constraint = GridCoordinateConstraint(
+        object="slab", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[10, 10, 10]
+    )
+    key = jax.random.PRNGKey(0)
+    place_objects([simple_volume, obj], simple_config, [constraint], key)
 
 
 def test_non_dispersive_unused_import_guard():

--- a/tests/unit/test_dispersion.py
+++ b/tests/unit/test_dispersion.py
@@ -134,14 +134,18 @@ class TestComputePoleCoefficients:
         assert c3[1] > 0
 
     def test_gamma_dt_at_least_two_raises(self):
-        # gamma * dt >= 2 violates the |c2| < 1 root condition.
+        # gamma * dt >= 2 drives c2 to 0 (and positive beyond), so the reversible
+        # (reverse-time) ADE update -- which divides by c2 -- is no longer well
+        # conditioned. This is a reversibility conditioning bound, separate from
+        # the forward unit-circle (Jury) criterion omega_0 * dt < 2; note |c2| < 1
+        # itself holds for every gamma * dt > 0.
         p = LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0)
         with pytest.raises(ValueError, match="gamma"):
             compute_pole_coefficients((p,), dt=2.0 / p.gamma)
 
     def test_omega0_dt_at_least_two_raises(self):
-        # omega_0 * dt >= 2 violates the |c1| < 1 - c2 root condition (roots leave
-        # the unit circle) even when gamma * dt is tiny.
+        # omega_0 * dt >= 2 violates the forward Jury bound |c1| < 1 - c2 (the
+        # recurrence roots leave the unit circle) even when gamma * dt is tiny.
         p = LorentzPole(resonance_frequency=1e15, damping=1e10, delta_epsilon=2.0)
         with pytest.raises(ValueError, match=r"omega_0 \* dt"):
             compute_pole_coefficients((p,), dt=2.0 / p.omega_0)
@@ -151,6 +155,15 @@ class TestComputePoleCoefficients:
         p = LorentzPole(resonance_frequency=1e15, damping=1e10, delta_epsilon=2.0)
         c1, _, _, _ = compute_pole_coefficients((p,), dt=1.9 / p.omega_0)
         assert np.isfinite(c1[0])
+
+    def test_zero_coupling_pole_skips_bounds(self):
+        # A Lorentz pole with delta_epsilon = 0 contributes nothing (coupling_sq =
+        # 0, so c3 = 0 and the polarization stays zero); its unused omega_0 / gamma
+        # must not trip the stability bounds even when both products exceed 2.
+        p = LorentzPole(resonance_frequency=3e17, damping=3e17, delta_epsilon=0.0)
+        c1, c2, c3, c4 = compute_pole_coefficients((p,), dt=1e-17)
+        assert c3[0] == 0.0 and c4[0] == 0.0
+        assert np.isfinite(c1[0]) and np.isfinite(c2[0])
 
 
 class TestMaterialIsDispersive:
@@ -504,6 +517,19 @@ class TestPerAxisCoefficients:
         p = LorentzPole(resonance_frequency=(1e15, 1e15, 3e17), damping=1e13, delta_epsilon=1.0)
         with pytest.raises(ValueError, match=r"omega_0 \* dt.*axis z"):
             compute_pole_coefficients_per_axis((p,), dt=1e-17)
+
+    def test_per_axis_inert_axes_skip_bounds(self):
+        # resonance only on x (delta_epsilon = 0 on y, z).
+        # A large unused omega_0 AND gamma on the inert y/z axes must not raise.
+        p = LorentzPole(
+            resonance_frequency=(1e15, 3e17, 3e17),
+            damping=(1e13, 3e17, 3e17),
+            delta_epsilon=(2.0, 0.0, 0.0),
+        )
+        c1, c2, c3, _ = compute_pole_coefficients_per_axis((p,), dt=1e-17)
+        # Inert axes carry zero coupling; the active x axis is fine (omega_0*dt<2).
+        assert c3[0, 1] == 0.0 and c3[0, 2] == 0.0
+        assert np.all(np.isfinite(c1)) and np.all(np.isfinite(c2))
 
     def test_eps_spectrum_averages_component_axis(self):
         # With a 3-component coefficient axis the spectrum helper must average

--- a/tests/unit/test_dispersion.py
+++ b/tests/unit/test_dispersion.py
@@ -133,6 +133,25 @@ class TestComputePoleCoefficients:
         # c3 for Drude should be non-zero because coupling_sq = omega_p**2
         assert c3[1] > 0
 
+    def test_gamma_dt_at_least_two_raises(self):
+        # gamma * dt >= 2 violates the |c2| < 1 root condition.
+        p = LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0)
+        with pytest.raises(ValueError, match="gamma"):
+            compute_pole_coefficients((p,), dt=2.0 / p.gamma)
+
+    def test_omega0_dt_at_least_two_raises(self):
+        # omega_0 * dt >= 2 violates the |c1| < 1 - c2 root condition (roots leave
+        # the unit circle) even when gamma * dt is tiny.
+        p = LorentzPole(resonance_frequency=1e15, damping=1e10, delta_epsilon=2.0)
+        with pytest.raises(ValueError, match=r"omega_0 \* dt"):
+            compute_pole_coefficients((p,), dt=2.0 / p.omega_0)
+
+    def test_omega0_dt_just_below_two_is_ok(self):
+        # Just under the bound must not raise.
+        p = LorentzPole(resonance_frequency=1e15, damping=1e10, delta_epsilon=2.0)
+        c1, _, _, _ = compute_pole_coefficients((p,), dt=1.9 / p.omega_0)
+        assert np.isfinite(c1[0])
+
 
 class TestMaterialIsDispersive:
     def test_material_is_not_dispersive_by_default(self):
@@ -478,6 +497,12 @@ class TestPerAxisCoefficients:
         # gamma * dt >= 2 only on the y axis must raise and identify the axis.
         p = LorentzPole(resonance_frequency=1e15, damping=(1e13, 3e17, 1e13), delta_epsilon=1.0)
         with pytest.raises(ValueError, match="axis y"):
+            compute_pole_coefficients_per_axis((p,), dt=1e-17)
+
+    def test_per_axis_omega0_stability_check_names_axis(self):
+        # omega_0 * dt >= 2 only on the z axis must raise and identify the axis.
+        p = LorentzPole(resonance_frequency=(1e15, 1e15, 3e17), damping=1e13, delta_epsilon=1.0)
+        with pytest.raises(ValueError, match=r"omega_0 \* dt.*axis z"):
             compute_pole_coefficients_per_axis((p,), dt=1e-17)
 
     def test_eps_spectrum_averages_component_axis(self):

--- a/tests/unit/test_materials.py
+++ b/tests/unit/test_materials.py
@@ -950,6 +950,27 @@ class TestDispersiveDivisorStability:
         dt_safe = self.DT * (cf_max / 0.99)
         assert _min_dispersive_divisor(mat, dt_safe)[0] >= 0.01 - 1e-9
 
+    def test_recommended_courant_factor_is_conservative_for_mixed_sign_poles(self):
+        # The divisor is a sum of individually-monotonic c4 terms with mixed
+        # residue signs, so it need not be monotonic in the time step. The
+        # recommendation must be the FIRST crossing from zero: EVERY scale below
+        # it must be stable, not just the returned point.
+        from fdtdx.dispersion import CCPRPole, DispersionModel
+        from fdtdx.materials import _min_dispersive_divisor, validate_dispersive_divisor_stability
+
+        poles = (
+            CCPRPole(pole=complex(-2e14, -2e15), residue=complex(-1.2e16, 1e15)),  # strong b < 0
+            CCPRPole(pole=complex(-4e15, -8e15), residue=complex(3e15, 5e14)),  # b > 0
+        )
+        mat = Material(permittivity=2.0, dispersion=DispersionModel(poles=poles))
+        with pytest.raises(ValueError) as exc:
+            validate_dispersive_divisor_stability({"m": mat}, dt=self.DT, courant_factor=0.99)
+        cf_max = float(str(exc.value).split("lower courant_factor to <= ")[1].split(" ")[0])
+        s_max = cf_max / 0.99
+        # Conservativeness invariant: divisor >= threshold at every scale up to s_max.
+        scales = [s_max * k / 400 for k in range(1, 401)]
+        assert min(_min_dispersive_divisor(mat, s * self.DT)[0] for s in scales) >= 0.01 - 1e-9
+
     def test_stable_ccpr_material_does_not_raise_or_warn(self):
         import warnings
 

--- a/tests/unit/test_materials.py
+++ b/tests/unit/test_materials.py
@@ -890,3 +890,106 @@ class TestHasIsotropicDispersion:
 
         disp = DispersionModel(poles=(DrudePole(plasma_frequency=(2e15, 0.0, 0.0), damping=1e13),))
         assert not Material(permittivity=2.25, dispersion=disp).has_isotropic_dispersion
+
+
+class TestDispersiveDivisorStability:
+    """Per-material implicit-update divisor validation for CCPR poles.
+
+    The CCPR polarization couples to E^{n+1} through c4, so update_E divides by
+    ``divisor = 1 + inv_eps * sum(c4) [+ conductivity term]``. A large negative
+    Re(residue) makes c4 negative and can drive the divisor to zero (huge ring-up)
+    or below zero (NaN). dt ~ 1.9e-16 corresponds to a ~1e-7 m grid at
+    courant_factor 0.99.
+    """
+
+    DT = 1.9e-16
+
+    @staticmethod
+    def _ccpr_material(re_residue, eps_inf=2.0, electric_conductivity=0.0):
+        from fdtdx.dispersion import CCPRPole, DispersionModel
+
+        pole = CCPRPole(pole=complex(-1e13, -2e15), residue=complex(re_residue, 1e15))
+        return Material(
+            permittivity=eps_inf,
+            electric_conductivity=electric_conductivity,
+            dispersion=DispersionModel(poles=(pole,)),
+        )
+
+    def test_non_positive_divisor_raises_with_name_and_courant_hint(self):
+        from fdtdx.materials import validate_dispersive_divisor_stability
+
+        mat = self._ccpr_material(-6e15)  # drives the divisor below zero
+        with pytest.raises(ValueError, match="gold") as exc:
+            validate_dispersive_divisor_stability({"gold": mat}, dt=self.DT, courant_factor=0.99)
+        msg = str(exc.value)
+        assert "non-positive" in msg
+        assert "courant_factor" in msg
+
+    def test_near_zero_divisor_warns(self):
+        from fdtdx.materials import validate_dispersive_divisor_stability
+
+        # A mildly-negative residue keeps the divisor positive but small; a wide
+        # explicit threshold makes the warn band robust (default 0.01 is narrow).
+        mat = self._ccpr_material(-4e15)
+        with pytest.warns(UserWarning, match="courant_factor"):
+            validate_dispersive_divisor_stability(
+                {"gold": mat}, dt=self.DT, courant_factor=0.99, near_zero_threshold=0.5
+            )
+
+    def test_recommended_courant_factor_is_below_current_and_stabilizes(self):
+        from fdtdx.materials import _min_dispersive_divisor, validate_dispersive_divisor_stability
+
+        mat = self._ccpr_material(-6e15)
+        with pytest.raises(ValueError) as exc:
+            validate_dispersive_divisor_stability({"gold": mat}, dt=self.DT, courant_factor=0.99)
+        # Parse the recommended courant_factor out of the message.
+        msg = str(exc.value)
+        cf_max = float(msg.split("lower courant_factor to <= ")[1].split(" ")[0])
+        assert 0.0 < cf_max < 0.99
+        # dt scales with courant_factor: at the recommended cf the divisor recovers.
+        dt_safe = self.DT * (cf_max / 0.99)
+        assert _min_dispersive_divisor(mat, dt_safe)[0] >= 0.01 - 1e-9
+
+    def test_stable_ccpr_material_does_not_raise_or_warn(self):
+        import warnings
+
+        from fdtdx.materials import validate_dispersive_divisor_stability
+
+        mat = self._ccpr_material(-2e15)  # divisor ~ 0.6, comfortably positive
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            validate_dispersive_divisor_stability({"safe": mat}, dt=self.DT, courant_factor=0.99)
+
+    def test_lorentz_and_drude_are_skipped(self):
+        import warnings
+
+        from fdtdx.dispersion import DispersionModel, DrudePole, LorentzPole
+        from fdtdx.materials import validate_dispersive_divisor_stability
+
+        lorentz = Material(
+            permittivity=2.0,
+            dispersion=DispersionModel(poles=(LorentzPole(resonance_frequency=2e15, damping=1e13, delta_epsilon=1.5),)),
+        )
+        drude = Material(
+            permittivity=1.0,
+            dispersion=DispersionModel(poles=(DrudePole(plasma_frequency=1.37e16, damping=1e14),)),
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            validate_dispersive_divisor_stability({"lorentz": lorentz, "drude": drude}, dt=self.DT, courant_factor=0.99)
+
+    def test_per_axis_instability_names_axis(self):
+        from fdtdx.materials import validate_dispersive_divisor_stability
+
+        # Anisotropic eps_inf: only the low-permittivity x axis destabilizes.
+        mat = self._ccpr_material(-6e15, eps_inf=(2.0, 8.0, 8.0))
+        with pytest.raises(ValueError, match="axis x"):
+            validate_dispersive_divisor_stability({"aniso": mat}, dt=self.DT, courant_factor=0.99)
+
+    def test_conductivity_term_relaxes_the_bound(self):
+        from fdtdx.materials import _min_dispersive_divisor
+
+        # The conductivity term is >= 0, so adding loss increases the divisor.
+        lossless = self._ccpr_material(-6e15, electric_conductivity=0.0)
+        lossy = self._ccpr_material(-6e15, electric_conductivity=5e5)
+        assert _min_dispersive_divisor(lossy, self.DT)[0] > _min_dispersive_divisor(lossless, self.DT)[0]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stronger stability validation for CCPR dispersive materials during simulation setup, including per-axis checks.
  * Detects unstable configurations (e.g., non-positive implicit E-field update divisor) and reports the affected object/axis with Courant-factor remediation guidance.
  * Ensures stability bounds are only enforced on axes where the material couples; Lorentz/Drude materials are skipped as appropriate.
* **Documentation**
  * Expanded discrete-time polarization recurrence and CCPR stability guidance, including recommended Courant-factor behavior.
* **Tests**
  * Added unit and integration coverage for stable/unstable CCPR, Lorentz, Drude, anisotropic cases, and error/warning messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->