### PR TITLE
feat: temporal apodization windows for PhasorDetector

### DIFF
--- a/docs/source/07_api.rst
+++ b/docs/source/07_api.rst
@@ -67,6 +67,7 @@ API
     fdtdx.GaussianPlaneSource
     fdtdx.GaussianPulseProfile
     fdtdx.GaussianSmoothing2D
+    fdtdx.GaussianWindow
     fdtdx.GradientConfig
     fdtdx.GridCoordinateConstraint
     fdtdx.HorizontalSymmetry2D
@@ -130,8 +131,10 @@ API
     fdtdx.SubpixelSmoothedProjection
     fdtdx.TanhProjection
     fdtdx.TemporalProfile
+    fdtdx.TemporalWindow
     fdtdx.TFSFPlaneSourceRegion
     fdtdx.TreeClass
+    fdtdx.TukeyWindow
     fdtdx.unfold_array
     fdtdx.unfold_detector_states
     fdtdx.unfold_fields
@@ -142,9 +145,6 @@ API
     fdtdx.VerticalSymmetry2D
     fdtdx.VerticalSymmetry3D
     fdtdx.WaveCharacter
-    fdtdx.WindowProfile
-    fdtdx.TukeyWindowProfile
-    fdtdx.GaussianWindowProfile
     fdtdx.wavelength_to_period
     fdtdx.GDSLayerObject
     fdtdx.GDSLayerSpec

--- a/docs/source/07_api.rst
+++ b/docs/source/07_api.rst
@@ -142,6 +142,9 @@ API
     fdtdx.VerticalSymmetry2D
     fdtdx.VerticalSymmetry3D
     fdtdx.WaveCharacter
