### PR TITLE
disable untested codepaths

### DIFF
--- a/.claude/skills/fdtdx/SKILL.md
+++ b/.claude/skills/fdtdx/SKILL.md
@@ -112,7 +112,7 @@ Note the asymmetry: sigma_E multiplied by eta0, sigma_H divided by eta0.
 P_p^(n+1) = c1_p * P_p^n + c2_p * P_p^(n-1) + c3_p * E^n
 E        += inv_eps * sum_p (P_p^n - P_p^(n+1))
 ```
-`P` is stored normalized as `P/eps_0`, so it has the same units as `E` and no eta0 factor enters. The reverse-time update in `update_E_reverse` inverts this recurrence (`c2 ~ -1` in the physical regime keeps the inversion numerically stable).
+`P` is stored normalized as `P/eps_0`, so it has the same units as `E` and no eta0 factor enters. There is no reverse-time counterpart: dispersive simulations are **checkpointed-only** (see Gradient Strategies).
 
 ## Material System
 
@@ -148,20 +148,19 @@ c1 = (2 − ω₀²·dt²) / (1 + γ·dt/2)
 c2 = −(1 − γ·dt/2) / (1 + γ·dt/2)
 c3 =  (K·dt²)      / (1 + γ·dt/2)
 ```
-Stability needs `γ·dt < 2`; physically `γ·dt ≪ 1`, so `c2 ≈ −1` and the reverse-time inversion in `update_E_reverse` is well-conditioned.
+Stability (forward Jury bound) needs `ω₀·dt < 2`; `γ·dt` is unconstrained (`|c2| < 1` for any `γ·dt > 0`).
 
 **Per-axis (diagonally anisotropic) dispersion:** every pole parameter accepts a scalar or a per-axis 3-tuple `(x, y, z)` — e.g. `DrudePole(plasma_frequency=(wp, 0.0, 0.0), damping=g)` for a hyperbolic medium metallic only along x. The canonical pole accessors are `omega_0_axes`/`gamma_axes`/`coupling_sq_axes`/`coupling_edot_axes` (the scalar `omega_0` etc. raise for per-axis poles). `compute_pole_coefficients_per_axis` returns `(n_poles, 3)` coefficient arrays; `DispersionModel.susceptibility_axes(omega)` gives per-axis χ. Static negative ε is unconditionally unstable in FDTD — hyperbolic/metallic behavior must come from poles with ε∞ ≥ 1 (`Material.__init__` warns otherwise).
 
-**Oriented (off-diagonal) dispersion:** a pole may carry an `orientation` unit vector — a single 1D oscillator along `u` with coupling tensor `K u uᵀ` (scalar parameters only; oriented CCPR with dE/dt coupling raises). `DispersionModel.rotated(R)` (3x3 matrix or Euler angles) converts a per-axis model into oriented poles for tilted crystals (signed axis permutations stay per-axis; pole count can grow up to 3x otherwise). `compute_pole_coefficients_tensor` returns c1/c2 `(n, 3)` + c3/c4 `(n, 9)`; `susceptibility_tensor(omega)`/`permittivity_tensor` give the 3x3 χ/ε. Oriented dispersion forces the 9-component ε tier (fully anisotropic kernel, which carries its own ADE block with Yee-averaged off-diagonal coupling) and is **checkpointed-only** — the reversible gradient method raises at init and in `run_fdtd`.
+**Oriented (off-diagonal) dispersion:** a pole may carry an `orientation` unit vector — a single 1D oscillator along `u` with coupling tensor `K u uᵀ` (scalar parameters only; oriented CCPR with dE/dt coupling raises). `DispersionModel.rotated(R)` (3x3 matrix or Euler angles) converts a per-axis model into oriented poles for tilted crystals (signed axis permutations stay per-axis; pole count can grow up to 3x otherwise). `compute_pole_coefficients_tensor` returns c1/c2 `(n, 3)` + c3/c4 `(n, 9)`; `susceptibility_tensor(omega)`/`permittivity_tensor` give the 3x3 χ/ε. Oriented dispersion forces the 9-component ε tier (fully anisotropic kernel, which carries its own ADE block with Yee-averaged off-diagonal coupling).
 
 **ArrayContainer fields** (all `None` unless any object is dispersive):
 - `dispersive_P_curr`, `dispersive_P_prev` — shape `(num_poles, 3, Nx, Ny, Nz)`, field-dtype (complex if `use_complex_fields`). Not differentiable (state-only; `None` cotangent in both gradient paths).
-- `dispersive_c1`, `dispersive_c2`, `dispersive_c3` — shape `(num_poles, C, Nx, Ny, Nz)`. For `c1`/`c2`, `C = 1` when all dispersion is isotropic (middle axis broadcasts over field components) or `C = 3` for per-axis dispersion (gated by `ObjectContainer.all_objects_isotropic_dispersion`). The coupling `c3` (and `c4`) additionally widens to `C = 9` (row-major 3x3 tensor per pole) when any pole is oriented (gated by `ObjectContainer.all_objects_axis_aligned_dispersion`). Config dtype. Differentiable: cotangents flow through them in both the reversible and checkpointed paths.
-- `dispersive_inv_c2` — cached `1/c2`, closure-captured and `stop_gradient`'d so gradients flow through `c2` only and don't double-count.
+- `dispersive_c1`, `dispersive_c2`, `dispersive_c3` — shape `(num_poles, C, Nx, Ny, Nz)`. For `c1`/`c2`, `C = 1` when all dispersion is isotropic (middle axis broadcasts over field components) or `C = 3` for per-axis dispersion (gated by `ObjectContainer.all_objects_isotropic_dispersion`). The coupling `c3` (and `c4`) additionally widens to `C = 9` (row-major 3x3 tensor per pole) when any pole is oriented (gated by `ObjectContainer.all_objects_axis_aligned_dispersion`). Config dtype. Differentiable: cotangents flow through them on the checkpointed path.
 
 **Leading pole axis size:** `objects.max_num_dispersive_poles` — the max pole count across all `UniformMaterialObject`, `Device`, `StaticMultiMaterialObject`. Materials with fewer poles get zero-padded slots, so non-dispersive cells automatically contribute zero. `UniformMaterialObject` always writes the full zero-padded coefficient stack into its `grid_slice`, so a non-dispersive object placed over a dispersive one cleanly clears stale coefficients.
 
-**Restriction:** Dispersion combined with fully anisotropic (off-diagonal) ε/σ tensors or oriented poles runs through the fully anisotropic update path and supports only the `checkpointed` gradient method (`reversible` raises — no closed-form time reversal). CCPR poles with a dE/dt coupling (`c4`) cannot be combined with that path (no implicit tensor solve).
+**Restriction:** *Any* dispersive material supports only the `checkpointed` gradient method. `reversible` raises `NotImplementedError` at three layers — `place_objects`, `reversible_fdtd`/`run_fdtd`, and `update_E_reverse` (so the public `full_backward`/`backward` API raises too, gradients or not). Dispersion combined with fully anisotropic (off-diagonal) ε/σ tensors or oriented poles additionally runs through the fully anisotropic update path, where CCPR poles with a dE/dt coupling (`c4`) are rejected (no implicit tensor solve).
 
 **Devices with dispersive materials:** `apply_params` interpolates ADE coefficients the same way it interpolates `inv_permittivities` — linearly between the two bracketing materials for `CONTINUOUS` output, straight-through-estimator for `DISCRETE`. This is not equivalent to interpolating the pole *parameters*, but it keeps gradients smooth for inverse design.
 
@@ -263,8 +262,8 @@ E_full = fdtdx.unfold_fields(arrays.fields.E, config.symmetry, "E")  # (3, Nx, N
 - O(1) field memory, O(T) boundary memory (PML interfaces only)
 - Uses `@jax.custom_vjp` — forward pass runs simulation recording boundaries, backward pass reconstructs fields in reverse
 - Requires a `Recorder` with optional compression modules (e.g., `DtypeConversion(dtype=jnp.bfloat16)`)
-- Differentiable primals: `inv_permittivities`, `inv_permeabilities`, and (when present) `dispersive_c1/c2/c3`. Conductivity arrays and `dispersive_inv_c2` are closure-captured non-primals; `dispersive_P_curr/prev` thread through as state-only primals with `None` cotangent.
-- Dispersive reverse update: the ADE recurrence `P^(n+1) = c1·P^n + c2·P^(n-1) + c3·E^n` is algebraically inverted to recover `P^(n-1)` (see `update_E_reverse`). For lossy + dispersive + conductive cells the reverse E update subtracts `inv_eps * sum(P^n − P^(n+1))` before dividing by the loss factor.
+- Differentiable primals: `inv_permittivities`, `inv_permeabilities`. Conductivity arrays are closure-captured non-primals.
+- **Rejects dispersive materials** (`NotImplementedError`) — reversing the ADE polarization recurrence is under active development. Lossy (conductive) materials are supported; `num_checkpoints_reversible` bounds the reverse-reconstruction drift they cause.
 
 **Checkpointed FDTD** (`method="checkpointed"`):
 - Standard gradient checkpointing via `eqxi.while_loop(kind="checkpointed")`
@@ -424,7 +423,7 @@ assert jnp.all(jnp.isfinite(grads))
 - **Inverse storage**: Material arrays store `1/epsilon` and `1/mu`, not epsilon and mu directly. For dispersive materials, `Material.permittivity` represents ε∞ only — the full ε(ω) must be reconstructed via the dispersion model.
 - **Detector timing**: Detectors only record at timesteps where their `OnOffSwitch` is active. Check `switch` configuration if data appears missing.
 - **donate_argnames**: When JIT-compiling simulation functions, use `donate_argnames=["arrays"]` to allow JAX to reuse array memory.
-- **Dispersive + full anisotropic**: Supported via the fully anisotropic kernel (checkpointed gradients only; `reversible` raises). Oriented poles force the 9-component ε tier for the whole simulation — memory and per-step cost grow accordingly; prefer per-axis poles when the optical axes align with the grid.
+- **Dispersion needs `method="checkpointed"`**: every dispersive gradient path raises under `reversible` (which is the *default* `GradientConfig` method — set it explicitly). Dispersion + full anisotropic is supported via the fully anisotropic kernel. Oriented poles force the 9-component ε tier for the whole simulation — memory and per-step cost grow accordingly; prefer per-axis poles when the optical axes align with the grid.
 - **Complex full tensors**: `Material.from_complex_permittivity` accepts flat 9-tuples / nested 3x3 complex tensors — real parts → ε tensor, imaginary parts → σ tensor (exact at one frequency). `from_refractive_index` rejects tensors (matrix vs elementwise square ambiguity).
 - **Dispersive pole count is max'd globally**: The `num_poles` leading axis size = `objects.max_num_dispersive_poles`. Adding one 3-pole material allocates 3 pole slots for every dispersive cell in the sim; non-dispersive cells still have their `c1/c2/c3` set to zero (ADE term vanishes) but consume array memory.
 - **Dispersive source impedance**: Inside a dispersive medium, never use ε∞ as the source's effective permittivity — call `effective_inv_permittivity` at ω_c. Broadband pulses additionally need the `_temporal_H_filter` path to avoid TFSF leakage at off-carrier frequencies.

--- a/src/fdtdx/config.py
+++ b/src/fdtdx/config.py
@@ -34,7 +34,7 @@ class GradientConfig(TreeClass):
 
     #: Number of interior full-field checkpoints for the ``"reversible"`` method.
     #: The reversible backward pass reconstructs the field state by running the simulation in
-    #: reverse; for lossy/dispersive materials this reverse reconstruction can accumulate numerical
+    #: reverse; for lossy materials this reverse reconstruction can accumulate numerical
     #: error over the full trajectory. Setting this to ``k - 1`` partitions the run into ``k`` slices
     #: and stores a full-field checkpoint at each interior slice boundary during the forward pass. The
     #: backward pass then resets the reverse reconstruction to the exact checkpoint at every boundary,

--- a/src/fdtdx/dispersion.py
+++ b/src/fdtdx/dispersion.py
@@ -44,26 +44,17 @@ step ``dt``:
     c_2 = -\\frac{1 - \\gamma \\Delta t / 2}{1 + \\gamma \\Delta t / 2}, \\quad
     c_3 = \\frac{K \\Delta t^2}{1 + \\gamma \\Delta t / 2}
 
-Two *independent* conditions constrain the coefficients; both are enforced in
-:func:`compute_pole_coefficients_per_axis` (only on axes where the pole
-actually couples, since a zero-coupling axis keeps its polarization
-identically zero):
-
-* **Forward unit-circle (Jury) stability.** The roots of
-  :math:`z^2 - c_1 z - c_2 = 0` lie inside the unit circle iff
-  :math:`|c_2| < 1` *and* :math:`|c_1| < 1 - c_2`. The first holds for every
-  :math:`\\gamma \\Delta t > 0` (:math:`c_2 = 0` at :math:`\\gamma \\Delta t = 2`
-  and :math:`|c_2| \\to 1` only as :math:`\\gamma \\Delta t \\to 0` or
-  :math:`\\infty`), so it is not the binding constraint. The second is
-  algebraically equivalent to :math:`\\omega_0 \\Delta t < 2` (independent of
-  :math:`\\gamma`), which is therefore the forward-stability bound.
-* **Reverse-update conditioning.** The backward (reverse-time) recurrence is
-  formed by dividing through by :math:`c_2`, so :math:`c_2` must stay bounded
-  away from zero. This is a *separate* requirement, :math:`\\gamma \\Delta t < 2`
-  (:math:`c_2 = 0` exactly at :math:`\\gamma \\Delta t = 2`); in the physical
-  regime :math:`\\gamma \\Delta t \\ll 1` so :math:`c_2 \\approx -1` and the
-  inversion is well conditioned. It is a conditioning bound for reversibility,
-  not a forward unit-circle criterion.
+**Forward unit-circle (Jury) stability** constrains the coefficients and is
+enforced in :func:`compute_pole_coefficients_per_axis` (only on axes where the
+pole actually couples, since a zero-coupling axis keeps its polarization
+identically zero). The roots of :math:`z^2 - c_1 z - c_2 = 0` lie inside the
+unit circle iff :math:`|c_2| < 1` *and* :math:`|c_1| < 1 - c_2`. The first
+holds for every :math:`\\gamma \\Delta t > 0` (:math:`c_2 = 0` at
+:math:`\\gamma \\Delta t = 2` and :math:`|c_2| \\to 1` only as
+:math:`\\gamma \\Delta t \\to 0` or :math:`\\infty`), so it is not the binding
+constraint. The second is algebraically equivalent to
+:math:`\\omega_0 \\Delta t < 2` (independent of :math:`\\gamma`), which is
+therefore the stability bound.
 
 For CCPR poles the polarization couples to :math:`E^{n+1}` through
 :math:`c_4`, so the E-field update divides by a per-cell implicit factor
@@ -99,8 +90,13 @@ polaritons), where each IR-active phonon oscillates along its own,
 generally non-orthogonal, direction. :meth:`DispersionModel.rotated`
 converts a per-axis model into oriented poles for the common case of a
 crystal rotated relative to the grid. Oriented dispersion runs through the