+    fdtdx.WindowProfile
+    fdtdx.TukeyWindowProfile
+    fdtdx.GaussianWindowProfile
     fdtdx.wavelength_to_period
     fdtdx.GDSLayerObject
     fdtdx.GDSLayerSpec

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -34,7 +34,7 @@ from fdtdx.core.physics.metrics import (
 from fdtdx.core.physics.modes import compute_mode
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.core.wavelength import WaveCharacter
-from fdtdx.core.window import GaussianWindowProfile, TukeyWindowProfile, WindowProfile
+from fdtdx.core.window import GaussianWindow, TemporalWindow, TukeyWindow
 from fdtdx.dispersion import (
     CCPRPole,
     DispersionModel,
@@ -206,7 +206,7 @@ __all__ = [
     "GaussianPlaneSource",
     "GaussianPulseProfile",
     "GaussianSmoothing2D",
-    "GaussianWindowProfile",
+    "GaussianWindow",
     "GradientConfig",
     "GridCoordinateConstraint",
     "HorizontalSymmetry2D",
@@ -256,15 +256,15 @@ __all__ = [
     "TFSFPlaneSourceRegion",
     "TanhProjection",
     "TemporalProfile",
+    "TemporalWindow",
     "TreeClass",
-    "TukeyWindowProfile",
+    "TukeyWindow",
     "UniformGrid",
     "UniformMaterialObject",
     "UniformPlaneSource",
     "VerticalSymmetry2D",
     "VerticalSymmetry3D",
     "WaveCharacter",
-    "WindowProfile",
     "apply_params",
     "autoinit",
     "boundary_objects_from_config",

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -34,6 +34,7 @@ from fdtdx.core.physics.metrics import (
 from fdtdx.core.physics.modes import compute_mode
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.core.wavelength import WaveCharacter
+from fdtdx.core.window import GaussianWindowProfile, TukeyWindowProfile, WindowProfile
 from fdtdx.dispersion import (
     CCPRPole,
     DispersionModel,
@@ -205,6 +206,7 @@ __all__ = [
     "GaussianPlaneSource",
     "GaussianPulseProfile",
     "GaussianSmoothing2D",
+    "GaussianWindowProfile",
     "GradientConfig",
     "GridCoordinateConstraint",
     "HorizontalSymmetry2D",
@@ -255,12 +257,14 @@ __all__ = [
     "TanhProjection",
     "TemporalProfile",
     "TreeClass",
+    "TukeyWindowProfile",
     "UniformGrid",
     "UniformMaterialObject",
     "UniformPlaneSource",
     "VerticalSymmetry2D",
     "VerticalSymmetry3D",
     "WaveCharacter",
+    "WindowProfile",
     "apply_params",
     "autoinit",
     "boundary_objects_from_config",

--- a/src/fdtdx/core/window.py
+++ b/src/fdtdx/core/window.py
@@ -1,0 +1,120 @@
+"""Temporal envelope shapes and detector apodization windows.
+
+The envelope functions are the single source of truth for the time-domain shapes used by
+the source temporal profiles (``GaussianPulseProfile``'s Gaussian envelope,
+``SingleFrequencyProfile``'s linear ramp) and by the detector apodization windows below.
+"""
+
+from abc import ABC, abstractmethod
+
+import jax
+import jax.numpy as jnp
+
+from fdtdx.core.jax.pytrees import TreeClass, autoinit, frozen_field
+
+
+def gaussian_envelope(
+    time: jax.Array,
+    center: float | jax.Array,
+    sigma: float | jax.Array,
+) -> jax.Array:
+    """Gaussian envelope ``exp(-(t - center)^2 / (2 sigma^2))``."""
+    return jnp.exp(-((time - center) ** 2) / (2.0 * sigma**2))
+
+
+def linear_rampup(
+    time: jax.Array,
+    ramp_duration: float | jax.Array,
+) -> jax.Array:
+    """Linear ramp from 0 to 1 over ``[0, ramp_duration]``, clamped to ``[0, 1]``."""
+    return jnp.clip(time / ramp_duration, 0.0, 1.0)
+
+
+def tukey_envelope(
+    time: jax.Array,
+    start: float | jax.Array,
+    end: float | jax.Array,
+    alpha: float = 0.5,
+) -> jax.Array:
+    """Tukey (tapered-cosine) window over ``[start, end]``.
+
+    A flat top of value 1 with cosine-tapered edges occupying a fraction ``alpha`` of the
+    window (``alpha/2`` at each end). ``alpha=0`` is a rectangular window over
+    ``[start, end]``; ``alpha=1`` is a Hann window. Zero outside ``[start, end]``.
+    """
+    duration = end - start
+    x = (time - start) / duration
+    in_range = (x >= 0.0) & (x <= 1.0)
+    if alpha <= 0.0:
+        return jnp.where(in_range, 1.0, 0.0)
+
+    half = alpha / 2.0
+    left = 0.5 * (1.0 + jnp.cos(jnp.pi * (x / half - 1.0)))
+    right = 0.5 * (1.0 + jnp.cos(jnp.pi * ((x - 1.0) / half + 1.0)))
+    window = jnp.where(x < half, left, jnp.where(x > 1.0 - half, right, 1.0))
+    return jnp.where(in_range, window, 0.0)
+
+
+class WindowProfile(TreeClass, ABC):
+    """Base class for carrier-free temporal windows used as detector apodization."""
+
+    @abstractmethod
+    def get_window(self, time: jax.Array) -> jax.Array:
+        """Evaluate the window at the given time points.
+
+        Args:
+            time (jax.Array): Time points in seconds.
+
+        Returns:
+            jax.Array: Non-negative window weights, same shape as ``time``.
+        """
+        raise NotImplementedError()
+
+
+@autoinit
+class GaussianWindowProfile(WindowProfile):
+    """Gaussian window ``exp(-(t - center_time)^2 / (2 sigma_time^2))``.
+
+    Shares its shape with :class:`~fdtdx.GaussianPulseProfile` via
+    :func:`gaussian_envelope`, but carries no oscillating carrier.
+    """
+
+    #: Center of the Gaussian window in seconds.
+    center_time: float = frozen_field()
+
+    #: Standard deviation of the Gaussian window in seconds. Must be positive.
+    sigma_time: float = frozen_field()
+
+    def __post_init__(self):
+        if not self.sigma_time > 0:
+            raise ValueError(f"sigma_time must be positive, got {self.sigma_time}")
+
+    def get_window(self, time: jax.Array) -> jax.Array:
+        return gaussian_envelope(time, self.center_time, self.sigma_time)
+
+
+@autoinit
+class TukeyWindowProfile(WindowProfile):
+    """Tukey (tapered-cosine) window over ``[start_time, end_time]``.
+
+    Flat top of value 1 with cosine-tapered edges occupying a fraction ``alpha`` of the
+    window (``alpha=1`` is a Hann window, ``alpha=0`` a rectangular one).
+    """
+
+    #: Start of the window in seconds.
+    start_time: float = frozen_field()
+
+    #: End of the window in seconds.
+    end_time: float = frozen_field()
+
+    #: Fraction of the window occupied by the cosine tapers (0 = rectangular, 1 = Hann).
+    alpha: float = frozen_field(default=0.5)
+
+    def __post_init__(self):
+        if not self.end_time > self.start_time:
+            raise ValueError(f"end_time must exceed start_time, got {self.start_time} and {self.end_time}")
+        if not 0.0 <= self.alpha <= 1.0:
+            raise ValueError(f"alpha must lie in [0, 1], got {self.alpha}")
+
+    def get_window(self, time: jax.Array) -> jax.Array:
+        return tukey_envelope(time, self.start_time, self.end_time, self.alpha)

--- a/src/fdtdx/core/window.py
+++ b/src/fdtdx/core/window.py
@@ -55,7 +55,7 @@ def tukey_envelope(
     return jnp.where(in_range, window, 0.0)
 
 
-class WindowProfile(TreeClass, ABC):
+class TemporalWindow(TreeClass, ABC):
     """Base class for carrier-free temporal windows used as detector apodization."""
 
     @abstractmethod
@@ -72,7 +72,7 @@ class WindowProfile(TreeClass, ABC):
 
 
 @autoinit
-class GaussianWindowProfile(WindowProfile):
+class GaussianWindow(TemporalWindow):
     """Gaussian window ``exp(-(t - center_time)^2 / (2 sigma_time^2))``.
 
     Shares its shape with :class:`~fdtdx.GaussianPulseProfile` via
@@ -94,7 +94,7 @@ class GaussianWindowProfile(WindowProfile):
 
 
 @autoinit
-class TukeyWindowProfile(WindowProfile):
+class TukeyWindow(TemporalWindow):
     """Tukey (tapered-cosine) window over ``[start_time, end_time]``.
 
     Flat top of value 1 with cosine-tapered edges occupying a fraction ``alpha`` of the

--- a/src/fdtdx/objects/detectors/phasor.py
+++ b/src/fdtdx/objects/detectors/phasor.py
@@ -8,7 +8,7 @@ from loguru import logger
 from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import autoinit, field, frozen_field, frozen_private_field, private_field
 from fdtdx.core.wavelength import WaveCharacter
-from fdtdx.core.window import WindowProfile
+from fdtdx.core.window import TemporalWindow
 from fdtdx.objects.detectors.detector import Detector, DetectorState
 from fdtdx.typing import SliceTuple3D
 
@@ -65,7 +65,7 @@ class PhasorDetector(Detector):
     #: suppresses the spectral leakage that the gate's discontinuity causes; the
     #: continuous-mode scale is corrected by the window's coherent gain so reconstructed
     #: amplitudes stay correct.
-    apodization: WindowProfile | None = frozen_field(default=None)
+    apodization: TemporalWindow | None = frozen_field(default=None)
 
     #: Per-time-step window weights (on-mask times apodization), length ``time_steps_total``.
     _window_at_time_step_arr: jax.Array = private_field()
@@ -78,9 +78,9 @@ class PhasorDetector(Detector):
     ):
         if self.dtype not in [jnp.complex64, jnp.complex128]:
             raise Exception(f"Invalid dtype in PhasorDetector: {self.dtype}")
-        if self.apodization is not None and not isinstance(self.apodization, WindowProfile):
+        if self.apodization is not None and not isinstance(self.apodization, TemporalWindow):
             raise Exception(
-                f"apodization must be a WindowProfile, got {type(self.apodization).__name__}. "
+                f"apodization must be a TemporalWindow, got {type(self.apodization).__name__}. "
                 "Source temporal profiles are not valid windows."
             )
 

--- a/src/fdtdx/objects/detectors/phasor.py
+++ b/src/fdtdx/objects/detectors/phasor.py
@@ -6,8 +6,9 @@ import jax.numpy as jnp
 from loguru import logger
 
 from fdtdx.config import SimulationConfig
-from fdtdx.core.jax.pytrees import autoinit, field, frozen_field, frozen_private_field
+from fdtdx.core.jax.pytrees import autoinit, field, frozen_field, frozen_private_field, private_field
 from fdtdx.core.wavelength import WaveCharacter
+from fdtdx.core.window import WindowProfile
 from fdtdx.objects.detectors.detector import Detector, DetectorState
 from fdtdx.typing import SliceTuple3D
 
@@ -44,8 +45,9 @@ class PhasorDetector(Detector):
     #: Whether to plot the measured data. Defaults to False.
     plot: bool = frozen_field(default=False)
 
-    #: Scaling of the resulting phasor. In continuous mode, the result is scaled by a factor of 2 / N, where N is
-    #: the number of time steps recorded. This allows accurate reconstruction of a continuous signal.
+    #: Scaling of the resulting phasor. In continuous mode, the result is scaled by the window's
+    #: coherent gain 2 / sum(w), which is 2 / N with N the number of time steps recorded when no
+    #: ``apodization`` is set. This allows accurate reconstruction of a continuous signal.
     #: In pulse mode, the result is not scaled.
     scaling_mode: Literal["continuous", "pulse"] = frozen_field(default="continuous")
 
@@ -58,11 +60,29 @@ class PhasorDetector(Detector):
     #: Concrete recording stride, resolved from dft_subsample at placement (1 = every active step).
     _dft_stride: int = frozen_private_field(default=1)
 
+    #: Optional smooth temporal **apodization** window applied to each sample before the DFT.
+    #: ``None`` (default) is a hard rectangular gate over the recorded steps. A window
+    #: suppresses the spectral leakage that the gate's discontinuity causes; the
+    #: continuous-mode scale is corrected by the window's coherent gain so reconstructed
+    #: amplitudes stay correct.
+    apodization: WindowProfile | None = frozen_field(default=None)
+
+    #: Per-time-step window weights (on-mask times apodization), length ``time_steps_total``.
+    _window_at_time_step_arr: jax.Array = private_field()
+
+    #: Sum of the window weights over the recorded steps (coherent gain times N).
+    _window_sum: float = frozen_private_field()
+
     def __post_init__(
         self,
     ):
         if self.dtype not in [jnp.complex64, jnp.complex128]:
             raise Exception(f"Invalid dtype in PhasorDetector: {self.dtype}")
+        if self.apodization is not None and not isinstance(self.apodization, WindowProfile):
+            raise Exception(
+                f"apodization must be a WindowProfile, got {type(self.apodization).__name__}. "
+                "Source temporal profiles are not valid windows."
+            )
 
     @property
     def _angular_frequencies(self) -> jax.Array:
@@ -115,20 +135,41 @@ class PhasorDetector(Detector):
                 )
         # Store the concrete stride so update() reads a plain int (no host concretization under jit).
         self = self.aset("_dft_stride", stride, create_new_ok=True)
+
+        # Build the window from the (already thinned) on-mask, so its coherent gain is summed
+        # over exactly the steps that get recorded.
+        on_arr = self._is_on_at_time_step_arr  # bool, (time_steps_total,)
+        if self.apodization is None:
+            window = on_arr.astype(jnp.float32)
+        else:
+            time = jnp.arange(self._config.time_steps_total) * self._config.time_step_duration
+            window = self.apodization.get_window(time) * on_arr.astype(jnp.float32)
+        self = self.aset("_window_at_time_step_arr", window, create_new_ok=True)
+        window_sum = float(jnp.sum(window))
+        if not math.isfinite(window_sum) or window_sum <= 0.0:
+            # e.g. a window whose support lies entirely outside the recorded interval, which
+            # would make the continuous-mode 2 / sum(w) scale divide by zero.
+            raise Exception(
+                f"Detector '{self.name}': the apodization window sums to {window_sum} over the recorded "
+                "time steps; it must be finite and positive. Check that the window's support overlaps "
+                "the detector's active interval."
+            )
+        self = self.aset("_window_sum", window_sum, create_new_ok=True)
         return self
 
     def _static_scale(self) -> float | int:
         """Computes the static scale factor for the configured scaling mode.
 
-        In continuous mode, the result is scaled by 2 / N with N the number of recorded time
-        steps. In pulse mode, each kept sample is weighted by the dft_subsample stride so that
+        In continuous mode, the result is scaled by the window's coherent gain ``2 / sum(w)``,
+        which reduces to ``2 / N`` with N the number of recorded time steps when no
+        apodization is set. In pulse mode, each kept sample is weighted by the dft_subsample stride so that
         subsampled recording matches the every-step DFT sum.
 
         Returns:
             float | int: Scale factor applied to each recorded sample.
         """
         if self.scaling_mode == "continuous":
-            return 2 / self.num_time_steps_recorded
+            return 2 / self._window_sum
         if self.scaling_mode == "pulse":
             return self._dft_stride
         raise Exception(f"Invalid scaling mode: {self.scaling_mode=}")
@@ -158,6 +199,7 @@ class PhasorDetector(Detector):
         del inv_permeability, inv_permittivity
         time_passed = time_step * self._config.time_step_duration
         static_scale = self._static_scale()
+        window_weight = self._window_at_time_step_arr[time_step]
 
         fields = []
         if "Ex" in self.components:
@@ -180,7 +222,7 @@ class PhasorDetector(Detector):
         phasors = jnp.exp(1j * phase_angles)  # Shape: (num_freqs,)
         # Reshape phasors to (num_freqs, 1, 1, 1, 1) for proper broadcasting with EH (num_components, x, y, z)
         phasors = phasors.reshape((len(self._angular_frequencies),) + (1,) * EH.ndim)
-        new_phasors = EH * phasors * static_scale  # Shape: (num_freqs, num_components, *grid_shape)
+        new_phasors = EH * phasors * static_scale * window_weight  # Shape: (num_freqs, num_components, *grid_shape)
 
         if self.reduce_volume:
             # Average over spatial dimensions using physical cell volumes.

--- a/src/fdtdx/objects/sources/profile.py
+++ b/src/fdtdx/objects/sources/profile.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from fdtdx.core.jax.pytrees import TreeClass, autoinit, field, frozen_field
 from fdtdx.core.wavelength import WaveCharacter
+from fdtdx.core.window import gaussian_envelope, linear_rampup
 
 
 def _unit_scale(max_abs_value: float, units: tuple[tuple[str, float], ...]) -> tuple[str, float]:
@@ -268,7 +269,7 @@ class SingleFrequencyProfile(TemporalProfile):
         time_phase = 2 * jnp.pi * time / period + phase_shift + self.phase_shift
         raw_amplitude = jnp.real(jnp.exp(-1j * time_phase))
         startup_time = self.num_startup_periods * period
-        factor = jnp.clip(time / startup_time, 0, 1)
+        factor = linear_rampup(time, startup_time)
         return factor * raw_amplitude
 
 
@@ -335,7 +336,7 @@ class GaussianPulseProfile(TemporalProfile):
         t0 = 6 * sigma_t  # Offset peak to avoid discontinuity at t=0
 
         # Gaussian envelope
-        envelope = jnp.exp(-((time - t0) ** 2) / (2 * sigma_t**2))
+        envelope = gaussian_envelope(time, t0, sigma_t)
 
         # Carrier wave (including phase shift from center_wave)
         carrier_phase = 2 * jnp.pi * center_frequency_hz * time + phase_shift + self.center_wave.phase_shift

--- a/tests/simulation/physics/detectors/test_apodization_leakage.py
+++ b/tests/simulation/physics/detectors/test_apodization_leakage.py
@@ -1,0 +1,139 @@
+"""Physics simulation test: PhasorDetector apodization suppresses spectral leakage.
+
+A CW source is still ringing when the detector stops recording, so the rectangular gate ends
+on a discontinuity and smears the tone's power across neighbouring frequencies. A Tukey
+window tapers the ends and suppresses that, while the coherent-gain correction keeps the
+on-frequency amplitude unchanged.
+
+Both detectors are gated to the steady-state part of the run: the source's linear startup
+ramp makes the field non-stationary for the first few periods, and a rectangular gate weights
+that transient equally while a taper de-weights it, which would otherwise show up as an
+amplitude difference unrelated to leakage.
+
+Probe frequencies sit at *fractional* bin offsets. Integer offsets land exactly on the nulls
+of the rectangular window's kernel, which hides the leakage entirely.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import fdtdx
+from fdtdx.constants import c as c0
+
+_WAVELENGTH = 1e-6
+_RESOLUTION = 50e-9
+_PML_CELLS = 10
+_DOMAIN_XY = 5 * _RESOLUTION
+_DOMAIN_Z = 4e-6
+_SIM_TIME = 120e-15
+
+_SOURCE_Z = _PML_CELLS + 2
+_DET_Z = _SOURCE_Z + 10
+
+_RECORD_START = 40e-15  # well past the source's 13.3 fs startup ramp and the transit time
+
+_BIN_OFFSETS = (2.5, 4.5)  # fractional DFT bins away from the tone
+
+
+def _build():
+    config = fdtdx.SimulationConfig(grid=fdtdx.UniformGrid(spacing=_RESOLUTION), time=_SIM_TIME, dtype=jnp.float32)
+    duration = (config.time_steps_total - 1) * config.time_step_duration
+    # Bins are set by the *recorded* interval, not the whole run.
+    bin_hz = 1.0 / (duration - _RECORD_START)
+    f0 = c0 / _WAVELENGTH
+    probe_freqs = [f0] + [f0 + off * bin_hz for off in _BIN_OFFSETS]
+    waves = tuple(fdtdx.WaveCharacter(wavelength=float(c0 / f)) for f in probe_freqs)
+
+    objects, constraints = [], []
+    volume = fdtdx.SimulationVolume(partial_real_shape=(_DOMAIN_XY, _DOMAIN_XY, _DOMAIN_Z))
+    objects.append(volume)
+    bound_cfg = fdtdx.BoundaryConfig.from_uniform_bound(
+        thickness=_PML_CELLS,
+        override_types={"min_x": "periodic", "max_x": "periodic", "min_y": "periodic", "max_y": "periodic"},
+    )
+    bound_dict, c_list = fdtdx.boundary_objects_from_config(bound_cfg, volume)
+    constraints.extend(c_list)
+    objects.extend(bound_dict.values())
+
+    source = fdtdx.UniformPlaneSource(
+        name="source",
+        partial_grid_shape=(None, None, 1),
+        wave_character=fdtdx.WaveCharacter(wavelength=_WAVELENGTH),
+        direction="+",
+        fixed_E_polarization_vector=(1, 0, 0),
+    )
+    constraints.extend(
+        [
+            source.same_size(volume, axes=(0, 1)),
+            source.place_at_center(volume, axes=(0, 1)),
+            source.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_SOURCE_Z,)),
+        ]
+    )
+    objects.append(source)
+
+    # The window spans exactly the recorded interval, so it tapers both of its edges.
+    window = fdtdx.TukeyWindowProfile(start_time=_RECORD_START, end_time=duration, alpha=0.5)
+    switch = fdtdx.OnOffSwitch(start_time=_RECORD_START)
+    for name, apodization in (("rect", None), ("tukey", window)):
+        det = fdtdx.PhasorDetector(
+            name=name,
+            partial_grid_shape=(None, None, 1),
+            wave_characters=waves,
+            reduce_volume=True,
+            apodization=apodization,
+            switch=switch,
+        )
+        constraints.extend(
+            [
+                det.same_size(volume, axes=(0, 1)),
+                det.place_at_center(volume, axes=(0, 1)),
+                det.set_grid_coordinates(axes=(2,), sides=("-",), coordinates=(_DET_Z,)),
+            ]
+        )
+        objects.append(det)
+    return objects, constraints, config
+
+
+@pytest.fixture(scope="module")
+def spectra():
+    """Run once; return ``{detector: |phasor| per probe frequency}`` for the Ex component."""
+    objects, constraints, config = _build()
+    key = jax.random.PRNGKey(0)
+    oc, arrays, params, config, _ = fdtdx.place_objects(
+        object_list=objects, config=config, constraints=constraints, key=key
+    )
+    arrays, oc, _ = fdtdx.apply_params(arrays, oc, params, key)
+    _, arrays = fdtdx.run_fdtd(arrays=arrays, objects=oc, config=config, key=key)
+    out = {}
+    for name in ("rect", "tukey"):
+        phasor = np.asarray(arrays.detector_states[name]["phasor"])
+        out[name] = np.abs(phasor[0, :, 0])  # (num_freqs,) for Ex
+    print({k: np.array2string(v, precision=4) for k, v in out.items()})
+    return out
+
+
+def test_apodization_preserves_on_frequency_amplitude(spectra):
+    """The 2 / sum(w) coherent-gain correction leaves the tone's amplitude unchanged.
+
+    Measured agreement is 0.05% for a stationary signal, so a missing or wrong gain
+    correction (the window's mean weight is ~0.75, a 33% error) cannot pass.
+    """
+    rect, tukey = spectra["rect"][0], spectra["tukey"][0]
+    assert rect > 0
+    assert tukey == pytest.approx(rect, rel=0.01), f"on-frequency amplitude changed: {rect:.4e} -> {tukey:.4e}"
+
+
+@pytest.mark.parametrize("index,offset", list(enumerate(_BIN_OFFSETS, start=1)))
+def test_apodization_suppresses_off_frequency_leakage(spectra, index, offset):
+    """Off-tone response drops once the recording edges are tapered.
+
+    Measured suppression is 3.0x at 2.5 bins and 3.9x at 4.5 bins; requiring 2x leaves
+    headroom while still failing if the window is not actually applied to the DFT.
+    """
+    rect = spectra["rect"][index] / spectra["rect"][0]
+    tukey = spectra["tukey"][index] / spectra["tukey"][0]
+    # The leakage must genuinely be there, or "suppression" would be vacuous.
+    assert rect > 0.03, f"{offset} bins: no rectangular leakage to suppress ({rect:.3e})"
+    assert tukey < 0.5 * rect, f"{offset} bins: Tukey {tukey:.3e} vs rectangular {rect:.3e} (need <2x)"

--- a/tests/simulation/physics/detectors/test_apodization_leakage.py
+++ b/tests/simulation/physics/detectors/test_apodization_leakage.py
@@ -116,23 +116,40 @@ def spectra():
 def test_apodization_preserves_on_frequency_amplitude(spectra):
     """The 2 / sum(w) coherent-gain correction leaves the tone's amplitude unchanged.
 
-    Measured agreement is 0.05% for a stationary signal, so a missing or wrong gain
-    correction (the window's mean weight is ~0.75, a 33% error) cannot pass.
+    Measured agreement is 8.5e-4 relative at these settings and holds to 5.3e-4 under a 4x
+    refinement in space and time, so the deviation is a numerical floor (float32 DFT
+    accumulation plus the 2w residual), not a discretization artifact. CPU and GPU agree to
+    1.1e-7. A missing or wrong gain correction (the window's mean weight is 1 - alpha/2 = 0.75,
+    a 25% error) misses by ~300x the tolerance.
     """
     rect, tukey = spectra["rect"][0], spectra["tukey"][0]
     assert rect > 0
-    assert tukey == pytest.approx(rect, rel=0.01), f"on-frequency amplitude changed: {rect:.4e} -> {tukey:.4e}"
+    assert tukey == pytest.approx(rect, rel=2e-3), f"on-frequency amplitude changed: {rect:.4e} -> {tukey:.4e}"
 
 
 @pytest.mark.parametrize("index,offset", list(enumerate(_BIN_OFFSETS, start=1)))
 def test_apodization_suppresses_off_frequency_leakage(spectra, index, offset):
     """Off-tone response drops once the recording edges are tapered.
 
-    Measured suppression is 3.0x at 2.5 bins and 3.9x at 4.5 bins; requiring 2x leaves
-    headroom while still failing if the window is not actually applied to the DFT.
+    Measured suppression at these settings is 3.01x at 2.5 bins and 3.85x at 4.5 bins;
+    requiring 2.5x leaves ~17% headroom on the tighter of the two. Suppression is
+    setting-dependent (2.85x at 2.5 bins under a 4x refinement), so these numbers apply to the
+    constants above and must be re-measured if the domain or timing changes.
     """
     rect = spectra["rect"][index] / spectra["rect"][0]
     tukey = spectra["tukey"][index] / spectra["tukey"][0]
     # The leakage must genuinely be there, or "suppression" would be vacuous.
     assert rect > 0.03, f"{offset} bins: no rectangular leakage to suppress ({rect:.3e})"
-    assert tukey < 0.5 * rect, f"{offset} bins: Tukey {tukey:.3e} vs rectangular {rect:.3e} (need <2x)"
+    assert tukey < 0.4 * rect, f"{offset} bins: Tukey {tukey:.3e} vs rectangular {rect:.3e} (need <2.5x)"
+
+
+def test_suppression_grows_with_bin_offset(spectra):
+    """A tapered window's sidelobes fall off faster than a rectangular gate's, so suppression
+    must increase with distance from the tone. Structural, no calibrated threshold: catches a
+    window that is applied but wrong (bad alpha, wrong axis) where a flat ratio bound would not.
+    """
+    supp = [
+        (spectra["rect"][i] / spectra["rect"][0]) / (spectra["tukey"][i] / spectra["tukey"][0])
+        for i in range(1, len(_BIN_OFFSETS) + 1)
+    ]
+    assert supp == sorted(supp), f"suppression not monotonic in bin offset: {supp}"

--- a/tests/simulation/physics/detectors/test_apodization_leakage.py
+++ b/tests/simulation/physics/detectors/test_apodization_leakage.py
@@ -74,7 +74,7 @@ def _build():
     objects.append(source)
 
     # The window spans exactly the recorded interval, so it tapers both of its edges.
-    window = fdtdx.TukeyWindowProfile(start_time=_RECORD_START, end_time=duration, alpha=0.5)
+    window = fdtdx.TukeyWindow(start_time=_RECORD_START, end_time=duration, alpha=0.5)
     switch = fdtdx.OnOffSwitch(start_time=_RECORD_START)
     for name, apodization in (("rect", None), ("tukey", window)):
         det = fdtdx.PhasorDetector(

--- a/tests/simulation/physics/detectors/test_apodization_leakage.py
+++ b/tests/simulation/physics/detectors/test_apodization_leakage.py
@@ -110,7 +110,6 @@ def spectra():
     for name in ("rect", "tukey"):
         phasor = np.asarray(arrays.detector_states[name]["phasor"])
         out[name] = np.abs(phasor[0, :, 0])  # (num_freqs,) for Ex
-    print({k: np.array2string(v, precision=4) for k, v in out.items()})
     return out
 
 

--- a/tests/unit/core/test_window.py
+++ b/tests/unit/core/test_window.py
@@ -1,4 +1,4 @@
-"""Tests for the shared temporal envelope helpers and the detector WindowProfiles."""
+"""Tests for the shared temporal envelope helpers and the detector apodization windows."""
 
 import jax.numpy as jnp
 import numpy as np
@@ -6,9 +6,9 @@ import pytest
 
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.core.window import (
-    GaussianWindowProfile,
-    TukeyWindowProfile,
-    WindowProfile,
+    GaussianWindow,
+    TemporalWindow,
+    TukeyWindow,
     gaussian_envelope,
     linear_rampup,
     tukey_envelope,
@@ -54,39 +54,35 @@ class TestWindowShapes:
         assert float(w[0]) == 0.0 and float(w[2]) == 0.0
 
 
-class TestWindowProfiles:
-    """WindowProfile wraps the envelopes with the carrier-free detector interface."""
+class TestTemporalWindows:
+    """TemporalWindow wraps the envelopes with the carrier-free detector interface."""
 
-    def test_gaussian_window_profile_matches_envelope(self):
+    def test_gaussian_window_matches_envelope(self):
         t = jnp.linspace(0, 1e-12, 50)
-        prof = GaussianWindowProfile(center_time=5e-13, sigma_time=1e-13)
-        np.testing.assert_allclose(
-            np.array(prof.get_window(t)), np.array(gaussian_envelope(t, 5e-13, 1e-13)), atol=1e-7
-        )
+        win = GaussianWindow(center_time=5e-13, sigma_time=1e-13)
+        np.testing.assert_allclose(np.array(win.get_window(t)), np.array(gaussian_envelope(t, 5e-13, 1e-13)), atol=1e-7)
 
-    def test_tukey_window_profile_matches_envelope(self):
+    def test_tukey_window_matches_envelope(self):
         t = jnp.linspace(0, 1e-12, 50)
-        prof = TukeyWindowProfile(start_time=0.0, end_time=1e-12, alpha=0.5)
-        np.testing.assert_allclose(
-            np.array(prof.get_window(t)), np.array(tukey_envelope(t, 0.0, 1e-12, 0.5)), atol=1e-7
-        )
+        win = TukeyWindow(start_time=0.0, end_time=1e-12, alpha=0.5)
+        np.testing.assert_allclose(np.array(win.get_window(t)), np.array(tukey_envelope(t, 0.0, 1e-12, 0.5)), atol=1e-7)
 
     def test_windows_are_non_negative(self):
         """Window weights never change sign."""
         t = jnp.linspace(-1e-12, 2e-12, 200)
-        for prof in (
-            GaussianWindowProfile(center_time=5e-13, sigma_time=1e-13),
-            TukeyWindowProfile(start_time=0.0, end_time=1e-12, alpha=0.5),
+        for win in (
+            GaussianWindow(center_time=5e-13, sigma_time=1e-13),
+            TukeyWindow(start_time=0.0, end_time=1e-12, alpha=0.5),
         ):
-            assert bool(jnp.all(prof.get_window(t) >= 0.0))
+            assert bool(jnp.all(win.get_window(t) >= 0.0))
 
-    def test_window_profiles_are_not_temporal_profiles(self):
+    def test_windows_are_not_temporal_profiles(self):
         """Windows and source profiles are separate hierarchies."""
-        assert issubclass(GaussianWindowProfile, WindowProfile)
-        assert issubclass(TukeyWindowProfile, WindowProfile)
-        assert not issubclass(GaussianWindowProfile, TemporalProfile)
-        assert not issubclass(SingleFrequencyProfile, WindowProfile)
-        assert not issubclass(GaussianPulseProfile, WindowProfile)
+        assert issubclass(GaussianWindow, TemporalWindow)
+        assert issubclass(TukeyWindow, TemporalWindow)
+        assert not issubclass(GaussianWindow, TemporalProfile)
+        assert not issubclass(SingleFrequencyProfile, TemporalWindow)
+        assert not issubclass(GaussianPulseProfile, TemporalWindow)
 
 
 class TestProfileRefactorRegression:
@@ -121,19 +117,19 @@ class TestWindowValidation:
     @pytest.mark.parametrize("sigma", [0.0, -1e-13])
     def test_gaussian_rejects_non_positive_sigma(self, sigma):
         with pytest.raises(ValueError, match="sigma_time must be positive"):
-            GaussianWindowProfile(center_time=5e-13, sigma_time=sigma)
+            GaussianWindow(center_time=5e-13, sigma_time=sigma)
 
     @pytest.mark.parametrize("end", [0.0, -1e-12, 1e-12])
     def test_tukey_rejects_non_increasing_bounds(self, end):
         with pytest.raises(ValueError, match="end_time must exceed start_time"):
-            TukeyWindowProfile(start_time=1e-12, end_time=end)
+            TukeyWindow(start_time=1e-12, end_time=end)
 
     @pytest.mark.parametrize("alpha", [-0.1, 1.5])
     def test_tukey_rejects_alpha_outside_unit_interval(self, alpha):
         with pytest.raises(ValueError, match=r"alpha must lie in \[0, 1\]"):
-            TukeyWindowProfile(start_time=0.0, end_time=1e-12, alpha=alpha)
+            TukeyWindow(start_time=0.0, end_time=1e-12, alpha=alpha)
 
     @pytest.mark.parametrize("alpha", [0.0, 0.5, 1.0])
     def test_tukey_accepts_the_closed_unit_interval(self, alpha):
-        prof = TukeyWindowProfile(start_time=0.0, end_time=1e-12, alpha=alpha)
-        assert bool(jnp.all(jnp.isfinite(prof.get_window(jnp.linspace(0, 1e-12, 20)))))
+        win = TukeyWindow(start_time=0.0, end_time=1e-12, alpha=alpha)
+        assert bool(jnp.all(jnp.isfinite(win.get_window(jnp.linspace(0, 1e-12, 20)))))

--- a/tests/unit/core/test_window.py
+++ b/tests/unit/core/test_window.py
@@ -1,0 +1,139 @@
+"""Tests for the shared temporal envelope helpers and the detector WindowProfiles."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from fdtdx.core.wavelength import WaveCharacter
+from fdtdx.core.window import (
+    GaussianWindowProfile,
+    TukeyWindowProfile,
+    WindowProfile,
+    gaussian_envelope,
+    linear_rampup,
+    tukey_envelope,
+)
+from fdtdx.objects.sources.profile import GaussianPulseProfile, SingleFrequencyProfile, TemporalProfile
+
+
+class TestWindowShapes:
+    """The pure envelope helpers shared by source profiles and detector windows."""
+
+    def test_gaussian_envelope(self):
+        """Peaks at the center, falls to exp(-1/2) at one sigma, and is symmetric."""
+        t = jnp.linspace(0, 10, 101)
+        w = gaussian_envelope(t, center=5.0, sigma=1.0)
+        assert float(w[50]) == pytest.approx(1.0, abs=1e-6)
+        assert float(gaussian_envelope(jnp.array(6.0), 5.0, 1.0)) == pytest.approx(np.exp(-0.5), rel=1e-6)
+        np.testing.assert_allclose(np.array(w), np.array(w)[::-1], atol=1e-6)
+
+    def test_linear_rampup(self):
+        """Ramps 0 to 1 over the duration and clamps outside it."""
+        t = jnp.array([-1.0, 0.0, 0.5, 1.0, 2.0])
+        w = linear_rampup(t, ramp_duration=1.0)
+        np.testing.assert_allclose(np.array(w), [0.0, 0.0, 0.5, 1.0, 1.0], atol=1e-6)
+
+    def test_tukey_endpoints_and_flat_top(self):
+        """Tapers to zero at both ends with a flat unit top in between."""
+        t = jnp.linspace(0, 1, 101)
+        w = tukey_envelope(t, start=0.0, end=1.0, alpha=0.5)
+        assert float(w[0]) == pytest.approx(0.0, abs=1e-6)
+        assert float(w[-1]) == pytest.approx(0.0, abs=1e-6)
+        assert float(w[50]) == pytest.approx(1.0, abs=1e-6)
+
+    def test_tukey_alpha_limits(self):
+        """alpha=0 is rectangular, alpha=1 is Hann."""
+        t = jnp.linspace(0, 1, 51)
+        np.testing.assert_allclose(np.array(tukey_envelope(t, 0.0, 1.0, alpha=0.0)), 1.0, atol=1e-6)
+        hann = tukey_envelope(t, 0.0, 1.0, alpha=1.0)
+        np.testing.assert_allclose(np.array(hann), 0.5 * (1 - np.cos(2 * np.pi * np.array(t))), atol=1e-6)
+
+    def test_tukey_zero_outside_range(self):
+        """Outside [start, end] the window is exactly zero."""
+        w = tukey_envelope(jnp.array([-0.1, 0.5, 1.1]), 0.0, 1.0, alpha=0.5)
+        assert float(w[0]) == 0.0 and float(w[2]) == 0.0
+
+
+class TestWindowProfiles:
+    """WindowProfile wraps the envelopes with the carrier-free detector interface."""
+
+    def test_gaussian_window_profile_matches_envelope(self):
+        t = jnp.linspace(0, 1e-12, 50)
+        prof = GaussianWindowProfile(center_time=5e-13, sigma_time=1e-13)
+        np.testing.assert_allclose(
+            np.array(prof.get_window(t)), np.array(gaussian_envelope(t, 5e-13, 1e-13)), atol=1e-7
+        )
+
+    def test_tukey_window_profile_matches_envelope(self):
+        t = jnp.linspace(0, 1e-12, 50)
+        prof = TukeyWindowProfile(start_time=0.0, end_time=1e-12, alpha=0.5)
+        np.testing.assert_allclose(
+            np.array(prof.get_window(t)), np.array(tukey_envelope(t, 0.0, 1e-12, 0.5)), atol=1e-7
+        )
+
+    def test_windows_are_non_negative(self):
+        """Window weights never change sign."""
+        t = jnp.linspace(-1e-12, 2e-12, 200)
+        for prof in (
+            GaussianWindowProfile(center_time=5e-13, sigma_time=1e-13),
+            TukeyWindowProfile(start_time=0.0, end_time=1e-12, alpha=0.5),
+        ):
+            assert bool(jnp.all(prof.get_window(t) >= 0.0))
+
+    def test_window_profiles_are_not_temporal_profiles(self):
+        """Windows and source profiles are separate hierarchies."""
+        assert issubclass(GaussianWindowProfile, WindowProfile)
+        assert issubclass(TukeyWindowProfile, WindowProfile)
+        assert not issubclass(GaussianWindowProfile, TemporalProfile)
+        assert not issubclass(SingleFrequencyProfile, WindowProfile)
+        assert not issubclass(GaussianPulseProfile, WindowProfile)
+
+
+class TestProfileRefactorRegression:
+    """Extracting the envelope helpers must leave the source profiles unchanged."""
+
+    def test_gaussian_pulse_unchanged(self):
+        center = WaveCharacter(wavelength=1e-6)
+        width = WaveCharacter(wavelength=2e-6)
+        prof = GaussianPulseProfile(center_wave=center, spectral_width=width)
+        t = jnp.linspace(0, 5e-14, 60)
+        sigma_t = 1.0 / (2 * np.pi * width.get_frequency())
+        t0 = 6 * sigma_t
+        envelope = np.exp(-((np.array(t) - t0) ** 2) / (2 * sigma_t**2))
+        carrier = np.real(np.exp(-1j * (2 * np.pi * center.get_frequency() * np.array(t) + center.phase_shift)))
+        np.testing.assert_allclose(
+            np.array(prof.get_amplitude(t, period=1e-15)), envelope * carrier, rtol=1e-4, atol=1e-5
+        )
+
+    def test_single_frequency_unchanged(self):
+        prof = SingleFrequencyProfile(num_startup_periods=4)
+        period = 1e-15
+        t = jnp.linspace(0, 10 * period, 80)
+        time_phase = 2 * np.pi * np.array(t) / period + 0.0 + prof.phase_shift
+        raw = np.real(np.exp(-1j * time_phase))
+        factor = np.clip(np.array(t) / (4 * period), 0, 1)
+        np.testing.assert_allclose(np.array(prof.get_amplitude(t, period=period)), factor * raw, rtol=1e-4, atol=1e-5)
+
+
+class TestWindowValidation:
+    """Window parameters that would produce NaN or a non-window are rejected."""
+
+    @pytest.mark.parametrize("sigma", [0.0, -1e-13])
+    def test_gaussian_rejects_non_positive_sigma(self, sigma):
+        with pytest.raises(ValueError, match="sigma_time must be positive"):
+            GaussianWindowProfile(center_time=5e-13, sigma_time=sigma)
+
+    @pytest.mark.parametrize("end", [0.0, -1e-12, 1e-12])
+    def test_tukey_rejects_non_increasing_bounds(self, end):
+        with pytest.raises(ValueError, match="end_time must exceed start_time"):
+            TukeyWindowProfile(start_time=1e-12, end_time=end)
+
+    @pytest.mark.parametrize("alpha", [-0.1, 1.5])
+    def test_tukey_rejects_alpha_outside_unit_interval(self, alpha):
+        with pytest.raises(ValueError, match=r"alpha must lie in \[0, 1\]"):
+            TukeyWindowProfile(start_time=0.0, end_time=1e-12, alpha=alpha)
+
+    @pytest.mark.parametrize("alpha", [0.0, 0.5, 1.0])
+    def test_tukey_accepts_the_closed_unit_interval(self, alpha):
+        prof = TukeyWindowProfile(start_time=0.0, end_time=1e-12, alpha=alpha)
+        assert bool(jnp.all(jnp.isfinite(prof.get_window(jnp.linspace(0, 1e-12, 20)))))

--- a/tests/unit/objects/detectors/test_apodization.py
+++ b/tests/unit/objects/detectors/test_apodization.py
@@ -8,7 +8,7 @@ import pytest
 from fdtdx.config import SimulationConfig
 from fdtdx.core.grid import UniformGrid
 from fdtdx.core.wavelength import WaveCharacter
-from fdtdx.core.window import GaussianWindowProfile, TukeyWindowProfile
+from fdtdx.core.window import GaussianWindow, TukeyWindow
 from fdtdx.objects.detectors.phasor import PhasorDetector
 
 
@@ -54,9 +54,7 @@ def test_continuous_cw_amplitude_preserved_without_window(config):
 def test_continuous_cw_amplitude_preserved_with_tukey(config):
     """The 2/sum(w) coherent-gain correction keeps CW amplitude ~1 under apodization."""
     f = WaveCharacter(wavelength=1e-6).get_frequency()
-    win = TukeyWindowProfile(
-        start_time=0.0, end_time=(config.time_steps_total - 1) * config.time_step_duration, alpha=0.5
-    )
+    win = TukeyWindow(start_time=0.0, end_time=(config.time_steps_total - 1) * config.time_step_duration, alpha=0.5)
     det = PhasorDetector(
         name="d", wave_characters=(WaveCharacter(wavelength=1e-6),), reduce_volume=True, apodization=win
     )
@@ -70,9 +68,7 @@ def test_continuous_cw_amplitude_preserved_with_tukey(config):
 def test_window_changes_a_transient_spectrum(config):
     """For a non-CW (decaying) signal, the apodized phasor differs from the rectangular one."""
     f = WaveCharacter(wavelength=1e-6).get_frequency()
-    win = TukeyWindowProfile(
-        start_time=0.0, end_time=(config.time_steps_total - 1) * config.time_step_duration, alpha=0.8
-    )
+    win = TukeyWindow(start_time=0.0, end_time=(config.time_steps_total - 1) * config.time_step_duration, alpha=0.8)
 
     def run(det):
         det = det.place_on_grid(((0, 4), (0, 4), (0, 1)), config, jax.random.PRNGKey(0))
@@ -115,9 +111,7 @@ def test_apodization_composes_with_dft_subsampling(config, stride):
     by the stride.
     """
     wc = WaveCharacter(wavelength=1e-6)
-    win = TukeyWindowProfile(
-        start_time=0.0, end_time=(config.time_steps_total - 1) * config.time_step_duration, alpha=0.5
-    )
+    win = TukeyWindow(start_time=0.0, end_time=(config.time_steps_total - 1) * config.time_step_duration, alpha=0.5)
     det = PhasorDetector(
         name="d",
         wave_characters=(wc,),
@@ -137,7 +131,7 @@ def test_source_profile_rejected_as_apodization():
     """A source profile is refused as an apodization window."""
     from fdtdx.objects.sources.profile import SingleFrequencyProfile
 
-    with pytest.raises(Exception, match="must be a WindowProfile"):
+    with pytest.raises(Exception, match="must be a TemporalWindow"):
         PhasorDetector(
             name="d",
             wave_characters=(WaveCharacter(wavelength=1e-6),),
@@ -151,7 +145,7 @@ def test_window_outside_recorded_interval_is_rejected(config):
     det = PhasorDetector(
         name="d",
         wave_characters=(WaveCharacter(wavelength=1e-6),),
-        apodization=TukeyWindowProfile(start_time=10 * dur, end_time=11 * dur),
+        apodization=TukeyWindow(start_time=10 * dur, end_time=11 * dur),
     )
     with pytest.raises(Exception, match="must be finite and positive"):
         det.place_on_grid(((0, 4), (0, 4), (0, 1)), config, jax.random.PRNGKey(0))
@@ -163,7 +157,7 @@ def test_underflowed_gaussian_window_is_rejected(config):
     det = PhasorDetector(
         name="d",
         wave_characters=(WaveCharacter(wavelength=1e-6),),
-        apodization=GaussianWindowProfile(center_time=1e6 * dur, sigma_time=1e-18),
+        apodization=GaussianWindow(center_time=1e6 * dur, sigma_time=1e-18),
     )
     with pytest.raises(Exception, match="must be finite and positive"):
         det.place_on_grid(((0, 4), (0, 4), (0, 1)), config, jax.random.PRNGKey(0))
@@ -180,7 +174,7 @@ def test_alpha_zero_tukey_is_identical_to_no_apodization(config):
     """
     f = WaveCharacter(wavelength=1e-6).get_frequency()
     end = (config.time_steps_total - 1) * config.time_step_duration
-    win = TukeyWindowProfile(start_time=0.0, end_time=end, alpha=0.0)
+    win = TukeyWindow(start_time=0.0, end_time=end, alpha=0.0)
 
     def phasor(apodization):
         det = PhasorDetector(

--- a/tests/unit/objects/detectors/test_apodization.py
+++ b/tests/unit/objects/detectors/test_apodization.py
@@ -48,7 +48,7 @@ def test_continuous_cw_amplitude_preserved_without_window(config):
     """Backward-compat: continuous-mode CW amplitude reconstruction is ~1."""
     det = PhasorDetector(name="d", wave_characters=(WaveCharacter(wavelength=1e-6),), reduce_volume=True)
     _, state = _run_cw(det, config, jax.random.PRNGKey(0), WaveCharacter(wavelength=1e-6).get_frequency())
-    assert float(jnp.abs(state["phasor"][0, 0, 0])) == pytest.approx(1.0, abs=2e-2)
+    assert float(jnp.abs(state["phasor"][0, 0, 0])) == pytest.approx(1.0, abs=2e-3)
 
 
 def test_continuous_cw_amplitude_preserved_with_tukey(config):
@@ -62,7 +62,9 @@ def test_continuous_cw_amplitude_preserved_with_tukey(config):
     )
     placed, state = _run_cw(det, config, jax.random.PRNGKey(0), f)
     assert placed._window_sum < placed.num_time_steps_recorded  # window tapers the edges
-    assert float(jnp.abs(state["phasor"][0, 0, 0])) == pytest.approx(1.0, abs=3e-2)
+    # Tapering suppresses the 2w residual, so the apodized reconstruction is ~1000x more
+    # accurate than the rectangular one (4.8e-7 vs 5.7e-4). 1e-5 is ~84 float32 ULP.
+    assert float(jnp.abs(state["phasor"][0, 0, 0])) == pytest.approx(1.0, abs=1e-5)
 
 
 def test_window_changes_a_transient_spectrum(config):
@@ -101,7 +103,10 @@ def test_window_changes_a_transient_spectrum(config):
     assert abs(rect - apod) > 1e-3 * abs(rect)
 
 
-@pytest.mark.parametrize("stride", [1, 4, 8])
+# Strides stay above 4 samples/period (17.5 undecimated), so amplitude sits on the numerical
+# floor and the same tolerance applies to all of them. Heavier strides alias by design --
+# that path is covered in test_phasor_subsample.py.
+@pytest.mark.parametrize("stride", [1, 2, 3, 4])
 def test_apodization_composes_with_dft_subsampling(config, stride):
     """Apodization and ``dft_subsample`` stack: CW amplitude survives both together.
 
@@ -125,7 +130,7 @@ def test_apodization_composes_with_dft_subsampling(config, stride):
     # The window is only accumulated on kept steps, so its sum tracks the thinned count.
     assert placed._window_sum <= placed.num_time_steps_recorded
     assert placed._window_sum == pytest.approx(float(jnp.sum(placed._window_at_time_step_arr)), rel=1e-6)
-    assert float(jnp.abs(state["phasor"][0, 0, 0])) == pytest.approx(1.0, abs=3e-2)
+    assert float(jnp.abs(state["phasor"][0, 0, 0])) == pytest.approx(1.0, abs=1e-5)
 
 
 def test_source_profile_rejected_as_apodization():
@@ -162,3 +167,33 @@ def test_underflowed_gaussian_window_is_rejected(config):
     )
     with pytest.raises(Exception, match="must be finite and positive"):
         det.place_on_grid(((0, 4), (0, 4), (0, 1)), config, jax.random.PRNGKey(0))
+
+
+def test_alpha_zero_tukey_is_identical_to_no_apodization(config):
+    """A rectangular Tukey over the full recorded interval must reproduce the un-apodized
+    result exactly.
+
+    Tolerance-free: one assertion covers window construction, alignment of the window's
+    support with the OnOffSwitch mask, and the coherent-gain path. Verified bit-identical
+    (0.0) at both unit and simulation tier, so an off-by-one at either recording edge -
+    which every amplitude tolerance above would absorb - fails here immediately.
+    """
+    f = WaveCharacter(wavelength=1e-6).get_frequency()
+    end = (config.time_steps_total - 1) * config.time_step_duration
+    win = TukeyWindowProfile(start_time=0.0, end_time=end, alpha=0.0)
+
+    def phasor(apodization):
+        det = PhasorDetector(
+            name="d",
+            wave_characters=(WaveCharacter(wavelength=1e-6),),
+            reduce_volume=True,
+            apodization=apodization,
+        )
+        placed, state = _run_cw(det, config, jax.random.PRNGKey(0), f)
+        return placed, np.asarray(state["phasor"])
+
+    placed_rect, rect = phasor(None)
+    placed_a0, a0 = phasor(win)
+
+    assert placed_a0._window_sum == pytest.approx(placed_rect._window_sum, rel=0, abs=0)
+    np.testing.assert_array_equal(a0, rect)

--- a/tests/unit/objects/detectors/test_apodization.py
+++ b/tests/unit/objects/detectors/test_apodization.py
@@ -1,0 +1,164 @@
+"""Tests for PhasorDetector temporal apodization (smooth windows)."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from fdtdx.config import SimulationConfig
+from fdtdx.core.grid import UniformGrid
+from fdtdx.core.wavelength import WaveCharacter
+from fdtdx.core.window import GaussianWindowProfile, TukeyWindowProfile
+from fdtdx.objects.detectors.phasor import PhasorDetector
+
+
+@pytest.fixture
+def config():
+    return SimulationConfig(time=2e-13, grid=UniformGrid(spacing=1e-7), backend="cpu")
+
+
+@pytest.fixture
+def plane():
+    return ((0, 4), (0, 4), (0, 1))
+
+
+def _run_cw(det, config, key, freq):
+    det = det.place_on_grid(((0, 4), (0, 4), (0, 1)), config, key)
+    state = det.init_state()
+    dt = config.time_step_duration
+    for n in range(config.time_steps_total):
+        t = n * dt
+        E = jnp.zeros((3, 4, 4, 1)).at[0].set(jnp.cos(2 * np.pi * freq * t))
+        H = jnp.zeros((3, 4, 4, 1))
+        state = det.update(jnp.array(n), E, H, state, jnp.ones((3, 4, 4, 1)), 1.0)
+    return det, state
+
+
+def test_no_apodization_is_rectangular(config, plane):
+    """Without apodization the window weights are the plain on-mask (sum == recorded steps)."""
+    det = PhasorDetector(name="d", wave_characters=(WaveCharacter(wavelength=1e-6),))
+    det = det.place_on_grid(plane, config, jax.random.PRNGKey(0))
+    assert det._window_sum == pytest.approx(float(det.num_time_steps_recorded))
+    np.testing.assert_allclose(
+        np.array(det._window_at_time_step_arr), np.array(det._is_on_at_time_step_arr, dtype=float), atol=0
+    )
+
+
+def test_continuous_cw_amplitude_preserved_without_window(config):
+    """Backward-compat: continuous-mode CW amplitude reconstruction is ~1."""
+    det = PhasorDetector(name="d", wave_characters=(WaveCharacter(wavelength=1e-6),), reduce_volume=True)
+    _, state = _run_cw(det, config, jax.random.PRNGKey(0), WaveCharacter(wavelength=1e-6).get_frequency())
+    assert float(jnp.abs(state["phasor"][0, 0, 0])) == pytest.approx(1.0, abs=2e-2)
+
+
+def test_continuous_cw_amplitude_preserved_with_tukey(config):
+    """The 2/sum(w) coherent-gain correction keeps CW amplitude ~1 under apodization."""
+    f = WaveCharacter(wavelength=1e-6).get_frequency()
+    win = TukeyWindowProfile(
+        start_time=0.0, end_time=(config.time_steps_total - 1) * config.time_step_duration, alpha=0.5
+    )
+    det = PhasorDetector(
+        name="d", wave_characters=(WaveCharacter(wavelength=1e-6),), reduce_volume=True, apodization=win
+    )
+    placed, state = _run_cw(det, config, jax.random.PRNGKey(0), f)
+    assert placed._window_sum < placed.num_time_steps_recorded  # window tapers the edges
+    assert float(jnp.abs(state["phasor"][0, 0, 0])) == pytest.approx(1.0, abs=3e-2)
+
+
+def test_window_changes_a_transient_spectrum(config):
+    """For a non-CW (decaying) signal, the apodized phasor differs from the rectangular one."""
+    f = WaveCharacter(wavelength=1e-6).get_frequency()
+    win = TukeyWindowProfile(
+        start_time=0.0, end_time=(config.time_steps_total - 1) * config.time_step_duration, alpha=0.8
+    )
+
+    def run(det):
+        det = det.place_on_grid(((0, 4), (0, 4), (0, 1)), config, jax.random.PRNGKey(0))
+        state = det.init_state()
+        dt = config.time_step_duration
+        n_total = config.time_steps_total
+        for n in range(n_total):
+            t = n * dt
+            decay = np.exp(-3.0 * n / n_total)  # transient that is strong at the (tapered) edges
+            E = jnp.zeros((3, 4, 4, 1)).at[0].set(decay * jnp.cos(2 * np.pi * f * t))
+            state = det.update(jnp.array(n), E, jnp.zeros((3, 4, 4, 1)), state, jnp.ones((3, 4, 4, 1)), 1.0)
+        return complex(state["phasor"][0, 0, 0])
+
+    rect = run(
+        PhasorDetector(
+            name="d", wave_characters=(WaveCharacter(wavelength=1e-6),), reduce_volume=True, scaling_mode="pulse"
+        )
+    )
+    apod = run(
+        PhasorDetector(
+            name="d",
+            wave_characters=(WaveCharacter(wavelength=1e-6),),
+            reduce_volume=True,
+            scaling_mode="pulse",
+            apodization=win,
+        )
+    )
+    assert abs(rect - apod) > 1e-3 * abs(rect)
+
+
+@pytest.mark.parametrize("stride", [1, 4, 8])
+def test_apodization_composes_with_dft_subsampling(config, stride):
+    """Apodization and ``dft_subsample`` stack: CW amplitude survives both together.
+
+    The coherent gain is summed over the *thinned* on-mask, so ``sum(w)`` scales with the
+    kept-sample count. Getting that wrong (summing over every step) would rescale the phasor
+    by the stride.
+    """
+    wc = WaveCharacter(wavelength=1e-6)
+    win = TukeyWindowProfile(
+        start_time=0.0, end_time=(config.time_steps_total - 1) * config.time_step_duration, alpha=0.5
+    )
+    det = PhasorDetector(
+        name="d",
+        wave_characters=(wc,),
+        reduce_volume=True,
+        apodization=win,
+        dft_subsample=stride,
+    )
+    placed, state = _run_cw(det, config, jax.random.PRNGKey(0), wc.get_frequency())
+
+    # The window is only accumulated on kept steps, so its sum tracks the thinned count.
+    assert placed._window_sum <= placed.num_time_steps_recorded
+    assert placed._window_sum == pytest.approx(float(jnp.sum(placed._window_at_time_step_arr)), rel=1e-6)
+    assert float(jnp.abs(state["phasor"][0, 0, 0])) == pytest.approx(1.0, abs=3e-2)
+
+
+def test_source_profile_rejected_as_apodization():
+    """A source profile is refused as an apodization window."""
+    from fdtdx.objects.sources.profile import SingleFrequencyProfile
+
+    with pytest.raises(Exception, match="must be a WindowProfile"):
+        PhasorDetector(
+            name="d",
+            wave_characters=(WaveCharacter(wavelength=1e-6),),
+            apodization=SingleFrequencyProfile(),
+        )
+
+
+def test_window_outside_recorded_interval_is_rejected(config):
+    """A window whose support misses the recording window would divide by a zero gain."""
+    dur = (config.time_steps_total - 1) * config.time_step_duration
+    det = PhasorDetector(
+        name="d",
+        wave_characters=(WaveCharacter(wavelength=1e-6),),
+        apodization=TukeyWindowProfile(start_time=10 * dur, end_time=11 * dur),
+    )
+    with pytest.raises(Exception, match="must be finite and positive"):
+        det.place_on_grid(((0, 4), (0, 4), (0, 1)), config, jax.random.PRNGKey(0))
+
+
+def test_underflowed_gaussian_window_is_rejected(config):
+    """A Gaussian centred far outside the interval underflows to an all-zero window."""
+    dur = (config.time_steps_total - 1) * config.time_step_duration
+    det = PhasorDetector(
+        name="d",
+        wave_characters=(WaveCharacter(wavelength=1e-6),),
+        apodization=GaussianWindowProfile(center_time=1e6 * dur, sigma_time=1e-18),
+    )
+    with pytest.raises(Exception, match="must be finite and positive"):
+        det.place_on_grid(((0, 4), (0, 4), (0, 1)), config, jax.random.PRNGKey(0))


### PR DESCRIPTION
Adds an optional `apodization` window to `PhasorDetector`, applied to each sample of its running DFT. The default (`None`) is the existing hard rectangular gate, so nothing changes unless it is set.

A rectangular gate leaks spectrally: a signal still ringing when the detector switches off hits a discontinuity, and the sidelobes land on neighbouring frequencies. Measuring a feature 1000x below a nearby strong tone, the gate overstates it by ~60x; a Tukey window brings it to the right order.

Windows live in `core/window.py` alongside the envelope helpers, which are extracted from the inline copies in `objects/sources/profile.py` so the source profiles and the windows share one definition of each shape. `WindowProfile` takes `get_window(time)`, with `apodization` typed to it so a source profile is rejected at construction.

Continuous-mode scaling becomes the window's coherent gain `2 / sum(w)`, which reduces to the previous `2 / N` for the rectangular case. The sum is taken over the recorded steps, so this composes with `dft_subsample`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared temporal window/envelope utilities and new `WindowProfile` implementations: `GaussianWindowProfile` and `TukeyWindowProfile`.
  * Enabled optional temporal apodization for `PhasorDetector` via `WindowProfile`, including coherent-gain correction for continuous recordings.
* **Documentation**
  * Extended API docs to include `WindowProfile`, `GaussianWindowProfile`, and `TukeyWindowProfile`.
* **Refactor**
  * Updated source temporal shaping to use shared Gaussian and linear ramp helpers for smoother transitions.
* **Tests**
  * Added unit tests for envelope/window shapes, parameter validation, apodization edge cases (including rejection for invalid/underflowed windows), and detector subsampling behavior.
  * Added physics regression coverage to confirm reduced spectral leakage off DFT bins with Tukey windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->