-fully anisotropic update path and currently supports only the
-``checkpointed`` gradient method.
+fully anisotropic update path.
+
+Gradients
+---------
+Dispersive simulations currently support only the ``checkpointed`` gradient
+method; the ``reversible`` method rejects them (reversing the ADE polarization
+recurrence is under active development).
 """
 
 from __future__ import annotations
@@ -806,8 +802,7 @@ def compute_pole_coefficients_per_axis(
         c_4 = \\frac{b \\Delta t}{D},
 
     where ``a = coupling_sq`` is the ``E`` coupling and ``b = coupling_edot`` is
-    the ``dE/dt`` coupling. The recurrence uses a forward difference for the
-    ``dE/dt`` term so it stays compatible with the reversible time stepping:
+    the ``dE/dt`` coupling, which is discretized with a forward difference:
 
     :math:`p_p^{n+1} = c_1 p_p^n + c_2 p_p^{n-1} + c_3 E^n + c_4 E^{n+1}`.
 
@@ -841,19 +836,12 @@ def compute_pole_coefficients_per_axis(
         for ax in range(3):
             gamma_dt = gamma[ax] * dt
             omega0_dt = omega_0[ax] * dt
-            # The stability bounds only bind on axes where the pole actually
+            # The stability bound only binds on axes where the pole actually
             # couples. A zero-coupling axis (e.g. a Lorentz pole with
             # delta_epsilon = 0 there, the documented way to express an absent
             # resonance) has c3 = c4 = 0, so its polarization stays identically
             # zero and its unused omega_0 / gamma are irrelevant.
             axis_active = coupling_sq[ax] != 0.0 or coupling_edot[ax] != 0.0
-            if axis_active and gamma_dt >= 2.0:
-                axis_note = "" if p.is_isotropic else f" on axis {'xyz'[ax]}"
-                raise ValueError(
-                    f"Pole {i} ({type(p).__name__}) has gamma * dt = {gamma_dt:.4g} >= 2{axis_note}; "
-                    "the reversible ADE update requires gamma * dt < 2 (physically gamma * dt << 1). "
-                    "Lower the damping or reduce the time step."
-                )
             if axis_active and omega0_dt >= 2.0:
                 axis_note = "" if p.is_isotropic else f" on axis {'xyz'[ax]}"
                 raise ValueError(
@@ -931,11 +919,15 @@ def compute_pole_coefficients_tensor(
         coupling_edot = p.coupling_edot_axes
         for ax in range(3):
             gamma_dt = gamma[ax] * dt
-            if gamma_dt >= 2.0:
+            omega0_dt = omega_0[ax] * dt
+            # Same forward-stability bound (and same zero-coupling exemption) as
+            # compute_pole_coefficients_per_axis.
+            axis_active = coupling_sq[ax] != 0.0 or coupling_edot[ax] != 0.0
+            if axis_active and omega0_dt >= 2.0:
                 raise ValueError(
-                    f"Pole {i} ({type(p).__name__}) has gamma * dt = {gamma_dt:.4g} >= 2; "
-                    "the ADE update requires gamma * dt < 2 (physically gamma * dt << 1). "
-                    "Lower the damping or reduce the time step."
+                    f"Pole {i} ({type(p).__name__}) has omega_0 * dt = {omega0_dt:.4g} >= 2; "
+                    "the ADE recurrence roots leave the unit circle (requires omega_0 * dt < 2, "
+                    "physically omega_0 * dt << 1). Lower the resonance frequency or reduce the time step."
                 )
             denom = 1.0 + 0.5 * gamma_dt
             c1[i, ax] = (2.0 - (omega_0[ax] ** 2) * (dt**2)) / denom

--- a/src/fdtdx/fdtd/container.py
+++ b/src/fdtdx/fdtd/container.py
@@ -444,13 +444,6 @@ class ArrayContainer(TreeClass):
     #: ``None`` and skip the CCPR update path.
     dispersive_c4: jax.Array | None = None
 
-    #: Per-cell cached ``1 / c2`` with non-dispersive cells set to 0. Lets the
-    #: reverse-time ADE update avoid a ``jnp.where`` + division per step.
-    #: Derived from ``dispersive_c2``; never differentiated independently.
-    #: Shape ``(num_poles, num_components, Nx, Ny, Nz)``, ``num_components in
-    #: (1, 3)``. ``None`` for non-dispersive simulations.
-    dispersive_inv_c2: jax.Array | None = None
-
     #: Backup of inverse permittivity values array.
     #: Only used when etching a device.
     initial_inv_permittivities: jax.Array | None = None
@@ -479,7 +472,7 @@ class ArrayContainer(TreeClass):
         # FieldState now holds the dispersive ADE polarization (dispersive_P_curr/prev)
         # alongside E/H/psi, so this single tree.map zeroes all dynamic per-timestep
         # state at once (``None`` leaves stay ``None`` for non-dispersive sims).
-        # Coefficient arrays (c1/c2/c3/inv_c2) are material properties and preserved.
+        # Coefficient arrays (c1/c2/c3/c4) are material properties and preserved.
         arrays = self.aset("fields", jax.tree.map(jnp.zeros_like, self.fields))
 
         detector_states = self.detector_states

--- a/src/fdtdx/fdtd/fdtd.py
+++ b/src/fdtdx/fdtd/fdtd.py
@@ -83,20 +83,30 @@ def reversible_fdtd(
         efficient backpropagation through the entire simulation while maintaining
         numerical stability. This makes it suitable for gradient-based optimization
         of electromagnetic designs.
+
+    Raises:
+        NotImplementedError: If the simulation contains dispersive materials. Reversing
+            the ADE polarization recurrence is not supported; use the ``"checkpointed"``
+            gradient method for dispersive simulations.
     """
     # if arrays.magnetic_conductivity is not None or arrays.electric_conductivity is not None:
     #     raise Exception(f"Reversible FDTD does not work with Conductive Materials")
-    arrays = arrays.reset()
 
-    # ``dispersive_inv_c2`` is a derived cache of ``1/c2``; stop_gradient it so
-    # gradients flow only through ``dispersive_c2`` and don't double-count.
-    if arrays.dispersive_inv_c2 is not None:
-        arrays = arrays.at["dispersive_inv_c2"].set(jax.lax.stop_gradient(arrays.dispersive_inv_c2))
+    # Checked here in addition to initialization time, since the gradient config can be
+    # swapped after ``place_objects`` and this function can be called directly, bypassing
+    # ``run_fdtd``.
+    if arrays.dispersive_c1 is not None or arrays.fields.dispersive_P_curr is not None:
+        raise NotImplementedError(
+            "Dispersive time-reversible gradient computation under active development. "
+            "Use GradientConfig(method='checkpointed') instead."
+        )
+
+    arrays = arrays.reset()
 
     # Sliced reversible backward pass: partition the run into ``num_slices`` slices and store a
     # full-field checkpoint at each interior boundary during the forward pass, so the reverse
     # reconstruction can be reset to the exact field at every boundary (bounding reconstruction
-    # drift for lossy/dispersive materials). ``num_checkpoints_reversible == 0`` (the default)
+    # drift for lossy materials). ``num_checkpoints_reversible == 0`` (the default)
     # gives a single slice and reproduces the classic full reverse pass exactly.
     num_ckpt = 0 if config.gradient_config is None else config.gradient_config.num_checkpoints_reversible
     num_slices = num_ckpt + 1
@@ -171,12 +181,6 @@ def reversible_fdtd(
         psi_H: PmlAuxField,
         inv_permittivities: jax.Array,
         inv_permeabilities: jax.Array,
-        dispersive_P_curr: jax.Array | None,
-        dispersive_P_prev: jax.Array | None,
-        dispersive_c1: jax.Array | None,
-        dispersive_c2: jax.Array | None,
-        dispersive_c3: jax.Array | None,
-        dispersive_c4: jax.Array | None,
         detector_states: dict[str, DetectorState],
         recording_state: RecordingState | None,
     ):
@@ -186,8 +190,6 @@ def reversible_fdtd(
                 H=H,
                 psi_E=psi_E,
                 psi_H=psi_H,
-                dispersive_P_curr=dispersive_P_curr,
-                dispersive_P_prev=dispersive_P_prev,
             ),
             inv_permittivities=inv_permittivities,
             inv_permeabilities=inv_permeabilities,
@@ -195,11 +197,6 @@ def reversible_fdtd(
             recording_state=recording_state,
             electric_conductivity=arrays.electric_conductivity,
             magnetic_conductivity=arrays.magnetic_conductivity,
-            dispersive_c1=dispersive_c1,
-            dispersive_c2=dispersive_c2,
-            dispersive_c3=dispersive_c3,
-            dispersive_c4=dispersive_c4,
-            dispersive_inv_c2=arrays.dispersive_inv_c2,
             initial_inv_permittivities=arrays.initial_inv_permittivities,
         )
         state = reversible_fdtd_base(arr)
@@ -211,12 +208,6 @@ def reversible_fdtd(
             state[1].fields.psi_H,
             state[1].inv_permittivities,
             state[1].inv_permeabilities,
-            state[1].fields.dispersive_P_curr,
-            state[1].fields.dispersive_P_prev,
-            state[1].dispersive_c1,
-            state[1].dispersive_c2,
-            state[1].dispersive_c3,
-            state[1].dispersive_c4,
             state[1].detector_states,
             state[1].recording_state,
         )
@@ -244,7 +235,6 @@ def reversible_fdtd(
                 simulate_boundaries=True,
                 electric_conductivity=arrays.electric_conductivity,
                 magnetic_conductivity=arrays.magnetic_conductivity,
-                dispersive_inv_c2=arrays.dispersive_inv_c2,
             ),
             state[0],
             state[1].fields.E,
@@ -253,12 +243,6 @@ def reversible_fdtd(
             state[1].fields.psi_H,
             state[1].inv_permittivities,
             state[1].inv_permeabilities,
-            state[1].fields.dispersive_P_curr,
-            state[1].fields.dispersive_P_prev,
-            state[1].dispersive_c1,
-            state[1].dispersive_c2,
-            state[1].dispersive_c3,
-            state[1].dispersive_c4,
             state[1].detector_states,
             state[1].recording_state,
         )
@@ -288,12 +272,6 @@ def reversible_fdtd(
             res_psi_H,
             res_inv_permittivities,
             res_inv_permeabilities,
-            res_dispersive_P_curr,
-            res_dispersive_P_prev,
-            res_dispersive_c1,
-            res_dispersive_c2,
-            res_dispersive_c3,
-            res_dispersive_c4,
             res_detector_states,
             res_recording_state,
         ) = primal_out
@@ -304,8 +282,6 @@ def reversible_fdtd(
                 H=res_H,
                 psi_E=res_psi_E,
                 psi_H=res_psi_H,
-                dispersive_P_curr=res_dispersive_P_curr,
-                dispersive_P_prev=res_dispersive_P_prev,
             ),
             inv_permittivities=res_inv_permittivities,
             inv_permeabilities=res_inv_permeabilities,
@@ -313,11 +289,6 @@ def reversible_fdtd(
             recording_state=res_recording_state,
             electric_conductivity=arrays.electric_conductivity,
             magnetic_conductivity=arrays.magnetic_conductivity,
-            dispersive_c1=res_dispersive_c1,
-            dispersive_c2=res_dispersive_c2,
-            dispersive_c3=res_dispersive_c3,
-            dispersive_c4=res_dispersive_c4,
-            dispersive_inv_c2=arrays.dispersive_inv_c2,
             initial_inv_permittivities=arrays.initial_inv_permittivities,
         )
 
@@ -357,14 +328,8 @@ def reversible_fdtd(
             None,  # cot[4],   psi_H
             cot[5],  #         inv_permittivities
             cot[6],  #         inv_permeabilities
-            None,  # cot[7],  dispersive_P_curr
-            None,  # cot[8],  dispersive_P_prev
-            cot[9],  #        dispersive_c1
-            cot[10],  #        dispersive_c2
-            cot[11],  #        dispersive_c3
-            cot[12],  #        dispersive_c4
-            None,  # cot[13],  detector_states
-            None,  # cot[14],  recording_state
+            None,  # cot[7],   detector_states
+            None,  # cot[8],   recording_state
         )
 
     def fdtd_fwd(
@@ -374,12 +339,6 @@ def reversible_fdtd(
         psi_H: PmlAuxField,
         inv_permittivities: jax.Array,
         inv_permeabilities: jax.Array,
-        dispersive_P_curr: jax.Array | None,
-        dispersive_P_prev: jax.Array | None,
-        dispersive_c1: jax.Array | None,
-        dispersive_c2: jax.Array | None,
-        dispersive_c3: jax.Array | None,
-        dispersive_c4: jax.Array | None,
         detector_states: dict[str, DetectorState],
         recording_state: RecordingState | None,
     ):
@@ -389,8 +348,6 @@ def reversible_fdtd(
                 H=H,
                 psi_E=psi_E,
                 psi_H=psi_H,
-                dispersive_P_curr=dispersive_P_curr,
-                dispersive_P_prev=dispersive_P_prev,
             ),
             inv_permittivities=inv_permittivities,
             inv_permeabilities=inv_permeabilities,
@@ -398,11 +355,6 @@ def reversible_fdtd(
             recording_state=recording_state,
             electric_conductivity=arrays.electric_conductivity,
             magnetic_conductivity=arrays.magnetic_conductivity,
-            dispersive_c1=dispersive_c1,
-            dispersive_c2=dispersive_c2,
-            dispersive_c3=dispersive_c3,
-            dispersive_c4=dispersive_c4,
-            dispersive_inv_c2=arrays.dispersive_inv_c2,
             initial_inv_permittivities=arrays.initial_inv_permittivities,
         )
         s_k, checkpoints = segmented_forward(arr)
@@ -415,12 +367,6 @@ def reversible_fdtd(
             s_k[1].fields.psi_H,
             s_k[1].inv_permittivities,
             s_k[1].inv_permeabilities,
-            s_k[1].fields.dispersive_P_curr,
-            s_k[1].fields.dispersive_P_prev,
-            s_k[1].dispersive_c1,
-            s_k[1].dispersive_c2,
-            s_k[1].dispersive_c3,
-            s_k[1].dispersive_c4,
             s_k[1].detector_states,
             s_k[1].recording_state,  # None
         )
@@ -440,12 +386,6 @@ def reversible_fdtd(
         psi_H,
         inv_permittivities,
         inv_permeabilities,
-        dispersive_P_curr,
-        dispersive_P_prev,
-        dispersive_c1,
-        dispersive_c2,
-        dispersive_c3,
-        dispersive_c4,
         detector_states,
         recording_state,
     ) = reversible_fdtd_primal(
@@ -455,12 +395,6 @@ def reversible_fdtd(
         psi_H=arrays.fields.psi_H,
         inv_permittivities=arrays.inv_permittivities,
         inv_permeabilities=arrays.inv_permeabilities,
-        dispersive_P_curr=arrays.fields.dispersive_P_curr,
-        dispersive_P_prev=arrays.fields.dispersive_P_prev,
-        dispersive_c1=arrays.dispersive_c1,
-        dispersive_c2=arrays.dispersive_c2,
-        dispersive_c3=arrays.dispersive_c3,
-        dispersive_c4=arrays.dispersive_c4,
         detector_states=arrays.detector_states,
         recording_state=arrays.recording_state,
     )
@@ -472,8 +406,6 @@ def reversible_fdtd(
             H=H,
             psi_E=psi_E,
             psi_H=psi_H,
-            dispersive_P_curr=dispersive_P_curr,
-            dispersive_P_prev=dispersive_P_prev,
         ),
         inv_permittivities=inv_permittivities,
         inv_permeabilities=inv_permeabilities,
@@ -481,11 +413,6 @@ def reversible_fdtd(
         recording_state=recording_state,
         electric_conductivity=arrays.electric_conductivity,
         magnetic_conductivity=arrays.magnetic_conductivity,
-        dispersive_c1=dispersive_c1,
-        dispersive_c2=dispersive_c2,
-        dispersive_c3=dispersive_c3,
-        dispersive_c4=dispersive_c4,
-        dispersive_inv_c2=arrays.dispersive_inv_c2,
         initial_inv_permittivities=arrays.initial_inv_permittivities,
     )
     return time_step, out_arrs

--- a/src/fdtdx/fdtd/forward.py
+++ b/src/fdtdx/fdtd/forward.py
@@ -15,12 +15,6 @@ def forward_single_args_wrapper(
     psi_H: PmlAuxField,
     inv_permittivities: jax.Array,
     inv_permeabilities: jax.Array,
-    dispersive_P_curr: jax.Array | None,
-    dispersive_P_prev: jax.Array | None,
-    dispersive_c1: jax.Array | None,
-    dispersive_c2: jax.Array | None,
-    dispersive_c3: jax.Array | None,
-    dispersive_c4: jax.Array | None,
     detector_states: dict[str, DetectorState],
     recording_state: RecordingState | None,
     config: SimulationConfig,
@@ -31,7 +25,6 @@ def forward_single_args_wrapper(
     simulate_boundaries: bool,
     electric_conductivity: jax.Array | None = None,
     magnetic_conductivity: jax.Array | None = None,
-    dispersive_inv_c2: jax.Array | None = None,
 ) -> tuple[
     jax.Array,
     jax.Array,
@@ -40,27 +33,23 @@ def forward_single_args_wrapper(
     PmlAuxField,
     jax.Array,
     jax.Array | float,
-    jax.Array | None,
-    jax.Array | None,
-    jax.Array | None,
-    jax.Array | None,
-    jax.Array | None,
-    jax.Array | None,
     dict[str, DetectorState],
     RecordingState | None,
 ]:
     # Wrapper function that unpacks ArrayContainer into individual arrays for JAX transformations.
-    # ``electric_conductivity``, ``magnetic_conductivity`` and ``dispersive_inv_c2`` are
-    # passed as defaulted kwargs so callers can closure-capture them via ``functools.partial``
-    # without exposing them as VJP primals.
+    # ``electric_conductivity`` and ``magnetic_conductivity`` are passed as defaulted kwargs so
+    # callers can closure-capture them via ``functools.partial`` without exposing them as VJP
+    # primals.
+    #
+    # This wrapper only serves the reversible gradient path, which rejects dispersive materials
+    # (see ``reversible_fdtd``), so the ADE polarization state and coefficient arrays are always
+    # ``None`` here and are not part of the signature.
     arr = ArrayContainer(
         fields=FieldState(
             E=E,
             H=H,
             psi_E=psi_E,
             psi_H=psi_H,
-            dispersive_P_curr=dispersive_P_curr,
-            dispersive_P_prev=dispersive_P_prev,
         ),
         inv_permittivities=inv_permittivities,
         inv_permeabilities=inv_permeabilities,
@@ -68,11 +57,6 @@ def forward_single_args_wrapper(
         recording_state=recording_state,
         electric_conductivity=electric_conductivity,
         magnetic_conductivity=magnetic_conductivity,
-        dispersive_c1=dispersive_c1,
-        dispersive_c2=dispersive_c2,
-        dispersive_c3=dispersive_c3,
-        dispersive_c4=dispersive_c4,
-        dispersive_inv_c2=dispersive_inv_c2,
     )
     state = forward(
         state=(time_step, arr),
@@ -91,12 +75,6 @@ def forward_single_args_wrapper(
         state[1].fields.psi_H,
         state[1].inv_permittivities,
         state[1].inv_permeabilities,
-        state[1].fields.dispersive_P_curr,
-        state[1].fields.dispersive_P_prev,
-        state[1].dispersive_c1,
-        state[1].dispersive_c2,
-        state[1].dispersive_c3,
-        state[1].dispersive_c4,
         state[1].detector_states,
         state[1].recording_state,
     )

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -465,14 +465,9 @@ def apply_params(
             new_c1 = arrays.dispersive_c1.at[:, :, *device.grid_slice].set(new_c1_slice)
             new_c2 = arrays.dispersive_c2.at[:, :, *device.grid_slice].set(new_c2_slice)
             new_c3 = arrays.dispersive_c3.at[:, :, *device.grid_slice].set(new_c3_slice)
-            # Recompute inv_c2 from the post-interpolation c2. Do NOT interpolate
-            # inv_c2 directly: 1/avg(c2) != avg(1/c2), and the reverse-time ADE
-            # relies on inv_c2 being the exact reciprocal of the stored c2.
-            new_inv_c2 = jnp.where(new_c2 == 0, 0.0, 1.0 / new_c2)
             arrays = arrays.at["dispersive_c1"].set(new_c1)
             arrays = arrays.at["dispersive_c2"].set(new_c2)
             arrays = arrays.at["dispersive_c3"].set(new_c3)
-            arrays = arrays.at["dispersive_inv_c2"].set(new_inv_c2)
             if write_dispersive_c4:
                 assert arrays.dispersive_c4 is not None
                 new_c4 = arrays.dispersive_c4.at[:, :, *device.grid_slice].set(new_c4_slice)
@@ -662,9 +657,23 @@ def _init_arrays(
     # additionally widen to 9 (row-major 3x3 tensor per pole) when any pole is
     # oriented. Oriented dispersion — and dispersion combined with fully
     # anisotropic material tensors — runs through the fully anisotropic update
-    # kernel, which carries its own ADE block but no closed-form time reversal
-    # and no CCPR dE/dt solve.
+    # kernel, which carries its own ADE block but no CCPR dE/dt solve.
     num_dispersive_poles = objects.max_num_dispersive_poles
+
+    # Dispersive materials support only the checkpointed gradient method. Reversing the
+    # ADE polarization recurrence is not currently supported. Checked here for the
+    # earliest possible error; ``reversible_fdtd`` repeats the check because the gradient
+    # config can be swapped after ``place_objects``.
+    if (
+        num_dispersive_poles > 0
+        and config.gradient_config is not None
+        and config.gradient_config.method == "reversible"
+    ):
+        raise NotImplementedError(
+            "Dispersive time-reversible gradient computation under active development. "
+            "Use GradientConfig(method='checkpointed') instead."
+        )
+
     num_disp_components = 1 if objects.all_objects_isotropic_dispersion else 3
     axis_aligned_dispersion = objects.all_objects_axis_aligned_dispersion
     num_disp_coupling_components = num_disp_components if axis_aligned_dispersion else 9
@@ -678,12 +687,6 @@ def _init_arrays(
             raise NotImplementedError(
                 "CCPR poles with a dE/dt coupling (non-zero Re(residue)) cannot be combined with "
                 "oriented poles or fully anisotropic (off-diagonal) material tensors."
-            )
-        if config.gradient_config is not None and config.gradient_config.method == "reversible":
-            raise NotImplementedError(
-                "Dispersion combined with oriented poles or off-diagonal material tensors supports "
-                "only the 'checkpointed' gradient method; the fully anisotropic ADE update has no "
-                "closed-form time reversal."
             )
         if not axis_aligned_dispersion and config.has_nonuniform_grid:
             raise NotImplementedError(
@@ -1116,18 +1119,12 @@ def _init_arrays(
         )
         config = config.aset("gradient_config", grad_cfg)
 
-    # Cache 1/c2 with non-dispersive cells zeroed so update_E_reverse can replace
-    # its ``jnp.where(c2 == 0, ..., / c2)`` pair with a single multiply.
-    dispersive_inv_c2 = None
-    if dispersive_c2 is not None:
-        dispersive_inv_c2 = jnp.where(dispersive_c2 == 0, 0.0, 1.0 / dispersive_c2)
-
     # Validate CCPR dispersive stability once, on concrete host values. Only CCPR
     # (non-zero dE/dt coupling) poles have a non-trivial implicit divisor, so the
-    # gate keeps Lorentz/Drude-only sims free of this cost. The full-tensor path
-    # (which has no ADE block) is already rejected for any dispersive material by
-    # the NotImplementedError guard above, so this only runs on the ADE-active
-    # 1/3-component paths whose divisor is exactly what update_E computes.
+    # gate keeps Lorentz/Drude-only sims free of this cost. CCPR poles on the
+    # full-tensor path are already rejected by the NotImplementedError guard above,
+    # so this only runs on the 1/3-component paths whose divisor is exactly what
+    # update_E computes.
     if objects.has_dispersive_edot:
         validate_dispersive_divisor_stability(
             _collect_labeled_materials(objects),
@@ -1158,7 +1155,6 @@ def _init_arrays(
         dispersive_c2=dispersive_c2,
         dispersive_c3=dispersive_c3,
         dispersive_c4=dispersive_c4,
-        dispersive_inv_c2=dispersive_inv_c2,
         initial_inv_permittivities=initial_inv_permittivities,
     )
     return arrays, config, info

--- a/src/fdtdx/fdtd/update.py
+++ b/src/fdtdx/fdtd/update.py
@@ -466,7 +466,18 @@ def update_E_reverse(
 
     Returns:
         ArrayContainer: Updated ArrayContainer with reversed E field values
+
+    Raises:
+        NotImplementedError: If the simulation contains dispersive materials. The ADE
+            polarization state has no supported time reversal, so neither this update
+            nor the ``full_backward`` / ``backward`` API can reconstruct it.
     """
+    if arrays.fields.dispersive_P_curr is not None:
+        raise NotImplementedError(
+            "Dispersive time-reversible gradient computation under active development. "
+            "Use GradientConfig(method='checkpointed') instead."
+        )
+
     E = arrays.fields.E
     for source in objects.sources:
         if _source_uses_default_always_on_switch(source):
@@ -513,58 +524,14 @@ def update_E_reverse(
 
     if not inv_eps_is_full_tensor and not sigma_E_is_full_tensor:
         # Isotropic and diagonal anisotropic case
-        # Capture E^{n+1} (post source-inverse, pre field-recovery) — the CCPR
-        # polarization inversion below needs it for the c4*E^{n+1} term. For the
-        # E-recovery itself the c4/D_kappa contributions cancel exactly, so that
-        # formula is unchanged from the non-CCPR case.
-        E_np1 = E
         factor = 1
         if sigma_E is not None:
             E = E * (1 + c * sigma_E * eta0 * inv_eps / 2)
             factor = 1 - c * sigma_E * eta0 * inv_eps / 2
 
-        # Dispersive (ADE) reverse correction. At reverse time, arrays.fields.dispersive_P_curr
-        # holds P^(n+1) and arrays.fields.dispersive_P_prev holds P^n. The forward update added
-        # inv_eps * sum(P^n - P^(n+1)) inside the lossy factor; subtract it here to
-        # recover E^n. Non-dispersive cells (all zero arrays) contribute zero.
-        if arrays.fields.dispersive_P_curr is not None:
-            P_curr_r = arrays.fields.dispersive_P_curr
-            P_prev_r = arrays.fields.dispersive_P_prev
-            disp_c1_r = arrays.dispersive_c1
-            disp_c3_r = arrays.dispersive_c3
-            disp_c4_r = arrays.dispersive_c4
-            disp_inv_c2_r = arrays.dispersive_inv_c2
-            assert (
-                P_prev_r is not None and disp_c1_r is not None and disp_c3_r is not None and disp_inv_c2_r is not None
-            )
-            delta_sum = jnp.sum(P_prev_r - P_curr_r, axis=0)
-            E = (E - c * curl * inv_eps - inv_eps * delta_sum) / factor
-            # Invert the polarization recurrence:
-            # P^(n+1) = c1 * P^n + c2 * P^(n-1) + c3 * E^n + c4 * E^(n+1)
-            # =>  P^(n-1) = (P^(n+1) - c1 * P^n - c3 * E^n - c4 * E^(n+1)) / c2
-            # Using precomputed inv_c2 (with non-dispersive cells zeroed) replaces
-            # a per-step jnp.where + division with a single multiply. Non-dispersive
-            # cells have inv_c2 = 0 and P_curr = P_prev = 0, so the product is zero.
-            # E is now the recovered E^n; the c4 term (CCPR only) uses E^(n+1).
-            P_prev_new = P_curr_r - disp_c1_r * P_prev_r - disp_c3_r * E
-            if disp_c4_r is not None:
-                P_prev_new = P_prev_new - disp_c4_r * E_np1
-            P_prev_new = P_prev_new * disp_inv_c2_r
-            arrays = arrays.aset("fields->dispersive_P_curr", P_prev_r)
-            arrays = arrays.aset("fields->dispersive_P_prev", P_prev_new)
-        else:
-            E = (E - c * curl * inv_eps) / factor
+        E = (E - c * curl * inv_eps) / factor
 
     else:
-        if arrays.fields.dispersive_P_curr is not None:
-            # The tensor-branch ADE has no closed-form time reversal (the
-            # off-diagonal coupling mixes neighboring cells through the Yee
-            # averages). Guarded at initialization; kept here defensively since
-            # full_backward is public API.
-            raise NotImplementedError(
-                "Time-reversal of dispersion on the fully anisotropic update path is not supported; "
-                "use the 'checkpointed' gradient method."
-            )
         # Full anisotropic case: expand inv_eps and sigma_E to (3, 3, Nx, Ny, Nz)
         inv_eps = expand_to_3x3(inv_eps)
         sigma_E = expand_to_3x3(sigma_E)

--- a/src/fdtdx/fdtd/wrapper.py
+++ b/src/fdtdx/fdtd/wrapper.py
@@ -29,25 +29,6 @@ def run_fdtd(
                 "setting stopping_condition=None."
             )
 
-    if (
-        config.gradient_config is not None
-        and config.gradient_config.method == "reversible"
-        and arrays.dispersive_c1 is not None
-    ):
-        # The fully anisotropic update path has no closed-form time reversal for
-        # dispersion. Checked here (shape-based) in addition to initialization
-        # time, since the gradient config can be swapped after place_objects.
-        tensor_path = (
-            arrays.inv_permittivities.shape[0] == 9
-            or (arrays.electric_conductivity is not None and arrays.electric_conductivity.shape[0] == 9)
-            or (arrays.dispersive_c3 is not None and arrays.dispersive_c3.shape[1] == 9)
-        )
-        if tensor_path:
-            raise NotImplementedError(
-                "Dispersion combined with oriented poles or off-diagonal material tensors supports "
-                "only the 'checkpointed' gradient method, not 'reversible'."
-            )
-
     if config.gradient_config is None:
         # only forward simulation, use standard while loop of checkpointed fdtd
         return checkpointed_fdtd(

--- a/tests/integration/fdtd/test_dispersive_init.py
+++ b/tests/integration/fdtd/test_dispersive_init.py
@@ -415,9 +415,24 @@ def test_fully_anisotropic_plus_dispersive_allocates(simple_config, simple_volum
     assert arrays.dispersive_c3.shape[1] == 1
 
 
+def test_isotropic_dispersive_reversible_raises(simple_config, simple_volume):
+    """Any dispersive material rejects the 'reversible' gradient method at
+    initialization — reversing the ADE recurrence is not supported."""
+    from fdtdx.config import GradientConfig
+    from fdtdx.interfaces.recorder import Recorder
+
+    obj = UniformMaterialObject(name="slab", partial_grid_shape=(10, 10, 10), material=_lorentz_material())
+    constraint = GridCoordinateConstraint(
+        object="slab", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[10, 10, 10]
+    )
+    config = simple_config.aset("gradient_config", GradientConfig(method="reversible", recorder=Recorder(modules=[])))
+    key = jax.random.PRNGKey(0)
+    with pytest.raises(NotImplementedError, match="under active development"):
+        place_objects([simple_volume, obj], config, [constraint], key)
+
+
 def test_fully_anisotropic_plus_dispersive_reversible_raises(simple_config, simple_volume):
-    """The fully anisotropic ADE path has no closed-form time reversal, so the
-    'reversible' gradient method must be rejected at initialization."""
+    """Same rejection on the fully anisotropic ADE path."""
     from fdtdx.config import GradientConfig
     from fdtdx.interfaces.recorder import Recorder
 
@@ -675,7 +690,6 @@ def test_per_axis_dispersion_allocates_3_component_coefficients(simple_config, s
     assert arrays.dispersive_c1.shape == (1, 3, Nx, Ny, Nz)
     assert arrays.dispersive_c2.shape == (1, 3, Nx, Ny, Nz)
     assert arrays.dispersive_c3.shape == (1, 3, Nx, Ny, Nz)
-    assert arrays.dispersive_inv_c2.shape == (1, 3, Nx, Ny, Nz)
     # polarization state keeps its (num_poles, 3, ...) shape
     assert arrays.fields.dispersive_P_curr.shape == (1, 3, Nx, Ny, Nz)
 
@@ -792,11 +806,6 @@ def test_device_per_axis_dispersive_continuous_and_discrete(simple_config, simpl
             assert jnp.allclose(arrays.dispersive_c3[0, ax, xs, ys, zs], c3_ref[0, ax])
         # x and z couplings differ by construction
         assert c3_ref[0, 0] != c3_ref[0, 2]
-        # inv_c2 must be the exact reciprocal of the stored c2
-        assert jnp.allclose(
-            arrays.dispersive_inv_c2[0, :, xs, ys, zs] * arrays.dispersive_c2[0, :, xs, ys, zs],
-            1.0,
-        )
 
 
 def test_full_tensor_sigma_plus_dispersive_allocates(simple_config, simple_volume):

--- a/tests/simulation/fdtd/test_fdtd.py
+++ b/tests/simulation/fdtd/test_fdtd.py
@@ -194,12 +194,23 @@ class TestReversibleFdtdGradients:
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-def _build_lossy_dispersive_scene(dtype, material=None):
-    """Lorentz + σ_E = 100 S/m + dipole, periodic. The scene where the recent
+#: Lossy, non-dispersive slab material. Reversible gradients support loss but not
+#: dispersion, so every reversible-path test uses this (or a lossless variant).
+_LOSSY_MATERIAL = fdtdx.Material(permittivity=2.0, electric_conductivity=1e2)
+
+#: Strongly lossy variant. The reverse pass turns loss into gain, so a large σ_E is
+#: what makes reverse-reconstruction drift visible in float32 (at σ_E = 1e2 the drift
+#: sits at the float32 noise floor and cannot be distinguished from it).
+_HIGH_LOSS_MATERIAL = fdtdx.Material(permittivity=2.0, electric_conductivity=1e4)
+
+
+def _build_slab_scene(dtype, material=None):
+    """Slab + dipole, periodic boundaries. The scene where the recent
     conductivity-not-forwarded bug actually mattered.
 
-    ``material`` overrides the slab material (used by the per-axis dispersive
-    gradient cross-check below).
+    Defaults to a Lorentz-dispersive slab with σ_E = 100 S/m; ``material``
+    overrides it (e.g. lossless, lossy non-dispersive, per-axis or oriented
+    dispersion).
     """
     config = SimulationConfig(
         time=_SIM_TIME,
@@ -402,8 +413,6 @@ class TestReversibleVsCheckpointedGradient:
                 H=arrays.fields.H,
                 psi_E=arrays.fields.psi_E,
                 psi_H=arrays.fields.psi_H,
-                dispersive_P_curr=arrays.fields.dispersive_P_curr,
-                dispersive_P_prev=arrays.fields.dispersive_P_prev,
             ),
             inv_permittivities=inv_permittivities,
             inv_permeabilities=arrays.inv_permeabilities,
@@ -411,16 +420,12 @@ class TestReversibleVsCheckpointedGradient:
             recording_state=arrays.recording_state,
             electric_conductivity=arrays.electric_conductivity,
             magnetic_conductivity=arrays.magnetic_conductivity,
-            dispersive_c1=arrays.dispersive_c1,
-            dispersive_c2=arrays.dispersive_c2,
-            dispersive_c3=arrays.dispersive_c3,
-            dispersive_inv_c2=arrays.dispersive_inv_c2,
         )
         return arrays
 
     @staticmethod
     def _run_inv_eps(method, dtype):
-        obj, arrays, config = _build_lossy_dispersive_scene(dtype=dtype)
+        obj, arrays, config = _build_slab_scene(dtype=dtype, material=_LOSSY_MATERIAL)
         arrays, config = _attach_gradient(arrays, config, obj, method=method)
 
         def loss_fn(inv_eps):
@@ -492,60 +497,20 @@ class TestReversibleVsCheckpointedGradient:
             rel = max_diff / (max_abs + 1e-30)
             assert rel < 1e-5, f"μ⁻¹ gradient mismatch: max|Δ|={max_diff:.3e}, max|grad|={max_abs:.3e}, rel={rel:.3e}"
 
-    def test_gradients_agree_dispersive_c3_float64(self):
-        """Cross-validate gradient w.r.t. dispersive_c3 — the ADE coefficient
-        whose VJP path differs most between reversible (algebraic inversion
-        of the recurrence in update_E_reverse) and checkpointed (forward
-        recurrence differentiated by jax)."""
 
-        def run(method):
-            obj, arrays, config = _build_lossy_dispersive_scene(dtype=jnp.float64)
-            arrays, config = _attach_gradient(arrays, config, obj, method=method)
+class TestPerAxisDispersiveGradientCheckpointed:
+    """PER-AXIS (diagonally anisotropic) dispersion: the ``c3`` coefficient array
+    carries a 3-entry component axis instead of the broadcast size-1 axis, and
+    each axis has different pole parameters.
 
-            def loss_fn(c3):
-                arr = ArrayContainer(
-                    fields=FieldState(
-                        E=arrays.fields.E,
-                        H=arrays.fields.H,
-                        psi_E=arrays.fields.psi_E,
-                        psi_H=arrays.fields.psi_H,
-                        dispersive_P_curr=arrays.fields.dispersive_P_curr,
-                        dispersive_P_prev=arrays.fields.dispersive_P_prev,
-                    ),
-                    inv_permittivities=arrays.inv_permittivities,
-                    inv_permeabilities=arrays.inv_permeabilities,
-                    detector_states=arrays.detector_states,
-                    recording_state=arrays.recording_state,
-                    electric_conductivity=arrays.electric_conductivity,
-                    magnetic_conductivity=arrays.magnetic_conductivity,
-                    dispersive_c1=arrays.dispersive_c1,
-                    dispersive_c2=arrays.dispersive_c2,
-                    dispersive_c3=c3,
-                    dispersive_inv_c2=arrays.dispersive_inv_c2,
-                )
-                fdtd_impl = reversible_fdtd if method == "reversible" else checkpointed_fdtd
-                _, out = fdtd_impl(arr, obj, config, jax.random.PRNGKey(99), show_progress=False)
-                return jnp.sum(jnp.real(out.fields.E) ** 2)
+    Dispersion is checkpointed-only, so there is no reversible path to
+    cross-check against; the oracle here is a central finite difference of the
+    forward loss, per component axis.
+    """
 
-            return jax.value_and_grad(loss_fn)(arrays.dispersive_c3)
-
-        with _x64_enabled():
-            loss_rev, grad_rev = run("reversible")
-            loss_chk, grad_chk = run("checkpointed")
-            assert jnp.isfinite(loss_rev) and jnp.isfinite(loss_chk)
-            assert jnp.allclose(loss_rev, loss_chk, rtol=1e-9, atol=1e-12)
-            max_abs = float(jnp.max(jnp.abs(grad_rev) + jnp.abs(grad_chk)))
-            max_diff = float(jnp.max(jnp.abs(grad_rev - grad_chk)))
-            rel = max_diff / (max_abs + 1e-30)
-            assert rel < 1e-5, f"c3 gradient mismatch: max|Δ|={max_diff:.3e}, max|grad|={max_abs:.3e}, rel={rel:.3e}"
-
-    def test_gradients_agree_per_axis_dispersive_c3_float64(self):
-        """Same c3 cross-check with PER-AXIS (diagonally anisotropic) dispersion:
-        the coefficient arrays carry a 3-entry component axis instead of the
-        broadcast size-1 axis, and each axis has different pole parameters.
-        Validates that the elementwise forward/reverse ADE updates and the VJP
-        stay exact when the coefficients vary per field component."""
-        per_axis_material = fdtdx.Material(
+    @staticmethod
+    def _material():
+        return fdtdx.Material(
             permittivity=(2.0, 2.5, 3.0),
             electric_conductivity=1e2,
             dispersion=fdtdx.DispersionModel(
@@ -559,10 +524,11 @@ class TestReversibleVsCheckpointedGradient:
             ),
         )
 
-        def run(method):
-            obj, arrays, config = _build_lossy_dispersive_scene(dtype=jnp.float64, material=per_axis_material)
+    def test_gradient_matches_finite_difference_per_axis_float64(self):
+        with _x64_enabled():
+            obj, arrays, config = _build_slab_scene(dtype=jnp.float64, material=self._material())
             assert arrays.dispersive_c3 is not None and arrays.dispersive_c3.shape[1] == 3
-            arrays, config = _attach_gradient(arrays, config, obj, method=method)
+            arrays, config = _attach_gradient(arrays, config, obj, method="checkpointed")
 
             def loss_fn(c3):
                 arr = ArrayContainer(
@@ -583,30 +549,29 @@ class TestReversibleVsCheckpointedGradient:
                     dispersive_c1=arrays.dispersive_c1,
                     dispersive_c2=arrays.dispersive_c2,
                     dispersive_c3=c3,
-                    dispersive_inv_c2=arrays.dispersive_inv_c2,
                 )
-                fdtd_impl = reversible_fdtd if method == "reversible" else checkpointed_fdtd
-                _, out = fdtd_impl(arr, obj, config, jax.random.PRNGKey(99), show_progress=False)
+                _, out = checkpointed_fdtd(arr, obj, config, jax.random.PRNGKey(99), show_progress=False)
                 return jnp.sum(jnp.real(out.fields.E) ** 2)
 
-            return jax.value_and_grad(loss_fn)(arrays.dispersive_c3)
+            c3 = arrays.dispersive_c3
+            loss, grad = jax.value_and_grad(loss_fn)(c3)
+            assert jnp.isfinite(loss) and jnp.all(jnp.isfinite(grad))
 
-        with _x64_enabled():
-            loss_rev, grad_rev = run("reversible")
-            loss_chk, grad_chk = run("checkpointed")
-            assert jnp.isfinite(loss_rev) and jnp.isfinite(loss_chk)
-            assert jnp.allclose(loss_rev, loss_chk, rtol=1e-9, atol=1e-12)
-            max_abs = float(jnp.max(jnp.abs(grad_rev) + jnp.abs(grad_chk)))
-            max_diff = float(jnp.max(jnp.abs(grad_rev - grad_chk)))
-            rel = max_diff / (max_abs + 1e-30)
-            assert rel < 1e-5, (
-                f"per-axis c3 gradient mismatch: max|Δ|={max_diff:.3e}, max|grad|={max_abs:.3e}, rel={rel:.3e}"
-            )
+            # One active voxel per component axis: AD must match a central FD.
+            for ax in range(3):
+                xs, ys, zs = jnp.where(c3[0, ax] != 0, size=1, fill_value=0)
+                idx = (0, ax, int(xs[0]), int(ys[0]), int(zs[0]))
+                h = 1e-4 * float(jnp.abs(c3[idx])) + 1e-10
+                fd = (loss_fn(c3.at[idx].add(h)) - loss_fn(c3.at[idx].add(-h))) / (2.0 * h)
+                ad = grad[idx]
+                diff = float(jnp.abs(ad - fd))
+                rel = diff / (float(jnp.abs(ad) + jnp.abs(fd)) + 1e-30)
+                assert rel < 1e-4 or diff < 1e-8, f"axis {ax}: AD={float(ad):.6e}, FD={float(fd):.6e}, rel={rel:.3e}"
+
             # The per-axis gradient must genuinely differ across the component
-            # axis inside the slab — otherwise this test degenerates to the
-            # isotropic case.
-            gx = float(jnp.max(jnp.abs(grad_rev[:, 0])))
-            gy = float(jnp.max(jnp.abs(grad_rev[:, 1])))
+            # axis inside the slab — otherwise this degenerates to the isotropic case.
+            gx = float(jnp.max(jnp.abs(grad[:, 0])))
+            gy = float(jnp.max(jnp.abs(grad[:, 1])))
             assert gx != gy
 
 
@@ -623,7 +588,7 @@ class TestSlicedReversibleGradient:
     1. In a numerically benign (lossless, exactly reversible) regime, adding checkpoints must not
        change a correct gradient — the reset lands on the same field the reverse pass would have
        reconstructed anyway.
-    2. In a lossy/dispersive regime where the reverse reconstruction drifts, more checkpoints must
+    2. In a lossy regime where the reverse reconstruction drifts, more checkpoints must
        drive the reversible gradient toward the checkpointed reference (exact autodiff) — never
        away from it.
     """
@@ -637,8 +602,6 @@ class TestSlicedReversibleGradient:
                     H=arrays.fields.H,
                     psi_E=arrays.fields.psi_E,
                     psi_H=arrays.fields.psi_H,
-                    dispersive_P_curr=arrays.fields.dispersive_P_curr,
-                    dispersive_P_prev=arrays.fields.dispersive_P_prev,
                 ),
                 inv_permittivities=inv_eps,
                 inv_permeabilities=arrays.inv_permeabilities,
@@ -646,10 +609,6 @@ class TestSlicedReversibleGradient:
                 recording_state=arrays.recording_state,
                 electric_conductivity=arrays.electric_conductivity,
                 magnetic_conductivity=arrays.magnetic_conductivity,
-                dispersive_c1=arrays.dispersive_c1,
-                dispersive_c2=arrays.dispersive_c2,
-                dispersive_c3=arrays.dispersive_c3,
-                dispersive_inv_c2=arrays.dispersive_inv_c2,
             )
             _, out = reversible_fdtd(arr, obj, config, jax.random.PRNGKey(99), show_progress=False)
             return jnp.sum(jnp.real(out.fields.E) ** 2)
@@ -663,7 +622,7 @@ class TestSlicedReversibleGradient:
         """
         lossless_material = fdtdx.Material(permittivity=2.0)  # no loss, no dispersion
         with _x64_enabled():
-            obj, arrays, config = _build_lossy_dispersive_scene(dtype=jnp.float64, material=lossless_material)
+            obj, arrays, config = _build_slab_scene(dtype=jnp.float64, material=lossless_material)
             t_total = config.time_steps_total
 
             def grad_for(num_ckpt):
@@ -684,14 +643,14 @@ class TestSlicedReversibleGradient:
                 assert rel < 1e-8, f"checkpoints changed benign gradient (num_ckpt={num_ckpt}): rel={rel:.3e}"
 
     def test_checkpoints_converge_to_checkpointed_reference_lossy(self):
-        """Lossy + dispersive scene: the reversible gradient with checkpoints must converge to the
+        """Strongly lossy scene: the reversible gradient with checkpoints must converge to the
         checkpointed-autodiff reference. More checkpoints must not increase the relative error, and
-        enough checkpoints must bring it below tolerance. Float32 is used because that is where the
+        enough checkpoints must bring it below tolerance. Float32 + a large σ_E is where the
         reverse-reconstruction drift (lossy forward = gain in reverse) is numerically visible."""
         dtype = jnp.float32
 
         # Reference: exact autodiff through the checkpointed loop.
-        obj_r, arrays_r, config_r = _build_lossy_dispersive_scene(dtype=dtype)
+        obj_r, arrays_r, config_r = _build_slab_scene(dtype=dtype, material=_HIGH_LOSS_MATERIAL)
         arrays_r, config_r = _attach_gradient(arrays_r, config_r, obj_r, method="checkpointed")
 
         def ref_loss(inv_eps):
@@ -701,8 +660,6 @@ class TestSlicedReversibleGradient:
                     H=arrays_r.fields.H,
                     psi_E=arrays_r.fields.psi_E,
                     psi_H=arrays_r.fields.psi_H,
-                    dispersive_P_curr=arrays_r.fields.dispersive_P_curr,
-                    dispersive_P_prev=arrays_r.fields.dispersive_P_prev,
                 ),
                 inv_permittivities=inv_eps,
                 inv_permeabilities=arrays_r.inv_permeabilities,
@@ -710,10 +667,6 @@ class TestSlicedReversibleGradient:
                 recording_state=arrays_r.recording_state,
                 electric_conductivity=arrays_r.electric_conductivity,
                 magnetic_conductivity=arrays_r.magnetic_conductivity,
-                dispersive_c1=arrays_r.dispersive_c1,
-                dispersive_c2=arrays_r.dispersive_c2,
-                dispersive_c3=arrays_r.dispersive_c3,
-                dispersive_inv_c2=arrays_r.dispersive_inv_c2,
             )
             _, out = checkpointed_fdtd(arr, obj_r, config_r, jax.random.PRNGKey(99), show_progress=False)
             return jnp.sum(jnp.real(out.fields.E) ** 2)
@@ -722,7 +675,7 @@ class TestSlicedReversibleGradient:
         ref_norm = float(jnp.max(jnp.abs(grad_ref))) + 1e-30
 
         def reversible_rel_err(num_ckpt):
-            obj, arrays, config = _build_lossy_dispersive_scene(dtype=dtype)
+            obj, arrays, config = _build_slab_scene(dtype=dtype, material=_HIGH_LOSS_MATERIAL)
             arrays, config = _attach_gradient(
                 arrays, config, obj, method="reversible", num_checkpoints_reversible=num_ckpt
             )
@@ -767,7 +720,7 @@ class TestOrientedDispersionGradients:
             ),
         )
 
-        obj, arrays, config = _build_lossy_dispersive_scene(dtype=jnp.float32, material=oriented_material)
+        obj, arrays, config = _build_slab_scene(dtype=jnp.float32, material=oriented_material)
         assert arrays.dispersive_c3 is not None and arrays.dispersive_c3.shape[1] == 9
         arrays, config = _attach_gradient(arrays, config, obj, method="checkpointed")
 
@@ -790,7 +743,6 @@ class TestOrientedDispersionGradients:
                 dispersive_c1=arrays.dispersive_c1,
                 dispersive_c2=arrays.dispersive_c2,
                 dispersive_c3=c3,
-                dispersive_inv_c2=arrays.dispersive_inv_c2,
             )
             _, out = checkpointed_fdtd(arr, obj, config, jax.random.PRNGKey(99), show_progress=False)
             return jnp.sum(jnp.real(out.fields.E) ** 2)

--- a/tests/simulation/fdtd/test_time_reversal.py
+++ b/tests/simulation/fdtd/test_time_reversal.py
@@ -187,38 +187,18 @@ def _multi_step_roundtrip(
     config,
     has_pml,
     n_steps,
-    seed_dispersive=False,
 ):
     """Run ``n_steps`` forward steps then ``n_steps`` backward steps.
 
     Per-step factor errors in the reverse pass accumulate over a multi-step
     horizon — a 1-step roundtrip has no headroom to expose drift that stays
     below atol. Returns ``(originals, reconstructed)`` as dicts containing
-    ``E``, ``H``, and optionally ``P_curr`` / ``P_prev`` when
-    ``seed_dispersive=True``.
+    ``E`` and ``H``.
     """
     key = jax.random.PRNGKey(42)
     arrays = _seed_fields(arrays, key, obj_container)
 
     originals = {"E": arrays.fields.E, "H": arrays.fields.H}
-    if seed_dispersive and arrays.fields.dispersive_P_curr is not None:
-        # Mask polarization seeds to dispersive cells only — vacuum cells have
-        # c1=c2=c3=0 and any nonzero P there would be killed by the forward
-        # recurrence and unrecoverable by the reverse.
-        k_pc, k_pp = jax.random.split(key)
-        disp_mask = (arrays.dispersive_c3 != 0).astype(arrays.fields.dispersive_P_curr.dtype)
-        P_curr = jax.random.normal(
-            k_pc, arrays.fields.dispersive_P_curr.shape, dtype=arrays.fields.dispersive_P_curr.dtype
-        )
-        P_curr = P_curr * 1e-3 * disp_mask
-        P_prev = jax.random.normal(
-            k_pp, arrays.fields.dispersive_P_prev.shape, dtype=arrays.fields.dispersive_P_prev.dtype
-        )
-        P_prev = P_prev * 1e-3 * disp_mask
-        arrays = arrays.aset("fields->dispersive_P_curr", P_curr)
-        arrays = arrays.aset("fields->dispersive_P_prev", P_prev)
-        originals["P_curr"] = P_curr
-        originals["P_prev"] = P_prev
 
     arrays, config = _add_gradient_config(arrays, config, obj_container)
 
@@ -245,9 +225,6 @@ def _multi_step_roundtrip(
 
     _, arr_rec = state
     reconstructed = {"E": arr_rec.fields.E, "H": arr_rec.fields.H}
-    if seed_dispersive and arr_rec.fields.dispersive_P_curr is not None:
-        reconstructed["P_curr"] = arr_rec.fields.dispersive_P_curr
-        reconstructed["P_prev"] = arr_rec.fields.dispersive_P_prev
     return originals, reconstructed
 
 
@@ -350,324 +327,14 @@ class TestTimeReversalBlochBoundary:
         assert jnp.allclose(H_rec, H_orig, atol=1e-5), f"H max error: {jnp.max(jnp.abs(H_rec - H_orig))}"
 
 
-class TestTimeReversalDispersiveLorentz:
-    """Dispersive (Lorentz) material round-trip reconstructs both E/H and
-    the ADE polarization state.
-
-    Periodic boundaries + a Lorentz slab filling the middle of the z axis.
-    P_curr and P_prev are seeded with non-zero random values masked to the
-    dispersive slab (vacuum cells have c1=c2=c3=0, and information in those
-    cells would be lost through the zero-valued recurrence). One forward step
-    followed by one reverse step must exactly reconstruct E, H, P_curr and
-    P_prev — the reverse is the algebraic inverse of the ADE recurrence.
-    """
-
-    @staticmethod
-    def _build(material=None):
-        config = SimulationConfig(
-            time=_SIM_TIME,
-            grid=UniformGrid(spacing=_RESOLUTION),
-            backend="cpu",
-            dtype=jnp.float32,
-            courant_factor=0.99,
-            gradient_config=None,
-        )
-        objects, constraints = [], []
-        volume = fdtdx.SimulationVolume(
-            partial_grid_shape=(_VOLUME_CELLS, _VOLUME_CELLS, _VOLUME_CELLS),
-        )
-        objects.append(volume)
-
-        bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
-            thickness=_PML_CELLS,
-            override_types=_uniform_boundaries("periodic"),
-        )
-        bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
-        objects.extend(bound_dict.values())
-        constraints.extend(c_list)
-
-        if material is None:
-            material = fdtdx.Material(
-                permittivity=2.0,
-                dispersion=fdtdx.DispersionModel(
-                    poles=(fdtdx.LorentzPole(resonance_frequency=2e15, damping=1e13, delta_epsilon=1.5),),
-                ),
-            )
-        slab_cells = _VOLUME_CELLS // 2
-        slab = fdtdx.UniformMaterialObject(
-            partial_grid_shape=(None, None, slab_cells),
-            material=material,
-        )
-        constraints.extend(
-            [
-                slab.same_size(volume, axes=(0, 1)),
-                slab.place_at_center(volume, axes=(0, 1)),
-                slab.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_VOLUME_CELLS // 4,)),
-            ]
-        )
-        objects.append(slab)
-
-        key = jax.random.PRNGKey(0)
-        obj_container, arrays, params, config, _ = fdtdx.place_objects(
-            object_list=objects,
-            config=config,
-            constraints=constraints,
-            key=key,
-        )
-        arrays, obj_container, _ = fdtdx.apply_params(arrays, obj_container, params, key)
-        return obj_container, arrays, config
-
-    @pytest.mark.parametrize("per_axis", [False, True], ids=["isotropic", "per_axis"])
-    def test_fields_and_polarization_reconstructed_exactly(self, per_axis):
-        material = None
-        if per_axis:
-            # Per-axis pole parameters (with non-zero coupling on every axis so
-            # the seeded polarization stays recoverable everywhere in the slab).
-            material = fdtdx.Material(
-                permittivity=(2.0, 2.5, 3.0),
-                dispersion=fdtdx.DispersionModel(
-                    poles=(
-                        fdtdx.LorentzPole(
-                            resonance_frequency=(2e15, 2.5e15, 3e15),
-                            damping=(1e13, 2e13, 1.5e13),
-                            delta_epsilon=(1.5, 0.5, 1.0),
-                        ),
-                    ),
-                ),
-            )
-        obj, arrays, config = self._build(material)
-        # Allocation sanity: the slab should have triggered allocation.
-        assert arrays.fields.dispersive_P_curr is not None
-        assert arrays.fields.dispersive_P_prev is not None
-        assert arrays.dispersive_c3 is not None
-        assert arrays.dispersive_c3.shape[1] == (3 if per_axis else 1)
-
-        key = jax.random.PRNGKey(42)
-        k_E, k_H, k_Pc, k_Pp = jax.random.split(key, 4)
-
-        E = jax.random.normal(k_E, arrays.fields.E.shape, dtype=arrays.fields.E.dtype) * 1e-3
-        H = jax.random.normal(k_H, arrays.fields.H.shape, dtype=arrays.fields.H.dtype) * 1e-3
-        for b in obj.boundary_objects:
-            E = b.apply_post_E_update(E)
-            H = b.apply_post_H_update(H)
-
-        # Mask polarization seeds to dispersive cells only. In vacuum cells the
-        # recurrence coefficients are zero, so any nonzero P there gets dropped
-        # by the forward step and the reverse cannot recover it. Keeping P=0 in
-        # those cells is consistent with both directions.
-        disp_mask = (arrays.dispersive_c3 != 0).astype(arrays.fields.dispersive_P_curr.dtype)
-        P_curr = (
-            jax.random.normal(k_Pc, arrays.fields.dispersive_P_curr.shape, dtype=arrays.fields.dispersive_P_curr.dtype)
-            * 1e-3
-            * disp_mask
-        )
-        P_prev = (
-            jax.random.normal(k_Pp, arrays.fields.dispersive_P_prev.shape, dtype=arrays.fields.dispersive_P_prev.dtype)
-            * 1e-3
-            * disp_mask
-        )
-
-        arrays = arrays.aset("fields->E", E)
-        arrays = arrays.aset("fields->H", H)
-        arrays = arrays.aset("fields->dispersive_P_curr", P_curr)
-        arrays = arrays.aset("fields->dispersive_P_prev", P_prev)
-
-        # Recorder setup: there are no PML objects, so the recorder ends up
-        # with an empty interface dict — but backward() still needs a
-        # gradient_config and recording_state to be present.
-        arrays, config = _add_gradient_config(arrays, config, obj)
-
-        E_orig = E
-        H_orig = H
-        Pc_orig = P_curr
-        Pp_orig = P_prev
-
-        state_fwd = forward(
-            state=(jnp.asarray(0, dtype=jnp.int32), arrays),
-            config=config,
-            objects=obj,
-            key=key,
-            record_detectors=False,
-            record_boundaries=False,
-            simulate_boundaries=True,
-        )
-        state_bwd = backward(
-            state=state_fwd,
-            config=config,
-            objects=obj,
-            key=key,
-            record_detectors=False,
-            reset_fields=False,
-        )
-        _, arrays_bwd = state_bwd
-
-        assert arrays_bwd.fields.dispersive_P_curr is not None
-        assert arrays_bwd.fields.dispersive_P_prev is not None
-
-        assert jnp.allclose(arrays_bwd.fields.E, E_orig, atol=1e-5), (
-            f"E max err: {jnp.max(jnp.abs(arrays_bwd.fields.E - E_orig))}"
-        )
-        assert jnp.allclose(arrays_bwd.fields.H, H_orig, atol=1e-5), (
-            f"H max err: {jnp.max(jnp.abs(arrays_bwd.fields.H - H_orig))}"
-        )
-        assert jnp.allclose(arrays_bwd.fields.dispersive_P_curr, Pc_orig, atol=1e-5), (
-            f"P_curr max err: {jnp.max(jnp.abs(arrays_bwd.fields.dispersive_P_curr - Pc_orig))}"
-        )
-        assert jnp.allclose(arrays_bwd.fields.dispersive_P_prev, Pp_orig, atol=1e-5), (
-            f"P_prev max err: {jnp.max(jnp.abs(arrays_bwd.fields.dispersive_P_prev - Pp_orig))}"
-        )
-
-
-class TestTimeReversalDispersiveLossy:
-    """Time-reversal for a Lorentz-dispersive material *with nonzero electric
-    conductivity*.
-
-    This combination activates both the lossy factor ``(1 ± c σ η₀ inv_eps/2)``
-    and the dispersive polarization recurrence in the forward/reverse E update.
-    Getting the reverse E update right requires the entire RHS (curl and
-    polarization delta) to be divided by the lossy factor — a subtle point
-    that a pure-dispersive or pure-lossy test alone does not exercise.
-    """
-
-    @staticmethod
-    def _build():
-        config = SimulationConfig(
-            time=_SIM_TIME,
-            grid=UniformGrid(spacing=_RESOLUTION),
-            backend="cpu",
-            dtype=jnp.float32,
-            courant_factor=0.99,
-            gradient_config=None,
-        )
-        objects, constraints = [], []
-        volume = fdtdx.SimulationVolume(
-            partial_grid_shape=(_VOLUME_CELLS, _VOLUME_CELLS, _VOLUME_CELLS),
-        )
-        objects.append(volume)
-
-        bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
-            thickness=_PML_CELLS,
-            override_types=_uniform_boundaries("periodic"),
-        )
-        bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
-        objects.extend(bound_dict.values())
-        constraints.extend(c_list)
-
-        material = fdtdx.Material(
-            permittivity=2.0,
-            electric_conductivity=1e2,
-            dispersion=fdtdx.DispersionModel(
-                poles=(fdtdx.LorentzPole(resonance_frequency=2e15, damping=1e13, delta_epsilon=1.5),),
-            ),
-        )
-        slab_cells = _VOLUME_CELLS // 2
-        slab = fdtdx.UniformMaterialObject(
-            partial_grid_shape=(None, None, slab_cells),
-            material=material,
-        )
-        constraints.extend(
-            [
-                slab.same_size(volume, axes=(0, 1)),
-                slab.place_at_center(volume, axes=(0, 1)),
-                slab.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_VOLUME_CELLS // 4,)),
-            ]
-        )
-        objects.append(slab)
-
-        key = jax.random.PRNGKey(0)
-        obj_container, arrays, params, config, _ = fdtdx.place_objects(
-            object_list=objects,
-            config=config,
-            constraints=constraints,
-            key=key,
-        )
-        arrays, obj_container, _ = fdtdx.apply_params(arrays, obj_container, params, key)
-        return obj_container, arrays, config
-
-    def test_fields_and_polarization_reconstructed_exactly(self):
-        obj, arrays, config = self._build()
-        # Both the dispersive state AND an electric_conductivity map must be
-        # populated for this test to mean what we claim.
-        assert arrays.fields.dispersive_P_curr is not None
-        assert arrays.dispersive_c3 is not None
-        assert arrays.electric_conductivity is not None
-        assert jnp.any(arrays.electric_conductivity != 0), "Slab must have nonzero σ_E"
-
-        key = jax.random.PRNGKey(42)
-        k_E, k_H, k_Pc, k_Pp = jax.random.split(key, 4)
-
-        E = jax.random.normal(k_E, arrays.fields.E.shape, dtype=arrays.fields.E.dtype) * 1e-3
-        H = jax.random.normal(k_H, arrays.fields.H.shape, dtype=arrays.fields.H.dtype) * 1e-3
-        for b in obj.boundary_objects:
-            E = b.apply_post_E_update(E)
-            H = b.apply_post_H_update(H)
-
-        disp_mask = (arrays.dispersive_c3 != 0).astype(arrays.fields.dispersive_P_curr.dtype)
-        P_curr = (
-            jax.random.normal(k_Pc, arrays.fields.dispersive_P_curr.shape, dtype=arrays.fields.dispersive_P_curr.dtype)
-            * 1e-3
-            * disp_mask
-        )
-        P_prev = (
-            jax.random.normal(k_Pp, arrays.fields.dispersive_P_prev.shape, dtype=arrays.fields.dispersive_P_prev.dtype)
-            * 1e-3
-            * disp_mask
-        )
-
-        arrays = arrays.aset("fields->E", E)
-        arrays = arrays.aset("fields->H", H)
-        arrays = arrays.aset("fields->dispersive_P_curr", P_curr)
-        arrays = arrays.aset("fields->dispersive_P_prev", P_prev)
-
-        arrays, config = _add_gradient_config(arrays, config, obj)
-
-        E_orig = E
-        H_orig = H
-        Pc_orig = P_curr
-        Pp_orig = P_prev
-
-        state_fwd = forward(
-            state=(jnp.asarray(0, dtype=jnp.int32), arrays),
-            config=config,
-            objects=obj,
-            key=key,
-            record_detectors=False,
-            record_boundaries=False,
-            simulate_boundaries=True,
-        )
-        state_bwd = backward(
-            state=state_fwd,
-            config=config,
-            objects=obj,
-            key=key,
-            record_detectors=False,
-            reset_fields=False,
-        )
-        _, arrays_bwd = state_bwd
-
-        # Magnitude-relative tolerance: exposes drift in low-amplitude regions
-        # that a fixed atol=1e-5 vs |E|~1e-3 (1% absolute) silently masks.
-        # Float32 single-step floor is ~1e-5 relative; 1e-4 leaves clear margin
-        # but catches an O(0.1%) algebraic factor error.
-        rel_tol = 1e-4
-        rel_E = _max_relative_error(arrays_bwd.fields.E, E_orig)
-        rel_H = _max_relative_error(arrays_bwd.fields.H, H_orig)
-        rel_Pc = _max_relative_error(arrays_bwd.fields.dispersive_P_curr, Pc_orig)
-        rel_Pp = _max_relative_error(arrays_bwd.fields.dispersive_P_prev, Pp_orig)
-        assert rel_E < rel_tol, f"E rel err: {rel_E:.3e}"
-        assert rel_H < rel_tol, f"H rel err: {rel_H:.3e}"
-        assert rel_Pc < rel_tol, f"P_curr rel err: {rel_Pc:.3e}"
-        assert rel_Pp < rel_tol, f"P_prev rel err: {rel_Pp:.3e}"
-
-
 class TestStrictReversibilityLossy:
-    """High-precision multi-step reversibility for a Lorentz-dispersive slab
-    with electric conductivity.
+    """High-precision multi-step reversibility for a slab with electric
+    conductivity.
 
     Float64 + 10 steps + magnitude-relative tolerance pushes the precision
     floor to ~1e-12. Any algebraic factor mis-distribution in the reverse
-    E update — e.g. dropping the lossy factor on the polarization-delta term
-    — shows up as ``rel_err`` orders of magnitude above this floor.
+    E update — e.g. dropping the lossy factor on one term — shows up as
+    ``rel_err`` orders of magnitude above this floor.
     """
 
     @staticmethod
@@ -696,9 +363,6 @@ class TestStrictReversibilityLossy:
         material = fdtdx.Material(
             permittivity=2.0,
             electric_conductivity=1e2,
-            dispersion=fdtdx.DispersionModel(
-                poles=(fdtdx.LorentzPole(resonance_frequency=2e15, damping=1e13, delta_epsilon=1.5),),
-            ),
         )
         slab_cells = _VOLUME_CELLS // 2
         slab = fdtdx.UniformMaterialObject(
@@ -724,14 +388,14 @@ class TestStrictReversibilityLossy:
         arrays, obj_container, _ = fdtdx.apply_params(arrays, obj_container, params, key)
         return obj_container, arrays, config
 
-    def test_fields_and_polarization_reconstructed_to_machine_precision(self):
+    def test_fields_reconstructed_to_machine_precision(self):
         with _x64_enabled():
             obj, arrays, config = self._build()
             assert arrays.fields.E.dtype == jnp.float64, "Strict test requires float64 fields"
             originals, reconstructed = _multi_step_roundtrip(
-                obj, arrays, config, has_pml=False, n_steps=_STRICT_N_STEPS, seed_dispersive=True
+                obj, arrays, config, has_pml=False, n_steps=_STRICT_N_STEPS
             )
-            for name in ("E", "H", "P_curr", "P_prev"):
+            for name in ("E", "H"):
                 rel = _max_relative_error(reconstructed[name], originals[name])
                 assert rel < _STRICT_REL_TOL, f"{name} rel err over {_STRICT_N_STEPS} steps: {rel:.3e}"
 
@@ -800,86 +464,9 @@ class TestTimeReversalMagneticConductivity:
             assert arrays.magnetic_conductivity is not None
             assert jnp.any(arrays.magnetic_conductivity != 0), "Slab must have nonzero σ_H"
             originals, reconstructed = _multi_step_roundtrip(
-                obj, arrays, config, has_pml=False, n_steps=_STRICT_N_STEPS, seed_dispersive=False
+                obj, arrays, config, has_pml=False, n_steps=_STRICT_N_STEPS
             )
             for name in ("E", "H"):
-                rel = _max_relative_error(reconstructed[name], originals[name])
-                assert rel < _STRICT_REL_TOL, f"{name} rel err over {_STRICT_N_STEPS} steps: {rel:.3e}"
-
-
-class TestTimeReversalDispersiveDrude:
-    """Reversibility for a Drude-pole material (ω₀ = 0).
-
-    Drude exercises a c1 = 2 / (1 + γdt/2) regime distinct from Lorentz; if
-    the ADE reverse inversion assumes Lorentz-only parameter ranges it
-    silently mis-reconstructs.
-    """
-
-    @staticmethod
-    def _build():
-        config = SimulationConfig(
-            time=_SIM_TIME,
-            grid=UniformGrid(spacing=_RESOLUTION),
-            backend="cpu",
-            dtype=jnp.float64,
-            courant_factor=0.99,
-            gradient_config=None,
-        )
-        objects, constraints = [], []
-        volume = fdtdx.SimulationVolume(
-            partial_grid_shape=(_VOLUME_CELLS, _VOLUME_CELLS, _VOLUME_CELLS),
-        )
-        objects.append(volume)
-        bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
-            thickness=_PML_CELLS,
-            override_types=_uniform_boundaries("periodic"),
-        )
-        bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
-        objects.extend(bound_dict.values())
-        constraints.extend(c_list)
-
-        material = fdtdx.Material(
-            permittivity=1.0,
-            dispersion=fdtdx.DispersionModel(
-                poles=(fdtdx.DrudePole(plasma_frequency=2e15, damping=5e13),),
-            ),
-        )
-        slab_cells = _VOLUME_CELLS // 2
-        slab = fdtdx.UniformMaterialObject(
-            partial_grid_shape=(None, None, slab_cells),
-            material=material,
-        )
-        constraints.extend(
-            [
-                slab.same_size(volume, axes=(0, 1)),
-                slab.place_at_center(volume, axes=(0, 1)),
-                slab.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_VOLUME_CELLS // 4,)),
-            ]
-        )
-        objects.append(slab)
-
-        key = jax.random.PRNGKey(0)
-        obj_container, arrays, params, config, _ = fdtdx.place_objects(
-            object_list=objects,
-            config=config,
-            constraints=constraints,
-            key=key,
-        )
-        arrays, obj_container, _ = fdtdx.apply_params(arrays, obj_container, params, key)
-        return obj_container, arrays, config
-
-    def test_fields_and_polarization_reconstructed_to_machine_precision(self):
-        with _x64_enabled():
-            obj, arrays, config = self._build()
-            assert arrays.dispersive_c3 is not None
-            # Drude has bounded-away-from-zero c2 in the lossy regime — required
-            # for the reverse-time inversion of the ADE recurrence to be stable.
-            c2_slab = arrays.dispersive_c2[arrays.dispersive_c3 != 0]
-            assert jnp.all(jnp.abs(c2_slab) > 1e-3), "Drude c2 must be bounded away from 0 for reversibility"
-            originals, reconstructed = _multi_step_roundtrip(
-                obj, arrays, config, has_pml=False, n_steps=_STRICT_N_STEPS, seed_dispersive=True
-            )
-            for name in ("E", "H", "P_curr", "P_prev"):
                 rel = _max_relative_error(reconstructed[name], originals[name])
                 assert rel < _STRICT_REL_TOL, f"{name} rel err over {_STRICT_N_STEPS} steps: {rel:.3e}"
 
@@ -965,378 +552,12 @@ class TestTimeReversalMixedPMLBloch:
             )
 
 
-# ── Test: gradient with PML + Bloch (complex fields) ───────────────────────────
-
-
-class TestGradientDispersiveLorentz:
-    """End-to-end gradient test through a full reversible FDTD run with a
-    Lorentz dispersive slab.
-
-    Exercises the custom VJP with the dispersive polarization state threaded
-    through forward and backward passes, verifying that ``reversible_fdtd``
-    produces finite gradients w.r.t. ``inv_permittivities`` when the ADE
-    update path is active.
-    """
-
-    @staticmethod
-    def _build():
-        obj, arrays, config = TestTimeReversalDispersiveLorentz._build()
-        arrays, config = _add_gradient_config(arrays, config, obj)
-        key = jax.random.PRNGKey(7)
-        arrays = _seed_fields(arrays, key, obj)
-        return obj, arrays, config
-
-    @staticmethod
-    def _loss_fn(inv_permittivities, arrays, objects, config, key):
-        arrays = ArrayContainer(
-            fields=FieldState(
-                E=arrays.fields.E,
-                H=arrays.fields.H,
-                psi_E=arrays.fields.psi_E,
-                psi_H=arrays.fields.psi_H,
-                dispersive_P_curr=arrays.fields.dispersive_P_curr,
-                dispersive_P_prev=arrays.fields.dispersive_P_prev,
-            ),
-            inv_permittivities=inv_permittivities,
-            inv_permeabilities=arrays.inv_permeabilities,
-            detector_states=arrays.detector_states,
-            recording_state=arrays.recording_state,
-            electric_conductivity=arrays.electric_conductivity,
-            magnetic_conductivity=arrays.magnetic_conductivity,
-            dispersive_c1=arrays.dispersive_c1,
-            dispersive_c2=arrays.dispersive_c2,
-            dispersive_c3=arrays.dispersive_c3,
-            dispersive_inv_c2=arrays.dispersive_inv_c2,
-        )
-        _, out = reversible_fdtd(arrays, objects, config, key, show_progress=False)
-        return jnp.sum(jnp.real(out.fields.E) ** 2)
-
-    def test_dispersive_arrays_allocated(self):
-        _, arrays, _ = self._build()
-        assert arrays.fields.dispersive_P_curr is not None
-        assert arrays.fields.dispersive_P_prev is not None
-        assert arrays.dispersive_c1 is not None
-
-    def test_gradients_are_finite(self):
-        obj, arrays, config = self._build()
-        key = jax.random.PRNGKey(99)
-        loss, grads = jax.value_and_grad(self._loss_fn)(
-            arrays.inv_permittivities,
-            arrays,
-            obj,
-            config,
-            key,
-        )
-        assert jnp.isfinite(loss), f"Loss is not finite: {loss}"
-        assert jnp.all(jnp.isfinite(grads)), "Gradients contain NaN or Inf"
-
-
-class TestGradientDispersiveLossy:
-    """End-to-end gradient test through a reversible FDTD run with a
-    Lorentz-dispersive slab that *also* has nonzero ``electric_conductivity``.
-
-    This combination exercises the reverse E update's lossy + ADE branch — the
-    exact code path that the reverse-factoring bug would silently poison.
-    The scene injects fields through a ``PointDipoleSource`` (reversible_fdtd
-    resets the seeded E/H at the start, so nonzero fields have to be driven
-    by a source). We verify (a) finite gradients and (b) agreement with a
-    central-difference finite-difference estimate at a single interior voxel:
-    if the backward pass drifts (e.g. because the reverse factor is incorrectly
-    distributed), AD and FD disagree even when both are finite.
-    """
-
-    @staticmethod
-    def _build():
-        config = SimulationConfig(
-            time=_SIM_TIME,
-            grid=UniformGrid(spacing=_RESOLUTION),
-            backend="cpu",
-            dtype=jnp.float32,
-            courant_factor=0.99,
-            gradient_config=None,
-        )
-        objects, constraints = [], []
-        volume = fdtdx.SimulationVolume(partial_grid_shape=(_VOLUME_CELLS, _VOLUME_CELLS, _VOLUME_CELLS))
-        objects.append(volume)
-
-        bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
-            thickness=_PML_CELLS,
-            override_types=_uniform_boundaries("periodic"),
-        )
-        bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
-        objects.extend(bound_dict.values())
-        constraints.extend(c_list)
-
-        material = fdtdx.Material(
-            permittivity=2.0,
-            electric_conductivity=1e2,
-            dispersion=fdtdx.DispersionModel(
-                poles=(fdtdx.LorentzPole(resonance_frequency=2e15, damping=1e13, delta_epsilon=1.5),),
-            ),
-        )
-        slab_cells = _VOLUME_CELLS // 2
-        slab = fdtdx.UniformMaterialObject(
-            name="slab",
-            partial_grid_shape=(None, None, slab_cells),
-            material=material,
-        )
-        constraints.extend(
-            [
-                slab.same_size(volume, axes=(0, 1)),
-                slab.place_at_center(volume, axes=(0, 1)),
-                slab.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_VOLUME_CELLS // 4,)),
-            ]
-        )
-        objects.append(slab)
-
-        # CW dipole source at the slab center — drives nonzero fields into the
-        # dispersive/lossy medium throughout the run.
-        omega = 2.0 * jnp.pi * c0 / 800e-9
-        source = fdtdx.PointDipoleSource(
-            name="dip",
-            partial_grid_shape=(1, 1, 1),
-            wave_character=fdtdx.WaveCharacter(frequency=float(omega) / (2.0 * float(jnp.pi))),
-            polarization=0,
-            amplitude=1.0,
-        )
-        constraints.append(
-            source.set_grid_coordinates(
-                axes=(0, 1, 2),
-                sides=("-", "-", "-"),
-                coordinates=(_VOLUME_CELLS // 2, _VOLUME_CELLS // 2, _VOLUME_CELLS // 2),
-            )
-        )
-        objects.append(source)
-
-        key = jax.random.PRNGKey(0)
-        obj_container, arrays, params, config, _ = fdtdx.place_objects(
-            object_list=objects,
-            config=config,
-            constraints=constraints,
-            key=key,
-        )
-        arrays, obj_container, _ = fdtdx.apply_params(arrays, obj_container, params, key)
-        arrays, config = _add_gradient_config(arrays, config, obj_container)
-        return obj_container, arrays, config
-
-    @staticmethod
-    def _loss_fn(inv_permittivities, arrays, objects, config, key):
-        arrays = ArrayContainer(
-            fields=FieldState(
-                E=arrays.fields.E,
-                H=arrays.fields.H,
-                psi_E=arrays.fields.psi_E,
-                psi_H=arrays.fields.psi_H,
-                dispersive_P_curr=arrays.fields.dispersive_P_curr,
-                dispersive_P_prev=arrays.fields.dispersive_P_prev,
-            ),
-            inv_permittivities=inv_permittivities,
-            inv_permeabilities=arrays.inv_permeabilities,
-            detector_states=arrays.detector_states,
-            recording_state=arrays.recording_state,
-            electric_conductivity=arrays.electric_conductivity,
-            magnetic_conductivity=arrays.magnetic_conductivity,
-            dispersive_c1=arrays.dispersive_c1,
-            dispersive_c2=arrays.dispersive_c2,
-            dispersive_c3=arrays.dispersive_c3,
-            dispersive_inv_c2=arrays.dispersive_inv_c2,
-        )
-        _, out = reversible_fdtd(arrays, objects, config, key, show_progress=False)
-        return jnp.sum(jnp.real(out.fields.E) ** 2)
-
-    def test_scene_has_active_loss_and_dispersion(self):
-        """Sanity: the medium must actually carry both σ_E and pole coefficients."""
-        _, arrays, _ = self._build()
-        assert arrays.electric_conductivity is not None
-        assert jnp.any(arrays.electric_conductivity != 0), "Slab must have nonzero σ_E"
-        assert arrays.dispersive_c3 is not None
-        assert jnp.any(arrays.dispersive_c3 != 0), "Slab must have nonzero pole coefficients"
-
-    def test_gradients_are_finite_and_nonzero(self):
-        obj, arrays, config = self._build()
-        key = jax.random.PRNGKey(99)
-        loss, grads = jax.value_and_grad(self._loss_fn)(
-            arrays.inv_permittivities,
-            arrays,
-            obj,
-            config,
-            key,
-        )
-        assert jnp.isfinite(loss), f"Loss is not finite: {loss}"
-        assert jnp.all(jnp.isfinite(grads)), "Gradients contain NaN or Inf"
-        assert loss > 0, "Loss must be positive — the source must drive nonzero fields"
-        assert jnp.any(grads != 0), "Gradient must be nonzero — reverse pass must propagate through Maxwell"
-
-    def test_gradient_matches_finite_difference(self):
-        """AD gradient for a single interior voxel matches central FD.
-
-        This is the sharpest test of reverse-pass correctness: AD and FD must
-        produce the same number (within tolerance) regardless of any
-        algebraic rearrangement inside the reverse step. A wrong factor
-        distribution in the reverse E update leaves AD finite but numerically
-        skewed relative to FD.
-        """
-        obj, arrays, config = self._build()
-        key = jax.random.PRNGKey(99)
-        inv_eps = arrays.inv_permittivities
-
-        _, grads = jax.value_and_grad(self._loss_fn)(inv_eps, arrays, obj, config, key)
-
-        # Find an interior voxel where both σ_E and the pole coefficients are
-        # active — that's where the lossy+dispersive reverse branch actually
-        # fires. Dispersive c3 is (num_poles, 1, Nx, Ny, Nz); a nonzero c3
-        # implies a slab voxel.
-        c3 = arrays.dispersive_c3[0, 0]
-        xs, ys, zs = jnp.where(c3 != 0, size=1, fill_value=0)
-        voxel = (int(xs[0]), int(ys[0]), int(zs[0]))
-        # pick the polarization component the dipole drives (axis 0)
-        idx = (0, *voxel)
-
-        # Scale the step to the magnitude of the voxel being probed so that
-        # float32 round-off doesn't swamp the finite-difference numerator.
-        h = 1e-3 * float(jnp.abs(inv_eps[idx])) + 1e-5
-        inv_eps_plus = inv_eps.at[idx].add(h)
-        inv_eps_minus = inv_eps.at[idx].add(-h)
-        loss_plus = self._loss_fn(inv_eps_plus, arrays, obj, config, key)
-        loss_minus = self._loss_fn(inv_eps_minus, arrays, obj, config, key)
-        fd = (loss_plus - loss_minus) / (2.0 * h)
-
-        ad = grads[idx]
-        # Tolerance wide enough for float32 FD noise over the full reversible
-        # pipeline but tight enough to catch a dropped algebraic factor.
-        diff = jnp.abs(ad - fd)
-        scale = jnp.abs(fd) + jnp.abs(ad) + 1e-12
-        rel_err = diff / scale
-        assert rel_err < 0.1 or diff < 1e-5, (
-            f"AD vs FD mismatch at {idx}: AD={float(ad):.6e}, FD={float(fd):.6e}, rel_err={float(rel_err):.3e}"
-        )
-
-    @staticmethod
-    def _build_float64():
-        """Identical scene to ``_build`` but in float64 so FD noise drops to
-        ~1e-12 and the tolerance can tighten by three orders of magnitude."""
-        config = SimulationConfig(
-            time=_SIM_TIME,
-            grid=UniformGrid(spacing=_RESOLUTION),
-            backend="cpu",
-            dtype=jnp.float64,
-            courant_factor=0.99,
-            gradient_config=None,
-        )
-        objects, constraints = [], []
-        volume = fdtdx.SimulationVolume(partial_grid_shape=(_VOLUME_CELLS, _VOLUME_CELLS, _VOLUME_CELLS))
-        objects.append(volume)
-        bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
-            thickness=_PML_CELLS,
-            override_types=_uniform_boundaries("periodic"),
-        )
-        bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
-        objects.extend(bound_dict.values())
-        constraints.extend(c_list)
-
-        material = fdtdx.Material(
-            permittivity=2.0,
-            electric_conductivity=1e2,
-            dispersion=fdtdx.DispersionModel(
-                poles=(fdtdx.LorentzPole(resonance_frequency=2e15, damping=1e13, delta_epsilon=1.5),),
-            ),
-        )
-        slab_cells = _VOLUME_CELLS // 2
-        slab = fdtdx.UniformMaterialObject(
-            name="slab",
-            partial_grid_shape=(None, None, slab_cells),
-            material=material,
-        )
-        constraints.extend(
-            [
-                slab.same_size(volume, axes=(0, 1)),
-                slab.place_at_center(volume, axes=(0, 1)),
-                slab.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_VOLUME_CELLS // 4,)),
-            ]
-        )
-        objects.append(slab)
-
-        omega = 2.0 * jnp.pi * c0 / 800e-9
-        source = fdtdx.PointDipoleSource(
-            name="dip",
-            partial_grid_shape=(1, 1, 1),
-            wave_character=fdtdx.WaveCharacter(frequency=float(omega) / (2.0 * float(jnp.pi))),
-            polarization=0,
-            amplitude=1.0,
-        )
-        constraints.append(
-            source.set_grid_coordinates(
-                axes=(0, 1, 2),
-                sides=("-", "-", "-"),
-                coordinates=(_VOLUME_CELLS // 2, _VOLUME_CELLS // 2, _VOLUME_CELLS // 2),
-            )
-        )
-        objects.append(source)
-
-        key = jax.random.PRNGKey(0)
-        obj_container, arrays, params, config, _ = fdtdx.place_objects(
-            object_list=objects,
-            config=config,
-            constraints=constraints,
-            key=key,
-        )
-        arrays, obj_container, _ = fdtdx.apply_params(arrays, obj_container, params, key)
-        arrays, config = _add_gradient_config(arrays, config, obj_container)
-        return obj_container, arrays, config
-
-    def test_gradient_matches_finite_difference_float64_multi_voxel(self):
-        """Multi-voxel float64 FD vs AD agreement.
-
-        Tightens the single-voxel float32 test in two independent directions:
-        (1) float64 drops FD noise to ~1e-12, allowing ``rel_err < 1e-3``
-        instead of 0.1; (2) sweeping every lossy+dispersive voxel catches a
-        bug that cancels at one voxel but not another (e.g. a sign or
-        component-index error in the reverse pass).
-        """
-        with _x64_enabled():
-            obj, arrays, config = self._build_float64()
-            assert arrays.fields.E.dtype == jnp.float64
-            key = jax.random.PRNGKey(99)
-            inv_eps = arrays.inv_permittivities
-            _, grads = jax.value_and_grad(TestGradientDispersiveLossy._loss_fn)(inv_eps, arrays, obj, config, key)
-
-            # Find every voxel where BOTH σ_E and c3 are active — the lossy+dispersive
-            # reverse branch fires only here. Use polarization axis 0 (the dipole).
-            c3 = arrays.dispersive_c3[0, 0]  # (Nx, Ny, Nz)
-            # electric_conductivity is shape (9, Nx, Ny, Nz) (full 9-tuple) or
-            # (3, ...) or (1, ...). For isotropic the diagonal component is at index 0.
-            sigma_diag = arrays.electric_conductivity[0]
-            active = (c3 != 0) & (sigma_diag != 0)
-            xs, ys, zs = jnp.where(active, size=8, fill_value=-1)
-
-            checked = 0
-            for xi, yi, zi in zip(xs.tolist(), ys.tolist(), zs.tolist(), strict=True):
-                if xi < 0:
-                    continue  # padding from size=8 fill_value
-                idx = (0, int(xi), int(yi), int(zi))
-                h = 1e-4 * float(jnp.abs(inv_eps[idx])) + 1e-7
-                inv_eps_plus = inv_eps.at[idx].add(h)
-                inv_eps_minus = inv_eps.at[idx].add(-h)
-                loss_plus = TestGradientDispersiveLossy._loss_fn(inv_eps_plus, arrays, obj, config, key)
-                loss_minus = TestGradientDispersiveLossy._loss_fn(inv_eps_minus, arrays, obj, config, key)
-                fd = (loss_plus - loss_minus) / (2.0 * h)
-                ad = grads[idx]
-                diff = float(jnp.abs(ad - fd))
-                scale = float(jnp.abs(fd) + jnp.abs(ad)) + 1e-12
-                rel_err = diff / scale
-                assert rel_err < 1e-3 or diff < 1e-9, (
-                    f"AD vs FD mismatch at {idx}: AD={float(ad):.6e}, FD={float(fd):.6e}, "
-                    f"rel_err={rel_err:.3e}, diff={diff:.3e}"
-                )
-                checked += 1
-            assert checked >= 1, "No active (σ_E≠0 ∧ c3≠0) voxels found — scene misconfigured"
-
-
 class TestGradientMagneticConductivity:
     """Float64 AD vs FD for ``inv_permeabilities`` in a magnetically lossy slab.
 
-    Symmetric to ``TestGradientDispersiveLossy`` but on the magnetic side.
-    The reverse H update has its own ``(1 ± c σ_H inv_μ / (2 η₀))`` factor —
+    The electric-side counterpart lives in ``test_fdtd.py`` (reversible vs
+    checkpointed cross-check on a lossy slab). The reverse H update has its own
+    ``(1 ± c σ_H inv_μ / (2 η₀))`` factor —
     a bug here would not show up in any electric-conductivity test.
     """
 
@@ -1588,6 +809,86 @@ class TestGradientPMLBlochComplex:
 
 
 # ── Tests: dispersion coefficient gradients ────────────────────────────────────
+#
+# Dispersive simulations only support the checkpointed gradient method — the
+# reversible path rejects them (see ``reversible_fdtd``), so every test below
+# runs through ``checkpointed_fdtd``.
+
+
+def _build_lossy_dispersive_scene():
+    """Periodic-boundary Lorentz slab with nonzero σ_E, driven by a CW dipole.
+
+    The dipole is what makes the fields nonzero at all: the FDTD entry points
+    reset the container, so seeded E/H would be discarded.
+    """
+    config = SimulationConfig(
+        time=_SIM_TIME,
+        grid=UniformGrid(spacing=_RESOLUTION),
+        backend="cpu",
+        dtype=jnp.float32,
+        courant_factor=0.99,
+        gradient_config=None,
+    )
+    objects, constraints = [], []
+    volume = fdtdx.SimulationVolume(partial_grid_shape=(_VOLUME_CELLS, _VOLUME_CELLS, _VOLUME_CELLS))
+    objects.append(volume)
+
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+        thickness=_PML_CELLS,
+        override_types=_uniform_boundaries("periodic"),
+    )
+    bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    objects.extend(bound_dict.values())
+    constraints.extend(c_list)
+
+    material = fdtdx.Material(
+        permittivity=2.0,
+        electric_conductivity=1e2,
+        dispersion=fdtdx.DispersionModel(
+            poles=(fdtdx.LorentzPole(resonance_frequency=2e15, damping=1e13, delta_epsilon=1.5),),
+        ),
+    )
+    slab_cells = _VOLUME_CELLS // 2
+    slab = fdtdx.UniformMaterialObject(
+        name="slab",
+        partial_grid_shape=(None, None, slab_cells),
+        material=material,
+    )
+    constraints.extend(
+        [
+            slab.same_size(volume, axes=(0, 1)),
+            slab.place_at_center(volume, axes=(0, 1)),
+            slab.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_VOLUME_CELLS // 4,)),
+        ]
+    )
+    objects.append(slab)
+
+    source = fdtdx.PointDipoleSource(
+        name="dip",
+        partial_grid_shape=(1, 1, 1),
+        wave_character=fdtdx.WaveCharacter(frequency=c0 / 800e-9),
+        polarization=0,
+        amplitude=1.0,
+    )
+    constraints.append(
+        source.set_grid_coordinates(
+            axes=(0, 1, 2),
+            sides=("-", "-", "-"),
+            coordinates=(_VOLUME_CELLS // 2, _VOLUME_CELLS // 2, _VOLUME_CELLS // 2),
+        )
+    )
+    objects.append(source)
+
+    key = jax.random.PRNGKey(0)
+    obj_container, arrays, params, config, _ = fdtdx.place_objects(
+        object_list=objects,
+        config=config,
+        constraints=constraints,
+        key=key,
+    )
+    arrays, obj_container, _ = fdtdx.apply_params(arrays, obj_container, params, key)
+    config = config.aset("gradient_config", GradientConfig(method="checkpointed", num_checkpoints=8))
+    return obj_container, arrays, config
 
 
 def _make_disp_loss_fn(coef_name):
@@ -1621,7 +922,6 @@ def _make_disp_loss_fn(coef_name):
             recording_state=arrays.recording_state,
             electric_conductivity=arrays.electric_conductivity,
             magnetic_conductivity=arrays.magnetic_conductivity,
-            dispersive_inv_c2=arrays.dispersive_inv_c2,
             **kwargs,
         )
         _, out = _fdtd(arr, objects, config, key, show_progress=False)
@@ -1652,120 +952,15 @@ def _coef_fd_check(coef_arr, loss_fn, arrays, obj, config, key, h_scale, h_floor
     return ad, fd, rel_err, diff, idx
 
 
-class TestDispersiveCoefficientGradientReversible:
-    """Verify that ``dispersive_c1/c2/c3`` are primal VJP inputs of the
-    reversible FDTD path, i.e. the AD gradient w.r.t. each coefficient at
-    an interior dispersive voxel matches a central finite-difference estimate.
-    """
-
-    @staticmethod
-    def _build():
-        return TestGradientDispersiveLossy._build()
-
-    @staticmethod
-    def _loss_fn(dispersive_c3, arrays, objects, config, key):
-        arrays = ArrayContainer(
-            fields=FieldState(
-                E=arrays.fields.E,
-                H=arrays.fields.H,
-                psi_E=arrays.fields.psi_E,
-                psi_H=arrays.fields.psi_H,
-                dispersive_P_curr=arrays.fields.dispersive_P_curr,
-                dispersive_P_prev=arrays.fields.dispersive_P_prev,
-            ),
-            inv_permittivities=arrays.inv_permittivities,
-            inv_permeabilities=arrays.inv_permeabilities,
-            detector_states=arrays.detector_states,
-            recording_state=arrays.recording_state,
-            electric_conductivity=arrays.electric_conductivity,
-            magnetic_conductivity=arrays.magnetic_conductivity,
-            dispersive_c1=arrays.dispersive_c1,
-            dispersive_c2=arrays.dispersive_c2,
-            dispersive_c3=dispersive_c3,
-            dispersive_inv_c2=arrays.dispersive_inv_c2,
-        )
-        _, out = reversible_fdtd(arrays, objects, config, key, show_progress=False)
-        return jnp.sum(jnp.real(out.fields.E) ** 2)
-
-    def test_gradient_through_c3_matches_finite_difference(self):
-        obj, arrays, config = self._build()
-        key = jax.random.PRNGKey(99)
-        c3 = arrays.dispersive_c3
-        assert c3 is not None
-
-        _, grads = jax.value_and_grad(self._loss_fn)(c3, arrays, obj, config, key)
-
-        c3_mid = c3[0, 0]
-        xs, ys, zs = jnp.where(c3_mid != 0, size=1, fill_value=0)
-        idx = (0, 0, int(xs[0]), int(ys[0]), int(zs[0]))
-
-        # c3 ~ K * dt^2 is small (O(1e-2) here). Scale FD step to magnitude so
-        # float32 round-off doesn't dominate the numerator.
-        h = 1e-2 * float(jnp.abs(c3[idx])) + 1e-6
-        c3_plus = c3.at[idx].add(h)
-        c3_minus = c3.at[idx].add(-h)
-        loss_plus = self._loss_fn(c3_plus, arrays, obj, config, key)
-        loss_minus = self._loss_fn(c3_minus, arrays, obj, config, key)
-        fd = (loss_plus - loss_minus) / (2.0 * h)
-
-        ad = grads[idx]
-        diff = jnp.abs(ad - fd)
-        scale = jnp.abs(fd) + jnp.abs(ad) + 1e-12
-        rel_err = diff / scale
-        assert rel_err < 0.1 or diff < 1e-5, (
-            f"AD vs FD mismatch at {idx}: AD={float(ad):.6e}, FD={float(fd):.6e}, rel_err={float(rel_err):.3e}"
-        )
-
-    def test_gradient_through_c1_matches_finite_difference(self):
-        """c1 appears in both ``update_E`` and ``update_E_reverse`` — a primal
-        of the reversible VJP. Currently only c3 was tested; an algebraic
-        error specific to c1 (e.g. wrong sign in the reverse recurrence
-        inversion) would slip past."""
-        obj, arrays, config = self._build()
-        key = jax.random.PRNGKey(99)
-        c1 = arrays.dispersive_c1
-        assert c1 is not None
-        loss_fn = _make_disp_loss_fn("c1")
-        # c1 ~ O(1) in the physical regime, so a multiplicative step ~1e-3
-        # gives well-resolved FD without truncation error.
-        ad, fd, rel_err, diff, idx = _coef_fd_check(
-            c1, loss_fn, arrays, obj, config, key, h_scale=1e-3, h_floor=1e-6, fdtd_impl=reversible_fdtd
-        )
-        assert rel_err < 0.1 or diff < 1e-5, (
-            f"AD vs FD mismatch (c1) at {idx}: AD={float(ad):.6e}, FD={float(fd):.6e}, rel_err={float(rel_err):.3e}"
-        )
-
-    def test_gradient_through_c2_matches_finite_difference(self):
-        """c2 is the inverted coefficient in the reverse recurrence:
-        ``P^(n-1) = (P^(n+1) - c1 P^n - c3 E^n) / c2``. ``dispersive_inv_c2``
-        is the cached 1/c2 (stop_gradient'd), so gradients must flow through
-        c2 only. A wrong-coefficient-derivative bug would only show here."""
-        obj, arrays, config = self._build()
-        key = jax.random.PRNGKey(99)
-        c2 = arrays.dispersive_c2
-        assert c2 is not None
-        # Physical c2 ~ -1; perturb a few percent.
-        loss_fn = _make_disp_loss_fn("c2")
-        ad, fd, rel_err, diff, idx = _coef_fd_check(
-            c2, loss_fn, arrays, obj, config, key, h_scale=1e-3, h_floor=1e-6, fdtd_impl=reversible_fdtd
-        )
-        assert rel_err < 0.1 or diff < 1e-5, (
-            f"AD vs FD mismatch (c2) at {idx}: AD={float(ad):.6e}, FD={float(fd):.6e}, rel_err={float(rel_err):.3e}"
-        )
-
-
 class TestDispersiveCoefficientGradientCheckpointed:
-    """Same verification as ``TestDispersiveCoefficientGradientReversible``
-    but for the checkpointed path, which uses standard autodiff through
-    ``eqxi.while_loop`` so gradients flow naturally.
+    """Verify that ``dispersive_c1/c2/c3`` are genuine differentiable inputs of
+    the checkpointed FDTD path: the AD gradient w.r.t. each coefficient at an
+    interior dispersive voxel matches a central finite-difference estimate.
     """
 
     @staticmethod
     def _build():
-        obj, arrays, config = TestGradientDispersiveLossy._build()
-        grad_cfg = GradientConfig(method="checkpointed", num_checkpoints=8)
-        config = config.aset("gradient_config", grad_cfg)
-        return obj, arrays, config
+        return _build_lossy_dispersive_scene()
 
     @staticmethod
     def _loss_fn(dispersive_c3, arrays, objects, config, key):
@@ -1787,7 +982,6 @@ class TestDispersiveCoefficientGradientCheckpointed:
             dispersive_c1=arrays.dispersive_c1,
             dispersive_c2=arrays.dispersive_c2,
             dispersive_c3=dispersive_c3,
-            dispersive_inv_c2=arrays.dispersive_inv_c2,
         )
         _, out = checkpointed_fdtd(arrays, objects, config, key, show_progress=False)
         return jnp.sum(jnp.real(out.fields.E) ** 2)
@@ -1908,76 +1102,17 @@ def _build_ccpr(electric_conductivity=0.0):
     return obj_container, arrays, config
 
 
-class TestTimeReversalDispersiveCCPR:
-    """Forward-then-reverse round-trip for a CCPR material with a non-zero c4
-    (dE/dt) coupling. Exercises the reverse polarization inversion's extra
-    ``- c4 * E^(n+1)`` term and the E^(n+1) capture ordering — a pure-Lorentz
-    test (c4 = None) does not cover these."""
-
-    def _run_roundtrip(self, electric_conductivity):
-        obj, arrays, config = _build_ccpr(electric_conductivity=electric_conductivity)
-        # Guard: the CCPR c4 array must actually be allocated and non-zero.
-        assert arrays.dispersive_c4 is not None
-        assert jnp.any(arrays.dispersive_c4 != 0), "CCPR pole must produce nonzero c4"
-        assert arrays.fields.dispersive_P_curr is not None
-
-        key = jax.random.PRNGKey(42)
-        k_E, k_H, k_Pc, k_Pp = jax.random.split(key, 4)
-        E = jax.random.normal(k_E, arrays.fields.E.shape, dtype=arrays.fields.E.dtype) * 1e-3
-        H = jax.random.normal(k_H, arrays.fields.H.shape, dtype=arrays.fields.H.dtype) * 1e-3
-        for b in obj.boundary_objects:
-            E = b.apply_post_E_update(E)
-            H = b.apply_post_H_update(H)
-
-        disp_mask = (arrays.dispersive_c3 != 0).astype(arrays.fields.dispersive_P_curr.dtype)
-        P_curr = jax.random.normal(k_Pc, arrays.fields.dispersive_P_curr.shape, dtype=E.dtype) * 1e-3 * disp_mask
-        P_prev = jax.random.normal(k_Pp, arrays.fields.dispersive_P_prev.shape, dtype=E.dtype) * 1e-3 * disp_mask
-
-        arrays = arrays.aset("fields->E", E)
-        arrays = arrays.aset("fields->H", H)
-        arrays = arrays.aset("fields->dispersive_P_curr", P_curr)
-        arrays = arrays.aset("fields->dispersive_P_prev", P_prev)
-        arrays, config = _add_gradient_config(arrays, config, obj)
-
-        state_fwd = forward(
-            state=(jnp.asarray(0, dtype=jnp.int32), arrays),
-            config=config,
-            objects=obj,
-            key=key,
-            record_detectors=False,
-            record_boundaries=False,
-            simulate_boundaries=True,
-        )
-        _, arrays_bwd = backward(
-            state=state_fwd, config=config, objects=obj, key=key, record_detectors=False, reset_fields=False
-        )
-
-        assert jnp.allclose(arrays_bwd.fields.E, E, atol=1e-5), (
-            f"E max err: {jnp.max(jnp.abs(arrays_bwd.fields.E - E))}"
-        )
-        assert jnp.allclose(arrays_bwd.fields.H, H, atol=1e-5), (
-            f"H max err: {jnp.max(jnp.abs(arrays_bwd.fields.H - H))}"
-        )
-        assert jnp.allclose(arrays_bwd.fields.dispersive_P_curr, P_curr, atol=1e-5), (
-            f"P_curr max err: {jnp.max(jnp.abs(arrays_bwd.fields.dispersive_P_curr - P_curr))}"
-        )
-        assert jnp.allclose(arrays_bwd.fields.dispersive_P_prev, P_prev, atol=1e-5), (
-            f"P_prev max err: {jnp.max(jnp.abs(arrays_bwd.fields.dispersive_P_prev - P_prev))}"
-        )
-
-    def test_reconstructed_exactly(self):
-        self._run_roundtrip(electric_conductivity=0.0)
-
-    def test_reconstructed_exactly_with_conductivity(self):
-        # CCPR + electric conductivity: the reverse E-recovery divides by the
-        # lossy factor while the c4 term feeds the polarization inversion.
-        self._run_roundtrip(electric_conductivity=1e2)
+def _ccpr_checkpointed():
+    """CCPR scene with a checkpointed gradient config attached."""
+    obj, arrays, config = _build_ccpr()
+    config = config.aset("gradient_config", GradientConfig(method="checkpointed", num_checkpoints=8))
+    return obj, arrays, config
 
 
 class TestGradientDispersiveCCPR:
-    """Gradients flow (finite, no NaN) through a CCPR simulation in both the
-    reversible and checkpointed paths, and the c4 coefficient is a genuine
-    differentiable primal (AD matches finite differences)."""
+    """Gradients flow (finite, no NaN) through a CCPR simulation on the
+    checkpointed path, and the c4 coefficient is a genuine differentiable
+    primal (AD matches finite differences)."""
 
     @staticmethod
     def _loss_fn_ie(inv_eps, arrays, objects, config, key, fdtd_impl):
@@ -1985,25 +1120,97 @@ class TestGradientDispersiveCCPR:
         _, out = fdtd_impl(arr, objects, config, key, show_progress=False)
         return jnp.sum(jnp.real(out.fields.E) ** 2)
 
-    def test_gradient_finite_reversible_and_checkpointed(self):
-        obj, arrays, config = _build_ccpr()
-        arrays, config = _add_gradient_config(arrays, config, obj)
+    def test_gradient_finite_checkpointed(self):
+        obj, arrays, config = _ccpr_checkpointed()
         key = jax.random.PRNGKey(7)
-        for impl in (reversible_fdtd, checkpointed_fdtd):
-            loss, grad = jax.value_and_grad(self._loss_fn_ie)(arrays.inv_permittivities, arrays, obj, config, key, impl)
-            assert jnp.isfinite(loss), f"{impl.__name__}: loss not finite"
-            assert jnp.all(jnp.isfinite(grad)), f"{impl.__name__}: grad not finite"
+        loss, grad = jax.value_and_grad(self._loss_fn_ie)(
+            arrays.inv_permittivities, arrays, obj, config, key, checkpointed_fdtd
+        )
+        assert jnp.isfinite(loss), "loss not finite"
+        assert jnp.all(jnp.isfinite(grad)), "grad not finite"
 
     def test_c4_is_differentiable_primal(self):
-        obj, arrays, config = _build_ccpr()
-        arrays, config = _add_gradient_config(arrays, config, obj)
+        obj, arrays, config = _ccpr_checkpointed()
         key = jax.random.PRNGKey(99)
         c4 = arrays.dispersive_c4
         assert c4 is not None
         loss_fn = _make_disp_loss_fn("c4")
         ad, fd, rel_err, diff, idx = _coef_fd_check(
-            c4, loss_fn, arrays, obj, config, key, h_scale=1e-2, h_floor=1e-6, fdtd_impl=reversible_fdtd
+            c4, loss_fn, arrays, obj, config, key, h_scale=1e-2, h_floor=1e-6, fdtd_impl=checkpointed_fdtd
         )
         assert rel_err < 0.1 or diff < 1e-5, (
             f"AD vs FD mismatch (c4) at {idx}: AD={float(ad):.6e}, FD={float(fd):.6e}, rel_err={float(rel_err):.3e}"
         )
+
+
+# ── Tests: dispersive materials reject the reversible gradient method ──────────
+
+
+class TestDispersiveReversibleRejected:
+    """Dispersive time-reversal is not supported. Every entry point that would
+    reach the reverse ADE update must raise ``NotImplementedError``, at each of
+    the three guard layers: ``place_objects``, the FDTD entry points, and
+    ``update_E_reverse`` (reached through the public ``backward`` API).
+    """
+
+    _MATCH = "under active development"
+
+    def test_place_objects_raises_with_reversible_config(self):
+        """Earliest guard: a reversible gradient config present at placement."""
+        base = SimulationConfig(
+            time=_SIM_TIME,
+            grid=UniformGrid(spacing=_RESOLUTION),
+            backend="cpu",
+            dtype=jnp.float32,
+            courant_factor=0.99,
+            gradient_config=GradientConfig(method="reversible", recorder=Recorder(modules=[])),
+        )
+        volume = fdtdx.SimulationVolume(partial_grid_shape=(_VOLUME_CELLS, _VOLUME_CELLS, _VOLUME_CELLS))
+        slab = fdtdx.UniformMaterialObject(
+            name="slab",
+            partial_grid_shape=(_VOLUME_CELLS, _VOLUME_CELLS, _VOLUME_CELLS // 2),
+            material=fdtdx.Material(
+                permittivity=2.0,
+                dispersion=fdtdx.DispersionModel(
+                    poles=(fdtdx.LorentzPole(resonance_frequency=2e15, damping=1e13, delta_epsilon=1.5),),
+                ),
+            ),
+        )
+        with pytest.raises(NotImplementedError, match=self._MATCH):
+            fdtdx.place_objects(
+                object_list=[volume, slab],
+                config=base,
+                constraints=[slab.place_at_center(volume)],
+                key=jax.random.PRNGKey(0),
+            )
+
+    def test_reversible_fdtd_raises(self):
+        """Second guard: the gradient config was swapped in after placement."""
+        obj, arrays, config = _build_lossy_dispersive_scene()
+        arrays, config = _add_gradient_config(arrays, config, obj)
+        assert config.gradient_config.method == "reversible"
+        with pytest.raises(NotImplementedError, match=self._MATCH):
+            reversible_fdtd(arrays, obj, config, jax.random.PRNGKey(0), show_progress=False)
+
+    def test_run_fdtd_raises(self):
+        """``run_fdtd`` dispatches to ``reversible_fdtd`` and surfaces the guard."""
+        obj, arrays, config = _build_lossy_dispersive_scene()
+        arrays, config = _add_gradient_config(arrays, config, obj)
+        with pytest.raises(NotImplementedError, match=self._MATCH):
+            fdtdx.run_fdtd(arrays=arrays, objects=obj, config=config, show_progress=False)
+
+    def test_backward_raises(self):
+        """Third guard: the public reverse-propagation API, inside ``update_E_reverse``."""
+        obj, arrays, config = _build_lossy_dispersive_scene()
+        # backward() restores recorded interfaces first, which needs a recorder.
+        arrays, config = _add_gradient_config(arrays, config, obj)
+        assert arrays.fields.dispersive_P_curr is not None
+        with pytest.raises(NotImplementedError, match=self._MATCH):
+            backward(
+                state=(jnp.asarray(1, dtype=jnp.int32), arrays),
+                config=config,
+                objects=obj,
+                key=jax.random.PRNGKey(0),
+                record_detectors=False,
+                reset_fields=False,
+            )

--- a/tests/unit/fdtd/test_forward.py
+++ b/tests/unit/fdtd/test_forward.py
@@ -307,12 +307,6 @@ class TestForwardSingleArgsWrapper:
                 psi_H=arrays.fields.psi_H,
                 inv_permittivities=arrays.inv_permittivities,
                 inv_permeabilities=arrays.inv_permeabilities,
-                dispersive_P_curr=None,
-                dispersive_P_prev=None,
-                dispersive_c1=None,
-                dispersive_c2=None,
-                dispersive_c3=None,
-                dispersive_c4=None,
                 detector_states=arrays.detector_states,
                 recording_state=arrays.recording_state,
                 config=config,
@@ -339,8 +333,8 @@ class TestForwardSingleArgsWrapper:
             assert call_kwargs["record_boundaries"] is True
             assert call_kwargs["simulate_boundaries"] is True
 
-    def test_wrapper_returns_all_14_unpacked_fields(self, arrays, config, objects, key):
-        """Wrapper unpacks the returned SimulationState into 15 individual values."""
+    def test_wrapper_returns_all_unpacked_fields(self, arrays, config, objects, key):
+        """Wrapper unpacks the returned SimulationState into 9 individual values."""
         result_arrays = ArrayContainer(
             fields=FieldState(
                 E=arrays.fields.E * 2.0,
@@ -364,12 +358,6 @@ class TestForwardSingleArgsWrapper:
                 psi_H=arrays.fields.psi_H,
                 inv_permittivities=arrays.inv_permittivities,
                 inv_permeabilities=arrays.inv_permeabilities,
-                dispersive_P_curr=None,
-                dispersive_P_prev=None,
-                dispersive_c1=None,
-                dispersive_c2=None,
-                dispersive_c3=None,
-                dispersive_c4=None,
                 detector_states=arrays.detector_states,
                 recording_state=arrays.recording_state,
                 config=config,
@@ -380,7 +368,7 @@ class TestForwardSingleArgsWrapper:
                 simulate_boundaries=False,
             )
 
-            assert len(result) == 15
+            assert len(result) == 9
             assert result[0] == 7  # time_step
             assert jnp.array_equal(result[1], result_arrays.fields.E)
             assert jnp.array_equal(result[2], result_arrays.fields.H)
@@ -388,11 +376,5 @@ class TestForwardSingleArgsWrapper:
             assert result[4] is result_arrays.fields.psi_H
             assert jnp.array_equal(result[5], result_arrays.inv_permittivities)
             assert jnp.array_equal(result[6], result_arrays.inv_permeabilities)
-            assert result[7] is result_arrays.fields.dispersive_P_curr
-            assert result[8] is result_arrays.fields.dispersive_P_prev
-            assert result[9] is result_arrays.dispersive_c1
-            assert result[10] is result_arrays.dispersive_c2
-            assert result[11] is result_arrays.dispersive_c3
-            assert result[12] is result_arrays.dispersive_c4
-            assert result[13] is result_arrays.detector_states
-            assert result[14] is result_arrays.recording_state
+            assert result[7] is result_arrays.detector_states
+            assert result[8] is result_arrays.recording_state

--- a/tests/unit/fdtd/test_wrapper.py
+++ b/tests/unit/fdtd/test_wrapper.py
@@ -16,10 +16,6 @@ class TestRunFdtd:
     @pytest.fixture
     def setup(self):
         mock_arrays = Mock(spec=ArrayContainer)
-        # non-dispersive scene: the reversible-method tensor-dispersion guard
-        # inspects these before dispatching
-        mock_arrays.dispersive_c1 = None
-        mock_arrays.dispersive_c3 = None
         mock_objects = Mock(spec=ObjectContainer)
         mock_config = Mock(spec=SimulationConfig)
         mock_config.gradient_config = None

--- a/tests/unit/test_dispersion.py
+++ b/tests/unit/test_dispersion.py
@@ -134,15 +134,20 @@ class TestComputePoleCoefficients:
         # c3 for Drude should be non-zero because coupling_sq = omega_p**2
         assert c3[1] > 0
 
-    def test_gamma_dt_at_least_two_raises(self):
-        # gamma * dt >= 2 drives c2 to 0 (and positive beyond), so the reversible
-        # (reverse-time) ADE update -- which divides by c2 -- is no longer well
-        # conditioned. This is a reversibility conditioning bound, separate from
-        # the forward unit-circle (Jury) criterion omega_0 * dt < 2; note |c2| < 1
-        # itself holds for every gamma * dt > 0.
-        p = LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0)
-        with pytest.raises(ValueError, match="gamma"):
-            compute_pole_coefficients((p,), dt=2.0 / p.gamma)
+    def test_large_gamma_dt_is_accepted(self):
+        # gamma * dt >= 2 drives c2 to 0 (and positive beyond) but keeps the
+        # forward recurrence inside the unit circle: |c2| < 1 holds for every
+        # gamma * dt > 0, and the binding Jury bound is omega_0 * dt < 2. It is
+        # therefore not rejected (it used to be, as a conditioning bound for the
+        # reverse-time ADE update, which no longer exists).
+        # Heavily overdamped (gamma >> omega_0) so that gamma * dt == 2 while
+        # omega_0 * dt stays far below the Jury bound.
+        p = LorentzPole(resonance_frequency=1e12, damping=1e16, delta_epsilon=2.0)
+        dt = 2.0 / p.gamma
+        assert p.omega_0 * dt < 2.0
+        c1, c2, c3, _ = compute_pole_coefficients((p,), dt=dt)
+        assert np.all(np.isfinite(c1)) and np.all(np.isfinite(c3))
+        assert np.allclose(c2, 0.0), "gamma * dt == 2 must put c2 exactly at zero"
 
     def test_omega0_dt_at_least_two_raises(self):
         # omega_0 * dt >= 2 violates the forward Jury bound |c1| < 1 - c2 (the
@@ -507,11 +512,12 @@ class TestPerAxisCoefficients:
         with pytest.raises(ValueError, match="per-axis"):
             compute_pole_coefficients((p,), dt=1e-17)
 
-    def test_per_axis_stability_check_names_axis(self):
-        # gamma * dt >= 2 only on the y axis must raise and identify the axis.
+    def test_per_axis_large_gamma_dt_is_accepted(self):
+        # A large gamma on the y axis alone is not a stability violation (only
+        # omega_0 * dt >= 2 is); the coefficients must stay finite.
         p = LorentzPole(resonance_frequency=1e15, damping=(1e13, 3e17, 1e13), delta_epsilon=1.0)
-        with pytest.raises(ValueError, match="axis y"):
-            compute_pole_coefficients_per_axis((p,), dt=1e-17)
+        c1, c2, c3, _ = compute_pole_coefficients_per_axis((p,), dt=1e-17)
+        assert np.all(np.isfinite(c1)) and np.all(np.isfinite(c2)) and np.all(np.isfinite(c3))
 
     def test_per_axis_omega0_stability_check_names_axis(self):
         # omega_0 * dt >= 2 only on the z axis must raise and identify the axis.


### PR DESCRIPTION
remove untested and unstable codepaths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that dispersive materials support checkpointed gradients only; reversible gradients now raise an error.
  * Updated stability guidance to use the forward frequency-step bound and clarified damping behavior.

* **Bug Fixes**
  * Removed obsolete dispersive cache handling.
  * Improved validation and error reporting for unsupported reversible dispersive simulations.
  * Preserved finite coefficient generation for larger damping time steps when the frequency stability limit is met.

* **Tests**
  * Expanded coverage for checkpointed dispersive gradients, stability validation, and reversible-method rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->