### PR TITLE
implemented dispersion in observer form

### DIFF
--- a/.claude/skills/fdtdx/SKILL.md
+++ b/.claude/skills/fdtdx/SKILL.md
@@ -107,12 +107,13 @@ H = H / (1 + c * sigma_H / eta0 * inv_mu / 2)
 
 Note the asymmetry: sigma_E multiplied by eta0, sigma_H divided by eta0.
 
-**With dispersion (ADE correction):** After the lossless/lossy E update but before the final divide by `(1 + c*sigma_E*eta0*inv_eps/2)`, add the per-pole polarization increment. For each pole `p`:
+**With dispersion (ADE correction):** After the lossless/lossy E update but before the final divide by `(1 + c*sigma_E*eta0*inv_eps/2)`, add the per-pole polarization increment. The loop marches the **delta basis** of the observer form (see Dispersive Materials), so for each pole `p`:
 ```text
-P_p^(n+1) = c1_p * P_p^n + c2_p * P_p^(n-1) + c3_p * E^n
-E        += inv_eps * sum_p (P_p^n - P_p^(n+1))
+dx1_p    = y2_p − a1_p * x1_p + b1_p * E^n        (= x1_p^(n+1) − x1_p^n)
+y2_p    += −a0_p * x1_p + b0_p * E^n
+E       += inv_eps * sum_p (c4_p * E^n − dx1_p)   (= inv_eps * sum_p (p_p^n − x1_p^(n+1)))
 ```
-`P` is stored normalized as `P/eps_0`, so it has the same units as `E` and no eta0 factor enters. There is no reverse-time counterpart: dispersive simulations are **checkpointed-only** (see Gradient Strategies).
+then divide by `1 + inv_eps*sum_p(c4_p) [+ c*sigma_E*eta0*inv_eps/2]` when any `c4 ≠ 0`. `P` is stored normalized as `P/eps_0`, so it has the same units as `E` and no eta0 factor enters. There is no reverse-time counterpart: dispersive simulations are **checkpointed-only** (see Gradient Strategies).
 
 ## Material System
 
@@ -141,33 +142,64 @@ Linear dispersion is implemented via the Auxiliary Differential Equation (ADE) m
 - `DrudePole(plasma_frequency, damping)` — `χ(ω) = −ωₚ² / (ω² + iγω)` (special case ω₀ = 0)
 - New pole types: subclass `Pole` and expose `omega_0`, `gamma`, `coupling_sq` (K = Δε·ω₀² for Lorentz, ωₚ² for Drude).
 
-**Discrete-time recurrence** (central differences, evaluated once at setup via `compute_pole_coefficients(poles, dt)`):
+**Discrete-time recurrence** (evaluated once at setup via `compute_pole_coefficients(poles, dt)`):
 ```text
-p^(n+1) = c1·p^n + c2·p^(n-1) + c3·E^n
-c1 = (2 − ω₀²·dt²) / (1 + γ·dt/2)
-c2 = −(1 − γ·dt/2) / (1 + γ·dt/2)
-c3 =  (K·dt²)      / (1 + γ·dt/2)
+p^(n+1) = c1·p^n + c2·p^(n-1) + c3·E^n + c4·E^(n+1) + c5·E^(n-1)
 ```
-Stability (forward Jury bound) needs `ω₀·dt < 2`; `γ·dt` is unconstrained (`|c2| < 1` for any `γ·dt > 0`).
+Every pole carries an `integrator` (`Pole.integrator`, default `"centered_edot"`) selecting how the ODE is discretized. With `D = 1 + γ·dt/2`, `K = 2/dt`, `D_b = K² + γK + ω₀²`, and the unified driving terms `a·E + b·dE/dt`:
+
+| scheme | c1 | c2 | c3 | c4 | c5 |
+|---|---|---|---|---|---|
+| `"central"` (legacy) | `(2 − ω₀²dt²)/D` | `−(1 − γdt/2)/D` | `(a·dt² − b·dt)/D` | `b·dt/D` | `0` |
+| `"centered_edot"` (default) | same | same | `a·dt²/D` | `b·dt/(2D)` | `−b·dt/(2D)` |
+| `"bilinear"` | `2(K² − ω₀²)/D_b` | `−(K² − γK + ω₀²)/D_b` | `2a/D_b` | `(a + bK)/D_b` | `(a − bK)/D_b` |
+
+- `"central"` uses a **forward** difference on `b·dE/dt`, so it is only **first order** whenever `b ≠ 0` (CCPR / modified Lorentz / critical points) and its leading error is *real* — it perturbs `a`. It also puts twice the correct weight on `E^(n+1)`, which overshoots the trapezoidal conductivity term that should cancel it (a physical fit has `Σ b_p = −σ/ε₀`) and drives the divisor negative — the ~2 nm resolution ceiling on standard Ag/Au fits. Kept only for reproducing pre-existing results.
+- `"centered_edot"` centres that term: second order for all `b`, halves `c4`, restores the cancellation. **Identical to `"central"` in all five coefficients when `b = 0`**, so Lorentz/Drude materials are unaffected by the default.
+- `"bilinear"` (trapezoidal / Newmark-equivalent) is second order, **unconditionally stable**, and exact at DC — but `c4 ≠ 0` even at `b = 0`, so *every* material becomes implicit, and it is rejected for oriented poles. Opt in with `DispersionModel.with_integrator("bilinear")`.
+
+Stability: `"central"`/`"centered_edot"` need the forward Jury bound `ω₀·dt < 2`; `"bilinear"` carries no such bound. `γ·dt` is unconstrained in all schemes (`|c2| < 1` for any `γ·dt > 0`).
+
+**Observer-canonical realization.** A non-zero `c5` would need an `E^(n-1)` field history. The loop therefore marches the observer form of the same transfer function `χ_d(z) = (c4z² + c3z + c5)/(z² − c1z − c2)`:
+```text
+x1^(n+1) = c1·x1^n + x2^n + β1·E^n      β1 = c3 + c1·c4
+x2^(n+1) = c2·x1^n        + β0·E^n      β0 = c5 + c2·c4
+p^(n+1)  = x1^(n+1) + c4·E^(n+1)
+```
+Two state levels, no field history, per-cell. `to_observer_form(c1..c5)` does the conversion.
+
+**Delta basis — what is actually stored and marched.** The observer form is exact but unusable in float32: in the physical regime `c1 → 2`, `c2 → −1` and all the physics lives in the residuals. For a *real* pole (`Im q = 0`, the near-DC pole of every vector-fitted metal) `1 − c1 − c2 = ω₀²dt²/D` is *quadratically* small, so below ~2 nm it drops under the float32 ulp of `c1 ≈ 2` and the pole's DC response becomes round-off — an error that **grows** under grid refinement. Expanding the same rational function in `ζ = z − 1` puts those residuals directly in the stored numbers:
+```text
+a1 = 2 − c1,  a0 = 1 − c1 − c2,  b1 = β1,  b0 = β1 + β0
+state (x1, y2 = x1 + x2), both zero-initialized:
+dx1^n    = y2^n − a1·x1^n + b1·E^n
+y2^(n+1) = y2^n − a0·x1^n + b0·E^n
+x1^(n+1) = x1^n + dx1^n
+p^(n+1)  = x1^(n+1) + c4·E^(n+1)
+```
+`compute_pole_delta_coefficients_per_axis` / `_tensor` build these from cancellation-free closed forms (sums of same-signed terms), so each coefficient keeps full *relative* precision; `to_delta_form(c1..c5)` is the generic (float64-only) converter. Measured on gold at 1 nm this drops the realized `ε''` error from +33% to +0.07%. **`dispersive_a1` is `2 − c1`, `dispersive_a0` is `1 − c1 − c2`, `dispersive_b1` is `β1` (not `c3`), and `dispersive_y2` is `x1 + x2` (neither `x2` nor `p^(n-1)`).** Zero-padded and non-dispersive slots must be produced by zero-padding the *delta* coefficients — converting padded P-form zeros would yield `(a1, a0) = (2, 1)` instead of an inert slot.
+
+**Implicit divisor** (only when some `c4 ≠ 0`): `1 + inv_eps·Σc4 [+ conductivity term]`, validated at init by `validate_dispersive_divisor_stability` (which resolves `c4` through each pole's own integrator — a check keyed on `coupling_edot` alone would wrongly skip bilinear Lorentz/Drude).
 
 **Per-axis (diagonally anisotropic) dispersion:** every pole parameter accepts a scalar or a per-axis 3-tuple `(x, y, z)` — e.g. `DrudePole(plasma_frequency=(wp, 0.0, 0.0), damping=g)` for a hyperbolic medium metallic only along x. The canonical pole accessors are `omega_0_axes`/`gamma_axes`/`coupling_sq_axes`/`coupling_edot_axes` (the scalar `omega_0` etc. raise for per-axis poles). `compute_pole_coefficients_per_axis` returns `(n_poles, 3)` coefficient arrays; `DispersionModel.susceptibility_axes(omega)` gives per-axis χ. Static negative ε is unconditionally unstable in FDTD — hyperbolic/metallic behavior must come from poles with ε∞ ≥ 1 (`Material.__init__` warns otherwise).
 
-**Oriented (off-diagonal) dispersion:** a pole may carry an `orientation` unit vector — a single 1D oscillator along `u` with coupling tensor `K u uᵀ` (scalar parameters only; oriented CCPR with dE/dt coupling raises). `DispersionModel.rotated(R)` (3x3 matrix or Euler angles) converts a per-axis model into oriented poles for tilted crystals (signed axis permutations stay per-axis; pole count can grow up to 3x otherwise). `compute_pole_coefficients_tensor` returns c1/c2 `(n, 3)` + c3/c4 `(n, 9)`; `susceptibility_tensor(omega)`/`permittivity_tensor` give the 3x3 χ/ε. Oriented dispersion forces the 9-component ε tier (fully anisotropic kernel, which carries its own ADE block with Yee-averaged off-diagonal coupling).
+**Oriented (off-diagonal) dispersion:** a pole may carry an `orientation` unit vector — a single 1D oscillator along `u` with coupling tensor `K u uᵀ` (scalar parameters only; oriented CCPR with dE/dt coupling raises, as does `integrator="bilinear"`). `DispersionModel.rotated(R)` (3x3 matrix or Euler angles) converts a per-axis model into oriented poles for tilted crystals (signed axis permutations stay per-axis; pole count can grow up to 3x otherwise). `compute_pole_coefficients_tensor` returns c1/c2 `(n, 3)` + c3/c4/c5 `(n, 9)` (delta-basis counterpart: `compute_pole_delta_coefficients_tensor` → a1/a0 `(n, 3)` + b1/c4/b0 `(n, 9)`); `susceptibility_tensor(omega)`/`permittivity_tensor` give the 3x3 χ/ε. Oriented dispersion forces the 9-component ε tier (fully anisotropic kernel, which carries its own ADE block with Yee-averaged off-diagonal coupling).
 
 **ArrayContainer fields** (all `None` unless any object is dispersive):
-- `dispersive_P_curr`, `dispersive_P_prev` — shape `(num_poles, 3, Nx, Ny, Nz)`, field-dtype (complex if `use_complex_fields`). Not differentiable (state-only; `None` cotangent in both gradient paths).
-- `dispersive_c1`, `dispersive_c2`, `dispersive_c3` — shape `(num_poles, C, Nx, Ny, Nz)`. For `c1`/`c2`, `C = 1` when all dispersion is isotropic (middle axis broadcasts over field components) or `C = 3` for per-axis dispersion (gated by `ObjectContainer.all_objects_isotropic_dispersion`). The coupling `c3` (and `c4`) additionally widens to `C = 9` (row-major 3x3 tensor per pole) when any pole is oriented (gated by `ObjectContainer.all_objects_axis_aligned_dispersion`). Config dtype. Differentiable: cotangents flow through them on the checkpointed path.
+- `dispersive_x1`, `dispersive_y2` — delta-basis ADE state, shape `(num_poles, 3, Nx, Ny, Nz)`, field-dtype (complex if `use_complex_fields`). Not differentiable (state-only; `None` cotangent). `p^n = x1^n + c4·E^n`, so `x1 == p` exactly when `dispersive_c4 is None`.
+- `dispersive_a1`, `dispersive_a0`, `dispersive_b1` — shape `(num_poles, C, Nx, Ny, Nz)`. For `a1`/`a0`, `C = 1` when all dispersion is isotropic (middle axis broadcasts over field components) or `C = 3` for per-axis dispersion (gated by `ObjectContainer.all_objects_isotropic_dispersion`). The couplings `b1` (and `c4`/`b0`) additionally widen to `C = 9` (row-major 3x3 tensor per pole) when any pole is oriented (gated by `ObjectContainer.all_objects_axis_aligned_dispersion`). Config dtype. Differentiable: cotangents flow through them on the checkpointed path.
+- `dispersive_c4`, `dispersive_b0` — allocated **together**, and only when some pole yields `c4 ≠ 0`: a non-zero `coupling_edot` under a central-difference scheme, or *any* pole under `"bilinear"`. Gated by `ObjectContainer.needs_implicit_dispersion(dt)` (which needs `dt`, since the coefficients do). Both `None` for Lorentz/Drude on the default scheme, which then takes the fully explicit path — and when `b0` is `None` the update substitutes `b1`, which is bit-exact because `c4 = c5 = 0` implies `β0 = 0`. Differentiable.
 
-**Leading pole axis size:** `objects.max_num_dispersive_poles` — the max pole count across all `UniformMaterialObject`, `Device`, `StaticMultiMaterialObject`. Materials with fewer poles get zero-padded slots, so non-dispersive cells automatically contribute zero. `UniformMaterialObject` always writes the full zero-padded coefficient stack into its `grid_slice`, so a non-dispersive object placed over a dispersive one cleanly clears stale coefficients.
+**Leading pole axis size:** `objects.max_num_dispersive_poles` — the max pole count across all `UniformMaterialObject`, `Device`, `StaticMultiMaterialObject`. Materials with fewer poles get zero-padded slots, so non-dispersive cells automatically contribute zero (`b1 = b0 = 0` pins their state at zero forever). `UniformMaterialObject` always writes the full zero-padded coefficient stack into its `grid_slice`, so a non-dispersive object placed over a dispersive one cleanly clears stale coefficients.
 
-**Restriction:** *Any* dispersive material supports only the `checkpointed` gradient method. `reversible` raises `NotImplementedError` at three layers — `place_objects`, `reversible_fdtd`/`run_fdtd`, and `update_E_reverse` (so the public `full_backward`/`backward` API raises too, gradients or not). Dispersion combined with fully anisotropic (off-diagonal) ε/σ tensors or oriented poles additionally runs through the fully anisotropic update path, where CCPR poles with a dE/dt coupling (`c4`) are rejected (no implicit tensor solve).
+**Restriction:** *Any* dispersive material supports only the `checkpointed` gradient method. `reversible` raises `NotImplementedError` at three layers — `place_objects`, `reversible_fdtd`/`run_fdtd`, and `update_E_reverse` (so the public `full_backward`/`backward` API raises too, gradients or not). Dispersion combined with fully anisotropic (off-diagonal) ε/σ tensors or oriented poles additionally runs through the fully anisotropic update path, where poles with a non-zero implicit `c4` — a dE/dt coupling, or any pole under `"bilinear"` — are rejected (the `E^(n+1)` term would become a per-cell 3x3 solve entangled with the off-diagonal Yee averaging).
 
 **Devices with dispersive materials:** `apply_params` interpolates ADE coefficients the same way it interpolates `inv_permittivities` — linearly between the two bracketing materials for `CONTINUOUS` output, straight-through-estimator for `DISCRETE`. This is not equivalent to interpolating the pole *parameters*, but it keeps gradients smooth for inverse design.
 
 **Evaluating χ(ω) / ε(ω) from stored coefficients** (useful in sources, detectors, setup-time analysis):
-- `susceptibility_from_coefficients(c1, c2, c3, omega, dt)` → JAX complex array of per-cell χ(ω), summed over poles.
-- `effective_inv_permittivity(inv_eps, c1, c2, c3, omega, dt)` → real 1/Re(ε∞ + χ(ω)); used by sources to sample the true medium at the carrier frequency (imaginary part is already handled by the ADE loop — injecting it would double-count).
-- `compute_eps_spectrum_from_coefficients(c1, c2, c3, inv_eps_inf, omegas, dt, weights=None)` → host-side numpy; volume-averaged complex ε(ω) spectrum for a block of cells.
+- `susceptibility_from_coefficients(a1, a0, b1, omega, dt, c4=..., b0=...)` → JAX complex array of per-cell χ(ω), summed over poles. Evaluates the **discrete** `χ_d(ζ) = c4 + (b1·ζ + b0)/(ζ² + a1·ζ + a0)` at `ζ = exp(−iωdt) − 1` — i.e. the permittivity the grid actually realizes, which differs from the continuum χ by the scheme's `O((ω·dt)²)` truncation. Scheme-agnostic by construction (no knowledge of which integrator produced the coefficients); pole-free cells have all-zero coefficients and a denominator of `ζ² ≠ 0`, so they contribute exactly zero with no masking. Evaluating in `ζ` also keeps the *evaluation* well conditioned at low frequency.
+- `effective_inv_permittivity(inv_eps, a1, a0, b1, omega, dt, c4=..., b0=...)` → real 1/Re(ε∞ + χ_d(ω)); used by sources to sample the true medium at the carrier frequency (imaginary part is already handled by the ADE loop — injecting it would double-count).
+- `compute_eps_spectrum_from_coefficients(a1, a0, b1, inv_eps_inf, omegas, dt, weights=None, c4=..., b0=...)` → host-side numpy; volume-averaged complex ε(ω) spectrum for a block of cells.
 - `compute_impedance_corrected_temporal_profile(raw_samples, dt, eps_spectrum, eps_center)` → applies the FIR filter `G(ω) = √(ε(ω)/ε(ω_c))` to an E-side temporal profile, producing the H-side profile for broadband TFSF injection.
 
 ## Constraint System
@@ -263,7 +295,7 @@ E_full = fdtdx.unfold_fields(arrays.fields.E, config.symmetry, "E")  # (3, Nx, N
 - Uses `@jax.custom_vjp` — forward pass runs simulation recording boundaries, backward pass reconstructs fields in reverse
 - Requires a `Recorder` with optional compression modules (e.g., `DtypeConversion(dtype=jnp.bfloat16)`)
 - Differentiable primals: `inv_permittivities`, `inv_permeabilities`. Conductivity arrays are closure-captured non-primals.
-- **Rejects dispersive materials** (`NotImplementedError`) — reversing the ADE polarization recurrence is under active development. Lossy (conductive) materials are supported; `num_checkpoints_reversible` bounds the reverse-reconstruction drift they cause.
+- **Rejects dispersive materials** (`NotImplementedError`) — reversing the ADE recurrence is under active development. Lossy (conductive) materials are supported; `num_checkpoints_reversible` bounds the reverse-reconstruction drift they cause.
 
 **Checkpointed FDTD** (`method="checkpointed"`):
 - Standard gradient checkpointing via `eqxi.while_loop(kind="checkpointed")`
@@ -318,7 +350,8 @@ device = fdtdx.Device(
 **`SimulationObject.apply()` signature** — `apply_params` passes dispersive coefficients through to every object:
 ```python
 def apply(self, *, key, inv_permittivities, inv_permeabilities,
-          dispersive_c1=None, dispersive_c2=None, dispersive_c3=None): ...
+          dispersive_a1=None, dispersive_a0=None, dispersive_b1=None,
+          dispersive_c4=None, dispersive_b0=None): ...
 ```
 Coefficient arrays are passed with `stop_gradient` (matching how `inv_permittivities` is passed to source apply) — the FDTD VJP itself still differentiates through them, this only avoids gradient noise from the source amplitude path. Objects that don't use them (detectors, boundaries, uniform material objects) just `del` the kwargs; sources use them to sample the real medium at the carrier frequency.
 
@@ -418,14 +451,14 @@ assert jnp.all(jnp.isfinite(grads))
 - **Forgetting `.aset()`**: Direct attribute assignment on TreeClass objects silently fails or raises. Always use `.aset()`.
 - **Material array sizing is global**: Adding one anisotropic object forces ALL material arrays to expand. Check `ObjectContainer` isotropy properties.
 - **PML + reversible gradients**: PML breaks time-reversal. Must set up `Recorder` and `recording_state` for boundary interfaces.
-- **Complex fields**: Bloch boundaries with nonzero k-vector automatically require complex fields. Check `config.use_complex_fields`. When complex fields are in effect, ADE polarization arrays (`dispersive_P_curr/prev`) are also allocated as complex.
+- **Complex fields**: Bloch boundaries with nonzero k-vector automatically require complex fields. Check `config.use_complex_fields`. When complex fields are in effect, ADE state arrays (`dispersive_x1/y2`) are also allocated as complex.
 - **Conductivity scaling**: Conductivity values are multiplied by `config.resolution` during `_init_arrays()`. Don't pre-scale.
 - **Inverse storage**: Material arrays store `1/epsilon` and `1/mu`, not epsilon and mu directly. For dispersive materials, `Material.permittivity` represents ε∞ only — the full ε(ω) must be reconstructed via the dispersion model.
 - **Detector timing**: Detectors only record at timesteps where their `OnOffSwitch` is active. Check `switch` configuration if data appears missing.
 - **donate_argnames**: When JIT-compiling simulation functions, use `donate_argnames=["arrays"]` to allow JAX to reuse array memory.
 - **Dispersion needs `method="checkpointed"`**: every dispersive gradient path raises under `reversible` (which is the *default* `GradientConfig` method — set it explicitly). Dispersion + full anisotropic is supported via the fully anisotropic kernel. Oriented poles force the 9-component ε tier for the whole simulation — memory and per-step cost grow accordingly; prefer per-axis poles when the optical axes align with the grid.
 - **Complex full tensors**: `Material.from_complex_permittivity` accepts flat 9-tuples / nested 3x3 complex tensors — real parts → ε tensor, imaginary parts → σ tensor (exact at one frequency). `from_refractive_index` rejects tensors (matrix vs elementwise square ambiguity).
-- **Dispersive pole count is max'd globally**: The `num_poles` leading axis size = `objects.max_num_dispersive_poles`. Adding one 3-pole material allocates 3 pole slots for every dispersive cell in the sim; non-dispersive cells still have their `c1/c2/c3` set to zero (ADE term vanishes) but consume array memory.
+- **Dispersive pole count is max'd globally**: The `num_poles` leading axis size = `objects.max_num_dispersive_poles`. Adding one 3-pole material allocates 3 pole slots for every dispersive cell in the sim; non-dispersive cells still have their `a1/a0/b1` set to zero (ADE term vanishes) but consume array memory.
 - **Dispersive source impedance**: Inside a dispersive medium, never use ε∞ as the source's effective permittivity — call `effective_inv_permittivity` at ω_c. Broadband pulses additionally need the `_temporal_H_filter` path to avoid TFSF leakage at off-carrier frequencies.
 - **Stacking objects with mixed dispersion**: `UniformMaterialObject` always writes a full zero-padded pole-coefficient stack into its `grid_slice`, so placing a non-dispersive object over a dispersive one cleanly overwrites stale coefficients. Rely on this rather than assuming "no dispersion = leave coefficients alone".
 - **Symmetry results look wrong / are half-size**: with `config.symmetry` set, `run_fdtd` returns *reduced-domain* arrays — you must call `fdtdx.unfold_detector_states` / `fdtdx.unfold_fields` to get full-domain results (see Simulation Symmetry). `place_objects` warns about this. Unfolding a non-symmetric model raises.

--- a/docs/source/07_api.rst
+++ b/docs/source/07_api.rst
@@ -28,6 +28,8 @@ API
     fdtdx.compute_pole_coefficients
     fdtdx.compute_pole_coefficients_per_axis
     fdtdx.compute_pole_coefficients_tensor
+    fdtdx.compute_pole_delta_coefficients_per_axis
+    fdtdx.compute_pole_delta_coefficients_tensor
     fdtdx.compute_poynting_flux
     fdtdx.ConnectHolesAndStructures
     fdtdx.CustomTimeSignalProfile
@@ -37,6 +39,8 @@ API
     fdtdx.Device
     fdtdx.DiagonalSymmetry2D
     fdtdx.DiagonalSymmetry3D
+    fdtdx.DISPERSION_INTEGRATORS
+    fdtdx.DispersionIntegrator
     fdtdx.DispersionModel
     fdtdx.DrudePole
     fdtdx.DtypeConversion
@@ -127,6 +131,8 @@ API
     fdtdx.TanhProjection
     fdtdx.TemporalProfile
     fdtdx.TFSFPlaneSourceRegion
+    fdtdx.to_delta_form
+    fdtdx.to_observer_form
     fdtdx.TreeClass
     fdtdx.unfold_array
     fdtdx.unfold_detector_states

--- a/src/fdtdx/__init__.py
+++ b/src/fdtdx/__init__.py
@@ -35,7 +35,9 @@ from fdtdx.core.physics.modes import compute_mode
 from fdtdx.core.switch import OnOffSwitch
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.dispersion import (
+    DISPERSION_INTEGRATORS,
     CCPRPole,
+    DispersionIntegrator,
     DispersionModel,
     DrudePole,
     LorentzPole,
@@ -45,6 +47,10 @@ from fdtdx.dispersion import (
     compute_pole_coefficients,
     compute_pole_coefficients_per_axis,
     compute_pole_coefficients_tensor,
+    compute_pole_delta_coefficients_per_axis,
+    compute_pole_delta_coefficients_tensor,
+    to_delta_form,
+    to_observer_form,
 )
 from fdtdx.fdtd.backward import full_backward
 from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer, ParameterContainer, SimulationState
@@ -162,6 +168,7 @@ ParameterContainer = ParameterContainer
 SimulationState = SimulationState
 
 __all__ = [
+    "DISPERSION_INTEGRATORS",
     "ArrayContainer",
     "BinaryMedianFilterModule",
     "BlochBoundary",
@@ -180,6 +187,7 @@ __all__ = [
     "Device",
     "DiagonalSymmetry2D",
     "DiagonalSymmetry3D",
+    "DispersionIntegrator",
     "DispersionModel",
     "DrudePole",
     "DtypeConversion",
@@ -266,6 +274,8 @@ __all__ = [
     "compute_pole_coefficients",
     "compute_pole_coefficients_per_axis",
     "compute_pole_coefficients_tensor",
+    "compute_pole_delta_coefficients_per_axis",
+    "compute_pole_delta_coefficients_tensor",
     "compute_poynting_flux",
     "detectors_from_gds_ports",
     "export_arrays_snapshot_to_vti",
@@ -299,6 +309,8 @@ __all__ = [
     "run_fdtd",
     "setup_sparams_simulation",
     "sources_from_gds_ports",
+    "to_delta_form",
+    "to_observer_form",
     "unfold_array",
     "unfold_detector_states",
     "unfold_fields",

--- a/src/fdtdx/dispersion.py
+++ b/src/fdtdx/dispersion.py
@@ -31,42 +31,211 @@ where ``coupling_sq`` is the effective squared coupling frequency
 
 Discrete update
 ---------------
-Central differences at integer time ``n``:
+Every integrator produces the same two-level rational map
 
 .. math::
-    p_p^{n+1} = c_1 p_p^{n} + c_2 p_p^{n-1} + c_3 E^{n}
+    \\chi_d(z) = \\frac{c_4 z^2 + c_3 z + c_5}{z^2 - c_1 z - c_2},
+    \\qquad z = e^{-i \\omega \\Delta t}
 
-with coefficients derived from the unified pole parameters and time
-step ``dt``:
+i.e. the "P-form" recurrence
 
 .. math::
-    c_1 = \\frac{2 - \\omega_0^2 \\Delta t^2}{1 + \\gamma \\Delta t / 2}, \\quad
-    c_2 = -\\frac{1 - \\gamma \\Delta t / 2}{1 + \\gamma \\Delta t / 2}, \\quad
-    c_3 = \\frac{K \\Delta t^2}{1 + \\gamma \\Delta t / 2}
+    p_p^{n+1} = c_1 p_p^{n} + c_2 p_p^{n-1} + c_3 E^{n} + c_4 E^{n+1}
+                + c_5 E^{n-1}.
 
-**Forward unit-circle (Jury) stability** constrains the coefficients and is
-enforced in :func:`compute_pole_coefficients_per_axis` (only on axes where the
-pole actually couples, since a zero-coupling axis keeps its polarization
-identically zero). The roots of :math:`z^2 - c_1 z - c_2 = 0` lie inside the
-unit circle iff :math:`|c_2| < 1` *and* :math:`|c_1| < 1 - c_2`. The first
-holds for every :math:`\\gamma \\Delta t > 0` (:math:`c_2 = 0` at
-:math:`\\gamma \\Delta t = 2` and :math:`|c_2| \\to 1` only as
-:math:`\\gamma \\Delta t \\to 0` or :math:`\\infty`), so it is not the binding
-constraint. The second is algebraically equivalent to
+Because the discrete Ampere law consumes only
+:math:`\\varepsilon_\\infty (E^{n+1} - E^n) + \\sum_p (p_p^{n+1} - p_p^n)`, the
+permittivity the grid actually realizes is exactly
+:math:`\\varepsilon_\\infty + \\chi_d(z)` — which is what
+:func:`susceptibility_from_coefficients` evaluates.
+
+Three schemes are available per pole via :attr:`Pole.integrator`
+(``D = 1 + \\gamma \\Delta t / 2``, ``K = 2 / \\Delta t``,
+``D_b = K^2 + \\gamma K + \\omega_0^2``):
+
+``"central"``
+    Central differences on the 2nd-order ODE with a **forward** difference on
+    the :math:`b \\dot E` term. Second-order accurate for :math:`b = 0`, but only
+    **first order** whenever :math:`b \\neq 0`, and its leading error is *real*,
+    so it perturbs the in-phase coupling :math:`a` rather than merely shifting
+    the pole. Kept for reproducing pre-existing results.
+
+    .. math::
+        c_1 = \\frac{2 - \\omega_0^2 \\Delta t^2}{D}, \\quad
+        c_2 = -\\frac{1 - \\gamma \\Delta t / 2}{D}, \\quad
+        c_3 = \\frac{a \\Delta t^2 - b \\Delta t}{D}, \\quad
+        c_4 = \\frac{b \\Delta t}{D}, \\quad c_5 = 0
+
+``"centered_edot"`` (default)
+    Same oscillator, with :math:`b \\dot E` **centred** so every term of the ODE
+    sits at time :math:`n`. Second order for all :math:`b`, and it halves
+    :math:`c_4`, which is what keeps the implicit divisor below well conditioned.
+
+    .. math::
+        c_3 = \\frac{a \\Delta t^2}{D}, \\quad
+        c_4 = \\frac{b \\Delta t}{2 D}, \\quad
+        c_5 = -\\frac{b \\Delta t}{2 D}
+
+    (:math:`c_1`, :math:`c_2` as for ``"central"``.) For :math:`b = 0` all five
+    coefficients coincide with ``"central"``, so Lorentz and Drude poles are
+    unaffected by the choice.
+
+``"bilinear"``
+    Trapezoidal / bilinear map :math:`s \\to K (z-1)/(z+1)`. Second order,
+    **unconditionally stable** (it maps the open left half-plane exactly onto
+    the open unit disk), and exact at DC. Not supported for oriented poles.
+
+    .. math::
+        c_1 = \\frac{2 (K^2 - \\omega_0^2)}{D_b}, \\quad
+        c_2 = -\\frac{K^2 - \\gamma K + \\omega_0^2}{D_b}, \\quad
+        c_3 = \\frac{2 a}{D_b}, \\quad
+        c_4 = \\frac{a + b K}{D_b}, \\quad
+        c_5 = \\frac{a - b K}{D_b}
+
+    Note :math:`c_4 \\neq 0` even for :math:`b = 0`, so *every* material becomes
+    implicit under this scheme.
+
+Observer-canonical realization
+------------------------------
+A non-zero :math:`c_5` would make the P-form need an :math:`E^{n-1}` array — an
+extra full field history per pole. The FDTD loop therefore marches the
+observer-canonical realization of the same :math:`\\chi_d(z)`:
+
+.. math::
+    x_1^{n+1} &= c_1 x_1^n + x_2^n + \\beta_1 E^n, \\qquad
+    \\beta_1 = c_3 + c_1 c_4 \\\\
+    x_2^{n+1} &= c_2 x_1^n \\phantom{{}+ x_2^n} + \\beta_0 E^n, \\qquad
+    \\beta_0 = c_5 + c_2 c_4 \\\\
+    p^{n+1}   &= x_1^{n+1} + c_4 E^{n+1}
+
+which carries every scheme with two state levels, no field history, and a
+purely per-cell polarization update. See :func:`to_observer_form`. This is the
+*algebraic* reference form; what the loop actually stores and marches is its
+delta-basis rewrite below.
+
+Delta basis (what is stored, and why)
+-------------------------------------
+The observer form above is mathematically exact but **numerically unusable in
+float32**. In the physical regime :math:`\\gamma \\Delta t, \\omega_0 \\Delta t
+\\ll 1` its coefficients crowd against fixed values,
+
+.. math::
+    c_1 \\to 2, \\qquad c_2 \\to -1,
+
+while every quantity of physical interest lives in the *residuals*. The
+denominator's constant term is the extreme case: for a **real** pole
+(:math:`\\mathrm{Im}\\,q = 0`, the near-DC pole of every vector-fitted metal),
+:math:`\\omega_0 = \\gamma / 2` gives a double root and
+
+.. math::
+    1 - c_1 - c_2 = \\frac{\\omega_0^2 \\Delta t^2}{D}
+    \\quad\\sim\\quad (\\omega_0 \\Delta t)^2 ,
+
+which is *quadratically* small. float32 resolves :math:`c_1 \\approx 2` only to
+:math:`1.2 \\times 10^{-7}` absolute, so once
+:math:`(\\omega_0 \\Delta t)^2` drops below that — for gold's
+:math:`|q| = 1.28 \\times 10^{14}\\,\\mathrm{s}^{-1}` this happens between 2 nm and
+1 nm — the pole's entire DC response is round-off noise. Because refining the
+grid *shrinks* :math:`\\Delta t`, the error **grows** under refinement: it
+overtakes the :math:`O(\\Delta t^2)` truncation error and the simulation gets
+less accurate the finer the grid.
+
+The cure is a change of basis. Expanding the same rational function in
+:math:`\\zeta = z - 1` instead of :math:`z`,
+
+.. math::
+    z^2 - c_1 z - c_2 &= \\zeta^2 + a_1 \\zeta + a_0, \\qquad
+    a_1 = 2 - c_1, \\quad a_0 = 1 - c_1 - c_2 \\\\
+    \\beta_1 z + \\beta_0 &= b_1 \\zeta + b_0, \\qquad
+    b_1 = \\beta_1, \\quad b_0 = \\beta_1 + \\beta_0
+
+puts the small residuals *in* the stored numbers, where float32 gives them full
+**relative** precision. They have closed forms that are sums of non-negative
+terms, so they are assembled without any subtraction (see
+:func:`_scheme_delta_coefficients`):
+
+.. math::
+    \\text{central / centered\\_edot:} \\quad
+    a_1 = \\frac{\\gamma \\Delta t + \\omega_0^2 \\Delta t^2}{D}, \\quad
+    a_0 = \\frac{\\omega_0^2 \\Delta t^2}{D} \\\\
+    \\text{bilinear:} \\quad
+    a_1 = \\frac{2 \\gamma K + 4 \\omega_0^2}{D_b}, \\quad
+    a_0 = \\frac{4 \\omega_0^2}{D_b}
+
+Since :math:`\\zeta` is the forward-difference operator, the time-domain
+realization is the observer form written **incrementally**. With the state
+:math:`(x_1, y_2) = (x_1, x_1 + x_2)` — an exact linear change of variables,
+both still zero-initialized:
+
+.. math::
+    \\Delta x_1^n &= y_2^n - a_1 x_1^n + b_1 E^n
+        \\qquad (= x_1^{n+1} - x_1^n) \\\\
+    y_2^{n+1} &= y_2^n - a_0 x_1^n + b_0 E^n \\\\
+    x_1^{n+1} &= x_1^n + \\Delta x_1^n \\\\
+    p^{n+1}   &= x_1^{n+1} + c_4 E^{n+1}
+
+This removes two further float32 cancellations for free: :math:`y_2 = x_1 + x_2`
+is :math:`O(\\Delta x_1)` where :math:`x_2 \\approx -x_1` was not, and the
+increment :math:`p^n - x_1^{n+1} = c_4 E^n - \\Delta x_1^n` that Ampere's law
+consumes is now *computed* rather than recovered by subtracting two nearly
+equal large numbers. Measured on gold at 1 nm, that increment's error drops from
+:math:`8 \\times 10^{-4}` to :math:`9 \\times 10^{-8}` (float32 machine
+precision), and the realized :math:`\\varepsilon''` error from +33% to +0.07%.
+
+Cost is nil: five coefficient arrays before and after, two state arrays before
+and after, and one extra add per pole per component per step.
+
+The stored arrays therefore hold :math:`(a_1, a_0, b_1, c_4, b_0)` —
+``dispersive_a1`` is :math:`2 - c_1` and ``dispersive_a0`` is
+:math:`1 - c_1 - c_2`, **not** :math:`c_1` and :math:`c_2`. Zero-padded and
+non-dispersive slots stay all-zero and remain inert (:math:`b_1 = b_0 = 0`
+keeps the state at zero forever), so they must be produced by zero-padding the
+delta coefficients, never by converting padded P-form zeros — the latter would
+yield :math:`(a_1, a_0) = (2, 1)`.
+``dispersive_y2`` holds :math:`x_1 + x_2`, which is neither :math:`x_2` nor
+:math:`p^{n-1}`.
+
+Stability
+---------
+**Forward unit-circle (Jury) stability** is enforced in
+:func:`compute_pole_coefficients_per_axis`, only on axes where the pole actually
+couples (a zero-coupling axis keeps its polarization identically zero). The
+roots of :math:`z^2 - c_1 z - c_2 = 0` lie inside the unit circle iff
+:math:`|c_2| < 1` *and* :math:`|c_1| < 1 - c_2`. For ``"central"`` /
+``"centered_edot"`` the first holds for every :math:`\\gamma \\Delta t > 0`
+(:math:`c_2 = 0` at :math:`\\gamma \\Delta t = 2` and :math:`|c_2| \\to 1` only
+as :math:`\\gamma \\Delta t \\to 0` or :math:`\\infty`), so it is not the binding
+constraint; the second is algebraically equivalent to
 :math:`\\omega_0 \\Delta t < 2` (independent of :math:`\\gamma`), which is
-therefore the stability bound.
+therefore the forward-stability bound. ``"bilinear"`` satisfies both for every
+:math:`\\Delta t` and carries no such bound.
 
-For CCPR poles the polarization couples to :math:`E^{n+1}` through
-:math:`c_4`, so the E-field update divides by a per-cell implicit factor
-:math:`1 + \\varepsilon_\\infty^{-1} \\sum_p c_{4,p}\\ (+\\ c\\,\\sigma\\,\\eta_0\\,\\varepsilon_\\infty^{-1} / 2)`.
-This must stay positive in every cell; as it approaches :math:`0^+` the
+Implicit divisor
+----------------
+When :math:`c_4 \\neq 0` the polarization couples to :math:`E^{n+1}`, so the
+E-field update divides by a per-cell factor
+
+.. math::
+    1 + \\varepsilon_\\infty^{-1} \\sum_p c_{4,p}
+    \\ (+\\ c\\,\\sigma\\,\\eta_0\\,\\varepsilon_\\infty^{-1} / 2)
+
+which must stay positive in every cell; as it approaches :math:`0^+` the
 transient gain (:math:`\\approx 1/\\text{divisor}`) explodes and accuracy
-collapses. Since :math:`c_4 \\propto \\Delta t \\propto` ``courant_factor``,
-the divisor can be kept safe by lowering ``courant_factor``. This per-cell
-condition is checked at initialization by
-:func:`fdtdx.materials.validate_dispersive_divisor_stability` (Lorentz and
-Drude poles have :math:`c_4 = 0`, so their divisor is always
-:math:`\\geq 1`).
+collapses. Checked at initialization by
+:func:`fdtdx.materials.validate_dispersive_divisor_stability`.
+
+For a *physical* CCPR fit the total :math:`1/\\omega` tail of
+:math:`\\varepsilon(\\omega)` must vanish, i.e.
+:math:`\\sum_p b_p = -\\sigma / \\varepsilon_0`. Since the static conductivity
+enters the same divisor trapezoidally as
+:math:`\\sigma \\Delta t / (2 \\varepsilon_0 \\varepsilon_\\infty)`, the
+``"centered_edot"`` :math:`c_4 = b \\Delta t / (2 D)` makes the two terms cancel
+and the divisor sit near 1 at every resolution. ``"central"`` puts twice that
+on :math:`E^{n+1}`, overshooting the cancellation and driving the divisor
+negative — which is why standard Drude-critical-point metal fits cannot be run
+above a few nanometres under that scheme. Lorentz and Drude poles have
+:math:`c_4 = 0` under both central-difference schemes, so their divisor is
+identically 1.
 
 Anisotropic (per-axis) dispersion
 ---------------------------------
@@ -95,13 +264,14 @@ fully anisotropic update path.
 Gradients
 ---------
 Dispersive simulations currently support only the ``checkpointed`` gradient
-method; the ``reversible`` method rejects them (reversing the ADE polarization
-recurrence is under active development).
+method; the ``reversible`` method rejects them (reversing the ADE recurrence is
+under active development).
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Literal, get_args
 
 import jax
 import jax.numpy as jnp
@@ -109,6 +279,17 @@ import numpy as np
 
 from fdtdx.constants import eps0
 from fdtdx.core.jax.pytrees import TreeClass, autoinit, frozen_field
+
+#: Time-integrator variants available per pole. See the module docstring for the
+#: coefficient formulas, accuracy order and stability bound of each.
+DispersionIntegrator = Literal["central", "centered_edot", "bilinear"]
+
+#: Tuple form of :data:`DispersionIntegrator` for validation and iteration.
+DISPERSION_INTEGRATORS: tuple[str, ...] = get_args(DispersionIntegrator)
+
+#: Schemes whose recurrence roots leave the unit circle for ``omega_0 * dt >= 2``
+#: and therefore keep that guard. ``"bilinear"`` is unconditionally stable.
+_CONDITIONALLY_STABLE: frozenset[str] = frozenset({"central", "centered_edot"})
 
 
 def _broadcast_axis_param(value: float | complex | tuple) -> tuple:
@@ -180,11 +361,16 @@ def _permute_pole_axes(p: "Pole", perm: tuple[int, int, int]) -> "Pole":
             resonance_frequency=_remap(p.resonance_frequency),
             damping=_remap(p.damping),
             delta_epsilon=_remap(p.delta_epsilon),
+            integrator=p.integrator,
         )
     if isinstance(p, DrudePole):
-        return DrudePole(plasma_frequency=_remap(p.plasma_frequency), damping=_remap(p.damping))
+        return DrudePole(
+            plasma_frequency=_remap(p.plasma_frequency),
+            damping=_remap(p.damping),
+            integrator=p.integrator,
+        )
     if isinstance(p, CCPRPole):
-        return CCPRPole(pole=_remap(p.pole), residue=_remap(p.residue))
+        return CCPRPole(pole=_remap(p.pole), residue=_remap(p.residue), integrator=p.integrator)
     raise TypeError(
         f"Cannot rotate pole of type {type(p).__name__}; construct oriented poles directly for custom pole types."
     )
@@ -201,16 +387,22 @@ def _oriented_pole_for_axis(p: "Pole", axis: int, direction: tuple[float, float,
             damping=float(g[axis]),
             delta_epsilon=float(de[axis]),
             orientation=direction,
+            integrator=p.integrator,
         )
     if isinstance(p, DrudePole):
         wp = _broadcast_axis_param(p.plasma_frequency)
         g = _broadcast_axis_param(p.damping)
-        return DrudePole(plasma_frequency=float(wp[axis]), damping=float(g[axis]), orientation=direction)
+        return DrudePole(
+            plasma_frequency=float(wp[axis]),
+            damping=float(g[axis]),
+            orientation=direction,
+            integrator=p.integrator,
+        )
     if isinstance(p, CCPRPole):
         q = _broadcast_axis_param(p.pole)
         r = _broadcast_axis_param(p.residue)
         # Raises at construction if the residue has a real part (dE/dt coupling).
-        return CCPRPole(pole=complex(q[axis]), residue=complex(r[axis]), orientation=direction)
+        return CCPRPole(pole=complex(q[axis]), residue=complex(r[axis]), orientation=direction, integrator=p.integrator)
     raise TypeError(
         f"Cannot rotate pole of type {type(p).__name__}; construct oriented poles directly for custom pole types."
     )
@@ -242,10 +434,27 @@ class Pole(TreeClass, ABC):
     #: tensor ``K * u u^T``; all other pole parameters must be scalars.
     orientation: tuple[float, float, float] | None = frozen_field(default=None)
 
+    #: Time-integrator used to discretize this pole's ODE. See the module
+    #: docstring for the coefficient formulas. ``"centered_edot"`` (the default)
+    #: is second-order accurate for every pole type; ``"central"`` reproduces
+    #: the historical scheme and is only first order when the ``dE/dt`` coupling
+    #: is non-zero; ``"bilinear"`` is unconditionally stable but makes every
+    #: material implicit and does not support oriented poles.
+    integrator: DispersionIntegrator = frozen_field(default="centered_edot")
+
     def _validate_orientation(self):
-        """Normalize and validate :attr:`orientation`. Concrete pole classes call
-        this from ``__post_init__`` (which ``autoinit`` only invokes when defined
-        directly on the class, not inherited)."""
+        """Normalize and validate :attr:`orientation` and :attr:`integrator`.
+        Concrete pole classes call this from ``__post_init__`` (which ``autoinit``
+        only invokes when defined directly on the class, not inherited)."""
+        if self.integrator not in DISPERSION_INTEGRATORS:
+            raise ValueError(
+                f"Unknown dispersion integrator {self.integrator!r}; expected one of {DISPERSION_INTEGRATORS}."
+            )
+        if self.orientation is not None and self.integrator == "bilinear":
+            raise NotImplementedError(
+                "Oriented poles are not supported with integrator='bilinear': its non-zero c4 at every pole would "
+                "turn the off-diagonal coupling into a per-cell 3x3 implicit solve. Use 'centered_edot' instead."
+            )
         if self.orientation is None:
             return
         vec = self.orientation
@@ -540,6 +749,7 @@ class CCPRPole(Pole):
         phase: float,
         resonance_frequency: float,
         damping: float,
+        integrator: DispersionIntegrator = "centered_edot",
     ) -> "CCPRPole":
         r"""Build a CCPR pole from critical-point (modified-Lorentz) parameters.
 
@@ -561,6 +771,8 @@ class CCPRPole(Pole):
             phase: Phase :math:`\phi` (radians).
             resonance_frequency: Resonance :math:`\Omega` (rad/s).
             damping: Broadening :math:`\Gamma` (rad/s), ``> 0`` for loss.
+            integrator: Time integrator for the resulting pole. Defaults to
+                ``"centered_edot"``; see :attr:`Pole.integrator`.
 
         Returns:
             CCPRPole: Equivalent pole with the ``(q, r)`` above.
@@ -569,7 +781,7 @@ class CCPRPole(Pole):
 
         q = complex(-damping, -resonance_frequency)
         r = 1j * amplitude * resonance_frequency * cmath.exp(1j * phase)
-        return cls(pole=q, residue=r)
+        return cls(pole=q, residue=r, integrator=integrator)
 
 
 @autoinit
@@ -599,6 +811,29 @@ class DispersionModel(TreeClass):
     def has_off_diagonal_coupling(self) -> bool:
         """Whether any pole is oriented (contributing an off-diagonal coupling tensor)."""
         return any(p.is_oriented for p in self.poles)
+
+    def with_integrator(self, integrator: DispersionIntegrator) -> "DispersionModel":
+        """Return a copy of this model with every pole switched to ``integrator``.
+
+        Convenience for multi-pole fits, where setting the scheme pole by pole is
+        tedious. See :attr:`Pole.integrator` for the available schemes.
+
+        Args:
+            integrator: Time integrator to apply to all poles.
+
+        Returns:
+            DispersionModel: Copy with every pole's ``integrator`` replaced.
+        """
+        if integrator not in DISPERSION_INTEGRATORS:
+            raise ValueError(f"Unknown dispersion integrator {integrator!r}; expected one of {DISPERSION_INTEGRATORS}.")
+        # ``aset`` bypasses ``__post_init__``, so re-check the one cross-field
+        # constraint here rather than letting an invalid pole through silently.
+        if integrator == "bilinear" and self.has_off_diagonal_coupling:
+            raise NotImplementedError(
+                "Oriented poles are not supported with integrator='bilinear': its non-zero c4 at every pole would "
+                "turn the off-diagonal coupling into a per-cell 3x3 implicit solve. Use 'centered_edot' instead."
+            )
+        return DispersionModel(poles=tuple(p.aset("integrator", integrator) for p in self.poles))
 
     def susceptibility_tensor(self, omega: complex | float) -> np.ndarray:
         """Evaluate the full 3x3 complex susceptibility tensor :math:`\\chi_{ij}(\\omega)`.
@@ -786,44 +1021,219 @@ class DispersionModel(TreeClass):
         return eps_inf + self.susceptibility(omega)
 
 
+def _scheme_coefficients(
+    scheme: str,
+    omega_0: float,
+    gamma: float,
+    coupling_sq: float,
+    coupling_edot: float,
+    dt: float,
+) -> tuple[float, float, float, float, float]:
+    """Discrete P-form coefficients ``(c1, c2, c3, c4, c5)`` of one pole on one axis.
+
+    See the module docstring for the per-scheme formulas and their derivation.
+    """
+    a, b = coupling_sq, coupling_edot
+    if scheme == "bilinear":
+        # Trapezoidal / bilinear map s -> K (z - 1) / (z + 1). Exact at DC and
+        # unconditionally stable; c4 != 0 even at b = 0.
+        k = 2.0 / dt
+        denom = k * k + gamma * k + omega_0**2
+        c1 = 2.0 * (k * k - omega_0**2) / denom
+        c2 = -(k * k - gamma * k + omega_0**2) / denom
+        c3 = 2.0 * a / denom
+        c4 = (a + b * k) / denom
+        c5 = (a - b * k) / denom
+        return c1, c2, c3, c4, c5
+
+    # Central differences on the 2nd-order ODE; the two variants differ only in
+    # how the b * dE/dt term is differenced.
+    denom = 1.0 + 0.5 * gamma * dt
+    c1 = (2.0 - (omega_0**2) * (dt**2)) / denom
+    c2 = -(1.0 - 0.5 * gamma * dt) / denom
+    if scheme == "central":
+        # Forward difference b (E^{n+1} - E^n) / dt: first order whenever b != 0.
+        c3 = (a * dt**2 - b * dt) / denom
+        c4 = (b * dt) / denom
+        c5 = 0.0
+    else:  # "centered_edot"
+        # Central difference b (E^{n+1} - E^{n-1}) / (2 dt): second order, and
+        # half the implicit c4 of the forward difference.
+        c3 = (a * dt**2) / denom
+        c4 = (b * dt) / (2.0 * denom)
+        c5 = -(b * dt) / (2.0 * denom)
+    return c1, c2, c3, c4, c5
+
+
+def _scheme_delta_coefficients(
+    scheme: str,
+    omega_0: float,
+    gamma: float,
+    coupling_sq: float,
+    coupling_edot: float,
+    dt: float,
+) -> tuple[float, float, float, float, float]:
+    r"""Delta-basis coefficients ``(a1, a0, b1, c4, b0)`` of one pole on one axis.
+
+    The same discrete transfer function as :func:`_scheme_coefficients`, expanded
+    in :math:`\zeta = z - 1` rather than :math:`z`:
+
+    .. math::
+        \chi_d(\zeta) = c_4 + \frac{b_1 \zeta + b_0}{\zeta^2 + a_1 \zeta + a_0}
+
+    so that ``a1 = 2 - c1``, ``a0 = 1 - c1 - c2``, ``b1 = beta1`` and
+    ``b0 = beta1 + beta0``. See the module docstring for why the FDTD loop stores
+    and marches these instead of ``(c1, c2, beta1, c4, beta0)``.
+
+    Every expression below is a sum of same-signed terms, so each coefficient
+    carries full *relative* accuracy — the whole point of the basis change.
+    Computing ``a0`` as ``1 - c1 - c2`` instead would already have lost
+    :math:`(\omega_0 \Delta t)^{-2}` digits before the float32 cast.
+    """
+    a, b = coupling_sq, coupling_edot
+    if scheme == "bilinear":
+        k = 2.0 / dt
+        denom = k * k + gamma * k + omega_0**2
+        a1 = (2.0 * gamma * k + 4.0 * omega_0**2) / denom
+        a0 = 4.0 * omega_0**2 / denom
+        c3 = 2.0 * a / denom
+        c4 = (a + b * k) / denom
+        # b0 = c3 + c5 + (1 - a0) c4, and c3 + c5 + c4 = 4a / D_b = 2 c3 exactly:
+        # the +-b*K terms of c5 and c4 cancel analytically.
+        b0 = 2.0 * c3 - a0 * c4
+        return a1, a0, c3 + (2.0 - a1) * c4, c4, b0
+
+    # Central differences. D = 1 + gamma dt / 2.
+    denom = 1.0 + 0.5 * gamma * dt
+    a1 = (gamma * dt + (omega_0**2) * (dt**2)) / denom
+    a0 = ((omega_0**2) * (dt**2)) / denom
+    if scheme == "central":
+        c3 = (a * dt**2 - b * dt) / denom
+        c4 = (b * dt) / denom
+    else:  # "centered_edot"
+        c3 = (a * dt**2) / denom
+        c4 = (b * dt) / (2.0 * denom)
+    # For both central-difference variants c3 + c5 + c4 = a dt^2 / D: the b dt
+    # terms cancel analytically, so b0 never forms that difference numerically.
+    b0 = (a * dt**2) / denom - a0 * c4
+    return a1, a0, c3 + (2.0 - a1) * c4, c4, b0
+
+
+def to_delta_form(
+    c1: np.ndarray,
+    c2: np.ndarray,
+    c3: np.ndarray,
+    c4: np.ndarray,
+    c5: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    r"""Convert P-form recurrence coefficients to the delta basis.
+
+    Returns ``(a1, a0, b1, c4, b0)`` with ``a1 = 2 - c1``, ``a0 = 1 - c1 - c2``,
+    ``b1 = c3 + c1 c4`` and ``b0 = b1 + c5 + c2 c4`` — the arrays the FDTD loop
+    stores. See the module docstring for the derivation.
+
+    Prefer :func:`compute_pole_delta_coefficients_per_axis` /
+    :func:`compute_pole_delta_coefficients_tensor`, which build the same values
+    from the pole parameters via cancellation-free closed forms. This converter
+    is exact in float64 but loses :math:`(\omega_0 \Delta t)^{-2}` digits of
+    ``a0``, which matters once the result is stored in float32.
+
+    .. warning::
+        Do **not** apply this to zero-padded pole slots: all-zero P-form
+        coefficients map to ``(a1, a0) = (2, 1)``, whereas padded slots must stay
+        all-zero to remain inert. Zero-pad the delta coefficients instead.
+
+    Args:
+        c1: P-form coefficient array.
+        c2: P-form coefficient array.
+        c3: P-form coefficient array.
+        c4: P-form coefficient array (the implicit ``E^{n+1}`` coupling).
+        c5: P-form coefficient array (the ``E^{n-1}`` coupling).
+
+    Returns:
+        ``(a1, a0, b1, c4, b0)`` — ``c4`` unchanged.
+    """
+    b1 = c3 + c1 * c4
+    b0 = b1 + (c5 + c2 * c4)
+    return 2.0 - c1, 1.0 - c1 - c2, b1, c4, b0
+
+
+def to_observer_form(
+    c1: np.ndarray,
+    c2: np.ndarray,
+    c3: np.ndarray,
+    c4: np.ndarray,
+    c5: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    r"""Convert P-form recurrence coefficients to the observer-canonical form.
+
+    The P-form ``p^{n+1} = c1 p^n + c2 p^{n-1} + c3 E^n + c4 E^{n+1} + c5 E^{n-1}``
+    needs an ``E^{n-1}`` array when ``c5 != 0`` — an extra full field history per
+    pole. The observer-canonical realization of the identical transfer function
+    :math:`\chi_d(z) = (c_4 z^2 + c_3 z + c_5)/(z^2 - c_1 z - c_2)`,
+
+    .. math::
+        x_1^{n+1} &= c_1 x_1^n + x_2^n + \beta_1 E^n \\
+        x_2^{n+1} &= c_2 x_1^n + \beta_0 E^n \\
+        p^{n+1}   &= x_1^{n+1} + c_4 E^{n+1}
+
+    with :math:`\beta_1 = c_3 + c_1 c_4` and :math:`\beta_0 = c_5 + c_2 c_4`,
+    carries every scheme with two state levels, no field history, and a purely
+    per-cell polarization update.
+
+    Args:
+        c1: P-form coefficient array.
+        c2: P-form coefficient array.
+        c3: P-form coefficient array.
+        c4: P-form coefficient array (the implicit ``E^{n+1}`` coupling).
+        c5: P-form coefficient array (the ``E^{n-1}`` coupling).
+
+    Returns:
+        ``(c1, c2, beta1, c4, beta0)`` — ``c1``, ``c2`` and ``c4`` unchanged.
+    """
+    beta1 = c3 + c1 * c4
+    beta0 = c5 + c2 * c4
+    return c1, c2, beta1, c4, beta0
+
+
 def compute_pole_coefficients_per_axis(
     poles: tuple[Pole, ...],
     dt: float,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Compute the per-axis discrete-time ADE recurrence coefficients.
 
-    For each pole and grid axis, returns ``(c1, c2, c3, c4)`` with
-    (``D = 1 + gamma dt / 2``)
+    For each pole and grid axis, returns the P-form coefficients
+    ``(c1, c2, c3, c4, c5)`` of
 
-    .. math::
-        c_1 = \\frac{2 - \\omega_0^2 \\Delta t^2}{D}, \\quad
-        c_2 = -\\frac{1 - \\gamma \\Delta t / 2}{D}, \\quad
-        c_3 = \\frac{a \\Delta t^2 - b \\Delta t}{D}, \\quad
-        c_4 = \\frac{b \\Delta t}{D},
+    :math:`p_p^{n+1} = c_1 p_p^n + c_2 p_p^{n-1} + c_3 E^n + c_4 E^{n+1} + c_5 E^{n-1}`
 
-    where ``a = coupling_sq`` is the ``E`` coupling and ``b = coupling_edot`` is
-    the ``dE/dt`` coupling, which is discretized with a forward difference:
-
-    :math:`p_p^{n+1} = c_1 p_p^n + c_2 p_p^{n-1} + c_3 E^n + c_4 E^{n+1}`.
+    under that pole's :attr:`Pole.integrator`. See the module docstring for the
+    per-scheme formulas; ``a = coupling_sq`` is the ``E`` coupling and
+    ``b = coupling_edot`` the ``dE/dt`` coupling.
 
     For isotropic poles the three axis columns are identical. For Lorentz and
-    Drude poles ``b = 0``, so ``c4 = 0`` and ``c3`` reduces to the classic
-    :math:`K \\Delta t^2 / D`.
+    Drude poles ``b = 0``, so the two central-difference schemes coincide and
+    give ``c4 = c5 = 0`` with ``c3 = a dt^2 / D``.
+
+    Use :func:`compute_pole_delta_coefficients_per_axis` for the coefficients the
+    FDTD loop actually stores and marches (:func:`to_observer_form` and
+    :func:`to_delta_form` convert these in place, at lower precision).
 
     Args:
         poles: Tuple of poles (may be empty).
         dt: Simulation time step (seconds).
 
     Returns:
-        Four ``numpy`` arrays of shape ``(len(poles), 3)`` with ``c1``, ``c2``,
-        ``c3``, ``c4`` per pole and axis. For an empty pole tuple, returns four
-        ``(0, 3)`` arrays.
+        Five ``numpy`` arrays of shape ``(len(poles), 3)`` with ``c1``, ``c2``,
+        ``c3``, ``c4``, ``c5`` per pole and axis. For an empty pole tuple,
+        returns five ``(0, 3)`` arrays.
     """
     n = len(poles)
     c1 = np.zeros((n, 3), dtype=np.float64)
     c2 = np.zeros((n, 3), dtype=np.float64)
     c3 = np.zeros((n, 3), dtype=np.float64)
     c4 = np.zeros((n, 3), dtype=np.float64)
+    c5 = np.zeros((n, 3), dtype=np.float64)
     for i, p in enumerate(poles):
         if p.is_oriented:
             raise ValueError(
@@ -834,33 +1244,33 @@ def compute_pole_coefficients_per_axis(
         coupling_sq = p.coupling_sq_axes
         coupling_edot = p.coupling_edot_axes
         for ax in range(3):
-            gamma_dt = gamma[ax] * dt
             omega0_dt = omega_0[ax] * dt
             # The stability bound only binds on axes where the pole actually
             # couples. A zero-coupling axis (e.g. a Lorentz pole with
             # delta_epsilon = 0 there, the documented way to express an absent
-            # resonance) has c3 = c4 = 0, so its polarization stays identically
-            # zero and its unused omega_0 / gamma are irrelevant.
+            # resonance) has c3 = c4 = c5 = 0, so its polarization stays
+            # identically zero and its unused omega_0 / gamma are irrelevant.
             axis_active = coupling_sq[ax] != 0.0 or coupling_edot[ax] != 0.0
-            if axis_active and omega0_dt >= 2.0:
+            # gamma * dt is unconstrained: |c2| < 1 holds for every gamma * dt > 0
+            # (c2 merely passes through zero at gamma * dt = 2), so the only
+            # binding forward bound is omega_0 * dt < 2.
+            if axis_active and omega0_dt >= 2.0 and p.integrator in _CONDITIONALLY_STABLE:
                 axis_note = "" if p.is_isotropic else f" on axis {'xyz'[ax]}"
                 raise ValueError(
                     f"Pole {i} ({type(p).__name__}) has omega_0 * dt = {omega0_dt:.4g} >= 2{axis_note}; "
-                    "the ADE recurrence roots leave the unit circle (requires omega_0 * dt < 2, "
-                    "physically omega_0 * dt << 1). Lower the resonance frequency or reduce the time step."
+                    f"the {p.integrator!r} ADE recurrence roots leave the unit circle (requires "
+                    "omega_0 * dt < 2, physically omega_0 * dt << 1). Lower the resonance frequency, "
+                    "reduce the time step, or use integrator='bilinear' (unconditionally stable)."
                 )
-            denom = 1.0 + 0.5 * gamma_dt
-            c1[i, ax] = (2.0 - (omega_0[ax] ** 2) * (dt**2)) / denom
-            c2[i, ax] = -(1.0 - 0.5 * gamma_dt) / denom
-            c3[i, ax] = (coupling_sq[ax] * dt**2 - coupling_edot[ax] * dt) / denom
-            c4[i, ax] = (coupling_edot[ax] * dt) / denom
-    return c1, c2, c3, c4
+            vals = _scheme_coefficients(p.integrator, omega_0[ax], gamma[ax], coupling_sq[ax], coupling_edot[ax], dt)
+            c1[i, ax], c2[i, ax], c3[i, ax], c4[i, ax], c5[i, ax] = vals
+    return c1, c2, c3, c4, c5
 
 
 def compute_pole_coefficients(
     poles: tuple[Pole, ...],
     dt: float,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Compute the discrete-time ADE recurrence coefficients of isotropic poles.
 
     Scalar-per-pole variant of :func:`compute_pole_coefficients_per_axis` (see
@@ -872,8 +1282,9 @@ def compute_pole_coefficients(
         dt: Simulation time step (seconds).
 
     Returns:
-        Four ``numpy`` arrays of shape ``(len(poles),)`` with ``c1``, ``c2``,
-        ``c3``, ``c4``. For an empty pole tuple, returns four empty arrays.
+        Five ``numpy`` arrays of shape ``(len(poles),)`` with ``c1``, ``c2``,
+        ``c3``, ``c4``, ``c5``. For an empty pole tuple, returns five empty
+        arrays.
     """
     for i, p in enumerate(poles):
         if not p.is_isotropic:
@@ -881,22 +1292,26 @@ def compute_pole_coefficients(
                 f"Pole {i} ({type(p).__name__}) has per-axis parameters or an orientation; "
                 "use compute_pole_coefficients_per_axis or compute_pole_coefficients_tensor instead."
             )
-    c1, c2, c3, c4 = compute_pole_coefficients_per_axis(poles, dt)
-    return c1[:, 0], c2[:, 0], c3[:, 0], c4[:, 0]
+    c1, c2, c3, c4, c5 = compute_pole_coefficients_per_axis(poles, dt)
+    return c1[:, 0], c2[:, 0], c3[:, 0], c4[:, 0], c5[:, 0]
 
 
 def compute_pole_coefficients_tensor(
     poles: tuple[Pole, ...],
     dt: float,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Compute ADE recurrence coefficients with full 3x3 coupling tensors.
 
     Generalizes :func:`compute_pole_coefficients_per_axis` to oriented poles:
     the recurrence coefficients ``c1``/``c2`` stay per-axis (uniform for an
     oriented pole, whose ``omega_0``/``gamma`` are scalars), while the field
-    couplings ``c3``/``c4`` become row-major 3x3 tensors per pole —
-    ``(K dt^2 / D) u u^T`` for a pole oriented along ``u``, diagonal for
+    couplings ``c3``/``c4``/``c5`` become row-major 3x3 tensors per pole —
+    proportional to ``u u^T`` for a pole oriented along ``u``, diagonal for
     per-axis and isotropic poles.
+
+    Oriented poles are restricted to ``integrator="central"`` /
+    ``"centered_edot"`` and have no ``dE/dt`` coupling, so their ``c4`` and
+    ``c5`` tensors are identically zero and the two schemes agree.
 
     Args:
         poles: Tuple of poles (may be empty). Oriented poles must have a
@@ -904,34 +1319,34 @@ def compute_pole_coefficients_tensor(
         dt: Simulation time step (seconds).
 
     Returns:
-        Four ``numpy`` arrays: ``c1``, ``c2`` of shape ``(len(poles), 3)`` and
-        ``c3``, ``c4`` of shape ``(len(poles), 9)``.
+        Five ``numpy`` arrays: ``c1``, ``c2`` of shape ``(len(poles), 3)`` and
+        ``c3``, ``c4``, ``c5`` of shape ``(len(poles), 9)``.
     """
     n = len(poles)
     c1 = np.zeros((n, 3), dtype=np.float64)
     c2 = np.zeros((n, 3), dtype=np.float64)
     c3 = np.zeros((n, 9), dtype=np.float64)
     c4 = np.zeros((n, 9), dtype=np.float64)
+    c5 = np.zeros((n, 9), dtype=np.float64)
     for i, p in enumerate(poles):
         gamma = p.gamma_axes
         omega_0 = p.omega_0_axes
         coupling_sq = p.coupling_sq_axes
         coupling_edot = p.coupling_edot_axes
         for ax in range(3):
-            gamma_dt = gamma[ax] * dt
             omega0_dt = omega_0[ax] * dt
             # Same forward-stability bound (and same zero-coupling exemption) as
             # compute_pole_coefficients_per_axis.
             axis_active = coupling_sq[ax] != 0.0 or coupling_edot[ax] != 0.0
-            if axis_active and omega0_dt >= 2.0:
+            if axis_active and omega0_dt >= 2.0 and p.integrator in _CONDITIONALLY_STABLE:
                 raise ValueError(
                     f"Pole {i} ({type(p).__name__}) has omega_0 * dt = {omega0_dt:.4g} >= 2; "
-                    "the ADE recurrence roots leave the unit circle (requires omega_0 * dt < 2, "
-                    "physically omega_0 * dt << 1). Lower the resonance frequency or reduce the time step."
+                    f"the {p.integrator!r} ADE recurrence roots leave the unit circle (requires "
+                    "omega_0 * dt < 2, physically omega_0 * dt << 1). Lower the resonance frequency, "
+                    "reduce the time step, or use integrator='bilinear' (unconditionally stable)."
                 )
-            denom = 1.0 + 0.5 * gamma_dt
-            c1[i, ax] = (2.0 - (omega_0[ax] ** 2) * (dt**2)) / denom
-            c2[i, ax] = -(1.0 - 0.5 * gamma_dt) / denom
+            row = _scheme_coefficients(p.integrator, omega_0[ax], gamma[ax], coupling_sq[ax], coupling_edot[ax], dt)
+            c1[i, ax], c2[i, ax] = row[0], row[1]
         if p.is_oriented:
             if coupling_sq[0] < 0.0:
                 raise ValueError(
@@ -941,15 +1356,118 @@ def compute_pole_coefficients_tensor(
                 )
             assert p.orientation is not None
             u = np.asarray(p.orientation, dtype=np.float64)
-            denom = 1.0 + 0.5 * gamma[0] * dt
-            c3[i] = ((coupling_sq[0] * dt**2 / denom) * np.outer(u, u)).reshape(-1)
-            # c4 is identically zero for oriented poles (validated at construction).
+            # coupling_edot is zero for oriented poles (validated at construction),
+            # so c4 and c5 stay zero and only the c3 tensor is populated.
+            _, _, c3_scalar, _, _ = _scheme_coefficients(p.integrator, omega_0[0], gamma[0], coupling_sq[0], 0.0, dt)
+            c3[i] = (c3_scalar * np.outer(u, u)).reshape(-1)
         else:
             for ax in range(3):
-                denom = 1.0 + 0.5 * gamma[ax] * dt
-                c3[i, 4 * ax] = (coupling_sq[ax] * dt**2 - coupling_edot[ax] * dt) / denom
-                c4[i, 4 * ax] = (coupling_edot[ax] * dt) / denom
-    return c1, c2, c3, c4
+                _, _, c3_ax, c4_ax, c5_ax = _scheme_coefficients(
+                    p.integrator, omega_0[ax], gamma[ax], coupling_sq[ax], coupling_edot[ax], dt
+                )
+                c3[i, 4 * ax] = c3_ax
+                c4[i, 4 * ax] = c4_ax
+                c5[i, 4 * ax] = c5_ax
+    return c1, c2, c3, c4, c5
+
+
+def compute_pole_delta_coefficients_per_axis(
+    poles: tuple[Pole, ...],
+    dt: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    r"""Per-axis delta-basis coefficients ``(a1, a0, b1, c4, b0)`` — what the loop stores.
+
+    Delta-basis counterpart of :func:`compute_pole_coefficients_per_axis`:
+    the same discrete transfer function expanded in :math:`\zeta = z - 1`, so
+    ``a1 = 2 - c1`` and ``a0 = 1 - c1 - c2`` are represented directly rather than
+    as differences of near-fixed :math:`O(1)` numbers. See the module docstring
+    for why this is what makes float32 dispersion usable.
+
+    Shares every stability guard with the P-form function.
+
+    Args:
+        poles: Tuple of non-oriented poles (may be empty).
+        dt: Simulation time step (seconds).
+
+    Returns:
+        Five ``numpy`` arrays of shape ``(len(poles), 3)`` with ``a1``, ``a0``,
+        ``b1``, ``c4``, ``b0`` per pole and axis.
+    """
+    # Delegate the guards (and the oriented-pole rejection) to the P-form path,
+    # then rebuild from the cancellation-free closed forms. Host-side numpy on
+    # (num_poles, 3) arrays, so the duplicated work is free.
+    compute_pole_coefficients_per_axis(poles, dt)
+    n = len(poles)
+    out = [np.zeros((n, 3), dtype=np.float64) for _ in range(5)]
+    for i, p in enumerate(poles):
+        omega_0, gamma = p.omega_0_axes, p.gamma_axes
+        coupling_sq, coupling_edot = p.coupling_sq_axes, p.coupling_edot_axes
+        for ax in range(3):
+            vals = _scheme_delta_coefficients(
+                p.integrator, omega_0[ax], gamma[ax], coupling_sq[ax], coupling_edot[ax], dt
+            )
+            for arr, v in zip(out, vals):
+                arr[i, ax] = v
+    return out[0], out[1], out[2], out[3], out[4]
+
+
+def compute_pole_delta_coefficients_tensor(
+    poles: tuple[Pole, ...],
+    dt: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    r"""Delta-basis coefficients with full 3x3 field-coupling tensors.
+
+    Delta-basis counterpart of :func:`compute_pole_coefficients_tensor` (see
+    there for the tensor layout, and the module docstring for the basis change).
+    The oscillator coefficients ``a1``/``a0`` stay per-axis while the field
+    couplings ``b1``/``c4``/``b0`` become row-major 3x3 tensors per pole.
+
+    Oriented poles have no ``dE/dt`` coupling, so their ``c4`` tensor is
+    identically zero and ``b0`` equals ``b1``.
+
+    Args:
+        poles: Tuple of poles (may be empty).
+        dt: Simulation time step (seconds).
+
+    Returns:
+        Five ``numpy`` arrays: ``a1``, ``a0`` of shape ``(len(poles), 3)`` and
+        ``b1``, ``c4``, ``b0`` of shape ``(len(poles), 9)``.
+    """
+    compute_pole_coefficients_tensor(poles, dt)  # guards + passivity checks
+    n = len(poles)
+    a1 = np.zeros((n, 3), dtype=np.float64)
+    a0 = np.zeros((n, 3), dtype=np.float64)
+    b1 = np.zeros((n, 9), dtype=np.float64)
+    c4 = np.zeros((n, 9), dtype=np.float64)
+    b0 = np.zeros((n, 9), dtype=np.float64)
+    for i, p in enumerate(poles):
+        omega_0, gamma = p.omega_0_axes, p.gamma_axes
+        coupling_sq, coupling_edot = p.coupling_sq_axes, p.coupling_edot_axes
+        for ax in range(3):
+            row = _scheme_delta_coefficients(
+                p.integrator, omega_0[ax], gamma[ax], coupling_sq[ax], coupling_edot[ax], dt
+            )
+            a1[i, ax], a0[i, ax] = row[0], row[1]
+        if p.is_oriented:
+            assert p.orientation is not None
+            u = np.asarray(p.orientation, dtype=np.float64)
+            # coupling_edot is zero for oriented poles (validated at construction),
+            # so c4 stays zero and b0 coincides with b1.
+            _, _, b1_scalar, _, b0_scalar = _scheme_delta_coefficients(
+                p.integrator, omega_0[0], gamma[0], coupling_sq[0], 0.0, dt
+            )
+            uu = np.outer(u, u).reshape(-1)
+            b1[i] = b1_scalar * uu
+            b0[i] = b0_scalar * uu
+        else:
+            for ax in range(3):
+                _, _, b1_ax, c4_ax, b0_ax = _scheme_delta_coefficients(
+                    p.integrator, omega_0[ax], gamma[ax], coupling_sq[ax], coupling_edot[ax], dt
+                )
+                b1[i, 4 * ax] = b1_ax
+                c4[i, 4 * ax] = c4_ax
+                b0[i, 4 * ax] = b0_ax
+    return a1, a0, b1, c4, b0
 
 
 def _tensor_from_components(arr: jax.Array) -> jax.Array:
@@ -986,100 +1504,99 @@ def _expand_recurrence_to_coupling(c: jax.Array, coupling_components: int) -> ja
 
 
 def susceptibility_from_coefficients(
-    c1: jax.Array,
-    c2: jax.Array,
-    c3: jax.Array,
+    a1: jax.Array,
+    a0: jax.Array,
+    b1: jax.Array,
     omega: float,
     dt: float,
     c4: jax.Array | None = None,
+    b0: jax.Array | None = None,
 ) -> jax.Array:
-    """Evaluate the per-cell complex susceptibility :math:`\\chi(\\omega)` from
-    the stored ADE recurrence coefficients.
+    """Evaluate the per-cell complex susceptibility from the stored ADE coefficients.
 
-    The coefficient arrays have shape ``(num_poles, ...)`` where the trailing
-    axes are the spatial (and optional component) dimensions. The inversion
-    (with ``D = 1 + \\gamma \\Delta t / 2``)
+    Evaluates the **discrete** transfer function each pole actually realizes on
+    the grid, in the delta basis the coefficients are stored in,
 
     .. math::
-        \\gamma \\Delta t     &= \\frac{2 (1 + c_2)}{1 - c_2},\\\\
-        \\omega_0^2 \\Delta t^2 &= 2 - c_1 D,\\\\
-        a \\Delta t^2          &= (c_3 + c_4) D,\\\\
-        b \\Delta t            &= c_4 D
+        \\chi_{d,p}(\\omega) = c_4
+            + \\frac{b_1 \\zeta + b_0}{\\zeta^2 + a_1 \\zeta + a_0},
+        \\qquad \\zeta = e^{-i \\omega \\Delta t} - 1
 
-    is applied pointwise, then each pole contributes
+    and sums over the leading pole axis. This is exact rather than approximate:
+    the discrete Ampere law consumes only
+    :math:`\\varepsilon_\\infty (E^{n+1} - E^n) + \\sum_p (p_p^{n+1} - p_p^n)`, so
+    :math:`\\varepsilon_\\infty + \\sum_p \\chi_{d,p}` *is* the permittivity the
+    simulation realizes. It differs from the continuum
+    :math:`\\chi(\\omega)` by the scheme's :math:`O((\\omega \\Delta t)^2)`
+    truncation, and is scheme-agnostic — it needs no knowledge of which
+    integrator produced the coefficients.
 
-    .. math::
-        \\chi_p(\\omega) = \\frac{a - i\\omega b}{\\omega_0^2 - \\omega^2 - i \\gamma \\omega}
+    Evaluating in :math:`\\zeta` also keeps the *evaluation* well conditioned:
+    at low frequency :math:`\\zeta \\to 0`, so the denominator is a sum of small
+    terms rather than a cancellation among :math:`O(1)` ones.
 
-    and the result is summed over the leading pole axis. Cells where the
-    coefficients are all zero (no pole) contribute exactly zero. When ``c4`` is
-    ``None`` (Lorentz/Drude) the ``b`` term vanishes and this reduces to the
-    classic real-numerator Lorentzian.
+    Cells with no pole have all-zero coefficients and contribute exactly zero
+    (the denominator is :math:`\\zeta^2 \\neq 0` there, so no masking is
+    required).
 
     Args:
-        c1: ADE coefficient array of shape ``(num_poles, ...)``.
-        c2: ADE coefficient array of shape ``(num_poles, ...)``.
-        c3: ADE coefficient array of shape ``(num_poles, ...)``.
+        a1: ADE coefficient array ``a1 = 2 - c1`` of shape ``(num_poles, ...)``
+            where the trailing axes are the spatial (and optional component)
+            dimensions.
+        a0: ADE coefficient array ``a0 = 1 - c1 - c2``, shape
+            ``(num_poles, ...)``.
+        b1: Field coupling ``b1 = beta1 = c3 + c1 c4``, shape
+            ``(num_poles, ...)``.
         omega: Angular frequency (rad/s) at which to evaluate the
             susceptibility.
         dt: Simulation time step (seconds) used to derive the coefficients.
-        c4: Optional ADE coefficient array (the ``dE/dt`` coupling), shape
-            ``(num_poles, ...)``. ``None`` is treated as all-zero.
+        c4: Optional implicit ``E^{n+1}`` coupling, shape ``(num_poles, ...)``.
+            ``None`` is treated as all-zero.
+        b0: Optional field coupling ``b0 = beta1 + beta0``, shape
+            ``(num_poles, ...)``. ``None`` means "equal to ``b1``", which is
+            exactly the case whenever no pole is implicit (``c4 = c5 = 0``
+            implies ``beta0 = 0``).
 
     Returns:
-        Complex ``jax.Array`` with shape ``c1.shape[1:]`` — the total
-        :math:`\\chi(\\omega)` summed over all poles, in every cell.
+        Complex ``jax.Array`` with shape ``b1.shape[1:]`` — the total
+        susceptibility summed over all poles, in every cell.
     """
-    c1 = jnp.asarray(c1)
-    c2 = jnp.asarray(c2)
-    c3 = jnp.asarray(c3)
-    c4 = jnp.zeros_like(c3) if c4 is None else jnp.asarray(c4)
-    if c1.ndim >= 2 and c3.ndim >= 2 and c3.shape[1] == 9:
+    a1 = jnp.asarray(a1)
+    a0 = jnp.asarray(a0)
+    b1 = jnp.asarray(b1)
+    c4 = jnp.zeros_like(b1) if c4 is None else jnp.asarray(c4)
+    b0 = b1 if b0 is None else jnp.asarray(b0)
+    if a1.ndim >= 2 and b1.ndim >= 2 and b1.shape[1] == 9:
         # 9-component coupling (oriented poles): the recurrence coefficients
         # expand so entry (i, j) uses the oscillator of row i; the result is
         # the per-entry chi_ij with shape (9, *spatial).
-        c1 = _expand_recurrence_to_coupling(c1, 9)
-        c2 = _expand_recurrence_to_coupling(c2, 9)
+        a1 = _expand_recurrence_to_coupling(a1, 9)
+        a0 = _expand_recurrence_to_coupling(a0, 9)
 
-    pole_mask = (c1 != 0.0) | (c3 != 0.0) | (c4 != 0.0)
-
-    one_minus_c2 = 1.0 - c2
-    safe_denom = jnp.where(one_minus_c2 == 0.0, 1.0, one_minus_c2)
-    gamma_dt = 2.0 * (1.0 + c2) / safe_denom
-    gamma_dt = jnp.where(pole_mask, gamma_dt, 0.0)
-
-    half_factor = 1.0 + 0.5 * gamma_dt
-    omega0_sq_dt2 = 2.0 - c1 * half_factor
-    omega0_sq_dt2 = jnp.where(pole_mask, omega0_sq_dt2, 0.0)
-    # a*dt^2 = (c3 + c4)*D, b*dt = c4*D (see compute_pole_coefficients).
-    a_dt2 = jnp.where(pole_mask, (c3 + c4) * half_factor, 0.0)
-    b_dt = jnp.where(pole_mask, c4 * half_factor, 0.0)
-
-    omega_dt = omega * dt
-    numer = a_dt2 - 1j * omega_dt * b_dt
-    denom = omega0_sq_dt2 - omega_dt * omega_dt - 1j * gamma_dt * omega_dt
-    safe_denom_cplx = jnp.where(pole_mask, denom, 1.0 + 0.0j)
-    chi_per_pole = jnp.where(pole_mask, numer / safe_denom_cplx, 0.0 + 0.0j)
-
+    zeta = jnp.exp(-1j * omega * dt) - 1.0
+    denom = zeta * zeta + a1 * zeta + a0
+    chi_per_pole = c4 + (b1 * zeta + b0) / denom
     return jnp.sum(chi_per_pole, axis=0)
 
 
 def compute_eps_spectrum_from_coefficients(
-    c1: jax.Array | np.ndarray,
-    c2: jax.Array | np.ndarray,
-    c3: jax.Array | np.ndarray,
+    a1: jax.Array | np.ndarray,
+    a0: jax.Array | np.ndarray,
+    b1: jax.Array | np.ndarray,
     inv_eps_inf: jax.Array | np.ndarray,
     omegas: np.ndarray,
     dt: float,
     weights: np.ndarray | None = None,
     c4: jax.Array | np.ndarray | None = None,
+    b0: jax.Array | np.ndarray | None = None,
 ) -> np.ndarray:
     """Spatially-averaged complex permittivity spectrum for a block of cells.
 
-    For each angular frequency in ``omegas``, evaluates the per-cell
-    complex permittivity :math:`\\varepsilon(\\omega) = \\varepsilon_\\infty + \\chi(\\omega)`
-    where :math:`\\chi` is reconstructed from the ADE recurrence coefficients,
-    and averages over the spatial axes (uniformly or with supplied weights).
+    For each angular frequency in ``omegas``, evaluates the per-cell complex
+    permittivity :math:`\\varepsilon_\\infty + \\chi_d(\\omega)` — with
+    :math:`\\chi_d` the discrete transfer function of
+    :func:`susceptibility_from_coefficients` — and averages over the spatial
+    axes (uniformly or with supplied weights).
 
     This is the broadband generalization of the single-frequency
     :func:`effective_inv_permittivity` used for carrier-frequency impedance
@@ -1089,13 +1606,14 @@ def compute_eps_spectrum_from_coefficients(
     :func:`compute_impedance_corrected_temporal_profile`.
 
     Args:
-        c1: ADE coefficient array of shape ``(num_poles, num_components, *spatial)``
-            as stored on :class:`~fdtdx.fdtd.container.ArrayContainer`, with
+        a1: ADE coefficient array ``a1 = 2 - c1`` of shape
+            ``(num_poles, num_components, *spatial)`` as stored on
+            :class:`~fdtdx.fdtd.container.ArrayContainer`, with
             ``num_components in (1, 3)`` (the material-component axis; size 3
             for per-axis anisotropic dispersion). Anisotropic components are
             averaged, mirroring the ``inv_eps_inf`` reduction.
-        c2: ADE coefficient array, same shape as ``c1``.
-        c3: ADE coefficient array, same shape as ``c1``.
+        a0: ADE coefficient array ``a0 = 1 - c1 - c2``, same shape as ``a1``.
+        b1: Field coupling array ``b1 = beta1``, same shape as ``a1``.
         inv_eps_inf: Per-cell inverse of the high-frequency permittivity,
             shape ``(num_components, *spatial)`` with
             ``num_components in (1, 3, 9)``. For anisotropic tensors
@@ -1104,33 +1622,25 @@ def compute_eps_spectrum_from_coefficients(
         dt: Simulation time step (seconds) used to derive the coefficients.
         weights: Optional spatial weights with the same shape as the
             trailing axes of ``c1``. If ``None``, uniform averaging.
+        c4: Optional implicit ``E^{n+1}`` coupling array. ``None`` is all-zero.
+        b0: Optional field coupling array ``b0 = beta1 + beta0``. ``None`` means
+            "equal to ``b1``" (exact whenever no pole is implicit).
 
     Returns:
         Complex numpy array of shape ``(len(omegas),)`` — the volume-averaged
         :math:`\\varepsilon(\\omega)` at each requested frequency.
     """
-    c1_np = np.asarray(c1)
-    c2_np = np.asarray(c2)
-    c3_np = np.asarray(c3)
-    c4_np = np.zeros_like(c3_np) if c4 is None else np.asarray(c4)
+    a1_np = np.asarray(a1)
+    a0_np = np.asarray(a0)
+    b1_np = np.asarray(b1)
+    c4_np = np.zeros_like(b1_np) if c4 is None else np.asarray(c4)
+    b0_np = b1_np if b0 is None else np.asarray(b0)
     inv_eps_np = np.asarray(inv_eps_inf)
     omegas_np = np.asarray(omegas, dtype=np.float64)
-    if c3_np.ndim >= 2 and c3_np.shape[1] == 9 and c1_np.shape[1] == 3:
+    if b1_np.ndim >= 2 and b1_np.shape[1] == 9 and a1_np.shape[1] == 3:
         # 9-component coupling (oriented poles): entry 3i+j uses oscillator row i.
-        c1_np = np.repeat(c1_np, 3, axis=1)
-        c2_np = np.repeat(c2_np, 3, axis=1)
-
-    # Reverse-engineer pole parameters from the ADE coefficients (same inversion
-    # as susceptibility_from_coefficients, duplicated in numpy for setup-time use).
-    pole_mask = (c1_np != 0.0) | (c3_np != 0.0) | (c4_np != 0.0)
-    one_minus_c2 = 1.0 - c2_np
-    safe_one_minus_c2 = np.where(one_minus_c2 == 0.0, 1.0, one_minus_c2)
-    gamma_dt = np.where(pole_mask, 2.0 * (1.0 + c2_np) / safe_one_minus_c2, 0.0)
-    half_factor = 1.0 + 0.5 * gamma_dt
-    omega0_sq_dt2 = np.where(pole_mask, 2.0 - c1_np * half_factor, 0.0)
-    # a*dt^2 = (c3 + c4)*D, b*dt = c4*D (numerator = a*dt^2 - i*omega*dt*b*dt).
-    a_dt2 = np.where(pole_mask, (c3_np + c4_np) * half_factor, 0.0)
-    b_dt = np.where(pole_mask, c4_np * half_factor, 0.0)
+        a1_np = np.repeat(a1_np, 3, axis=1)
+        a0_np = np.repeat(a0_np, 3, axis=1)
 
     # Reduce inv_eps_inf → scalar eps_inf per spatial cell.
     num_components = inv_eps_np.shape[0]
@@ -1148,11 +1658,12 @@ def compute_eps_spectrum_from_coefficients(
 
     # Broadcast: omegas over (M,); coefficient arrays have shape (P, C, *spatial)
     # with C in (1, 3). After [None, ...] prepend: (M, P, C, *spatial).
-    omega_dt = (omegas_np * dt).reshape((-1,) + (1,) * c1_np.ndim)
-    numer = a_dt2[None, ...] - 1j * omega_dt * b_dt[None, ...]
-    denom = omega0_sq_dt2[None, ...] - omega_dt**2 - 1j * gamma_dt[None, ...] * omega_dt
-    safe_denom = np.where(pole_mask[None, ...], denom, 1.0 + 0.0j)
-    chi_per_pole = np.where(pole_mask[None, ...], numer / safe_denom, 0.0 + 0.0j)
+    # Evaluates the same discrete chi_d(zeta) as susceptibility_from_coefficients;
+    # pole-free slots have all-zero coefficients and a denominator of zeta^2 != 0,
+    # so they contribute exactly zero without masking.
+    zeta = (np.exp(-1j * (omegas_np * dt)) - 1.0).reshape((-1,) + (1,) * a1_np.ndim)
+    denom = zeta * zeta + a1_np[None, ...] * zeta + a0_np[None, ...]
+    chi_per_pole = c4_np[None, ...] + (b1_np[None, ...] * zeta + b0_np[None, ...]) / denom
     chi_per_cell = chi_per_pole.sum(axis=1)  # sum over pole axis → (M, C, *spatial)
     # Average the material-component axis (identity for C = 1), mirroring the
     # eps_inf reduction above — this scalar spectrum feeds an impedance filter
@@ -1253,12 +1764,13 @@ def compute_impedance_corrected_temporal_profile(
 
 def effective_inv_permittivity(
     inv_eps: jax.Array,
-    c1: jax.Array | None,
-    c2: jax.Array | None,
-    c3: jax.Array | None,
+    a1: jax.Array | None,
+    a0: jax.Array | None,
+    b1: jax.Array | None,
     omega: float,
     dt: float,
     c4: jax.Array | None = None,
+    b0: jax.Array | None = None,
 ) -> jax.Array:
     """Per-cell real inverse permittivity :math:`1/\\text{Re}(\\varepsilon_\\infty + \\chi(\\omega))`.
 
@@ -1267,41 +1779,46 @@ def effective_inv_permittivity(
     absorption, which is already handled by the ADE update loop (injecting it
     into the source amplitude would double-count).
 
-    Cells with no pole (``c1 = c2 = c3 = 0``) contribute :math:`\\chi = 0` so
+    Cells with no pole (all-zero coefficients) contribute :math:`\\chi = 0` so
     their ``inv_eps`` is returned unchanged.
 
     Args:
         inv_eps: Per-cell :math:`1/\\varepsilon_\\infty` array. Typically
             has shape ``(num_components, ...)``; any shape broadcast-compatible
-            with ``c1.shape[1:]`` works.
-        c1: ADE coefficient array of shape ``(num_poles, ...)`` or ``None``.
-        c2: ADE coefficient array of shape ``(num_poles, ...)`` or ``None``.
-        c3: ADE coefficient array of shape ``(num_poles, ...)`` or ``None``.
+            with ``a1.shape[1:]`` works.
+        a1: Delta-basis coefficient ``a1 = 2 - c1``, shape
+            ``(num_poles, ...)`` or ``None``.
+        a0: Delta-basis coefficient ``a0 = 1 - c1 - c2``, shape
+            ``(num_poles, ...)`` or ``None``.
+        b1: Delta-basis field coupling ``b1 = beta1``, shape
+            ``(num_poles, ...)`` or ``None``.
         omega: Angular frequency (rad/s) at which to evaluate.
         dt: Simulation time step (seconds).
+        c4: Optional implicit ``E^{n+1}`` coupling array.
+        b0: Optional delta-basis field coupling ``b0``; ``None`` means equal to ``b1``.
 
     Returns:
         Real-valued ``jax.Array`` with the same shape and dtype as
-        ``inv_eps``. If any of ``c1``/``c2``/``c3`` is ``None``, returns
+        ``inv_eps``. If any of ``a1``/``a0``/``b1`` is ``None``, returns
         ``inv_eps`` unchanged.
     """
     inv_eps_arr = jnp.asarray(inv_eps)
-    coupling_c = jnp.asarray(c3).shape[1] if c3 is not None and jnp.asarray(c3).ndim >= 2 else 1
+    coupling_c = jnp.asarray(b1).shape[1] if b1 is not None and jnp.asarray(b1).ndim >= 2 else 1
     if inv_eps_arr.shape[0] == 9 or coupling_c == 9:
         # Tensor path: reconstruct the real permittivity matrix per cell, add
         # the (possibly off-diagonal) susceptibility, and invert per cell.
         # Elementwise 1/inv_eps would divide by the zero off-diagonal entries.
         eps_mat = jnp.real(_eps_matrix_from_inv(inv_eps_arr))
-        if c1 is not None and c2 is not None and c3 is not None:
-            chi = susceptibility_from_coefficients(c1=c1, c2=c2, c3=c3, omega=omega, dt=dt, c4=c4)
+        if a1 is not None and a0 is not None and b1 is not None:
+            chi = susceptibility_from_coefficients(a1=a1, a0=a0, b1=b1, omega=omega, dt=dt, c4=c4, b0=b0)
             eps_mat = eps_mat + jnp.real(_tensor_from_components(chi))
         inv_eff = _invert_3x3_matrix_field(eps_mat)
         return inv_eff.reshape(9, *inv_eff.shape[2:]).astype(inv_eps_arr.dtype)
 
-    if c1 is None or c2 is None or c3 is None:
+    if a1 is None or a0 is None or b1 is None:
         return inv_eps
 
-    chi = susceptibility_from_coefficients(c1=c1, c2=c2, c3=c3, omega=omega, dt=dt, c4=c4)
+    chi = susceptibility_from_coefficients(a1=a1, a0=a0, b1=b1, omega=omega, dt=dt, c4=c4, b0=b0)
     eps_inf = 1.0 / inv_eps_arr
     eps_eff = eps_inf + jnp.real(chi)
     return (1.0 / eps_eff).astype(inv_eps_arr.dtype)
@@ -1311,12 +1828,13 @@ def effective_complex_inv_permittivity(
     inv_eps: jax.Array,
     omega: float,
     dt: float,
-    c1: jax.Array | None = None,
-    c2: jax.Array | None = None,
-    c3: jax.Array | None = None,
+    a1: jax.Array | None = None,
+    a0: jax.Array | None = None,
+    b1: jax.Array | None = None,
     electric_conductivity: jax.Array | None = None,
     conductivity_spacing: float | None = None,
     c4: jax.Array | None = None,
+    b0: jax.Array | None = None,
 ) -> jax.Array:
     r"""Per-cell COMPLEX inverse permittivity :math:`1 / (\varepsilon_\infty + \chi(\omega) + i\sigma/(\varepsilon_0\omega))`.
 
@@ -1332,7 +1850,7 @@ def effective_complex_inv_permittivity(
     (positive imaginary part = loss):
 
     * the dispersive susceptibility :math:`\chi(\omega)` reconstructed from the
-      ADE coefficients (omitted when ``c1``/``c2``/``c3`` are ``None``), and
+      ADE coefficients (omitted when ``a1``/``a0``/``b1`` are ``None``), and
     * the conductivity loss :math:`i\,\sigma_\text{phys} / (\varepsilon_0 \omega)`,
       where :math:`\sigma_\text{phys} = \sigma_\text{array} / \Delta` recovers the
       physical S/m value from the resolution-scaled ``electric_conductivity``
@@ -1343,27 +1861,32 @@ def effective_complex_inv_permittivity(
         inv_eps: Per-cell ``1/eps_inf`` (real). Shape ``(num_components, ...)``.
         omega: Angular frequency (rad/s).
         dt: Simulation time step (seconds).
-        c1: ADE coefficient array of shape ``(num_poles, ...)`` or ``None``.
-        c2: ADE coefficient array of shape ``(num_poles, ...)`` or ``None``.
-        c3: ADE coefficient array of shape ``(num_poles, ...)`` or ``None``.
+        a1: Delta-basis coefficient ``a1 = 2 - c1``, shape
+            ``(num_poles, ...)`` or ``None``.
+        a0: Delta-basis coefficient ``a0 = 1 - c1 - c2``, shape
+            ``(num_poles, ...)`` or ``None``.
+        b1: Delta-basis field coupling ``b1 = beta1``, shape
+            ``(num_poles, ...)`` or ``None``.
         electric_conductivity: Resolution-scaled conductivity array, or ``None``.
         conductivity_spacing: Scaling factor used to recover the physical
             conductivity. Required when ``electric_conductivity`` is given.
+        c4: Optional implicit ``E^{n+1}`` coupling array.
+        b0: Optional delta-basis field coupling ``b0``; ``None`` means equal to ``b1``.
 
     Returns:
         Complex ``jax.Array`` broadcasting ``inv_eps`` against the loss terms.
     """
     inv_eps = jnp.asarray(inv_eps)
     complex_dtype = jnp.complex128 if inv_eps.dtype == jnp.float64 else jnp.complex64
-    coupling_c = jnp.asarray(c3).shape[1] if c3 is not None and jnp.asarray(c3).ndim >= 2 else 1
+    coupling_c = jnp.asarray(b1).shape[1] if b1 is not None and jnp.asarray(b1).ndim >= 2 else 1
     if inv_eps.shape[0] == 9 or coupling_c == 9:
         # Diagonal reduction for the mode solver: off-diagonal permittivity and
         # susceptibility entries are dropped, so modal geometry in monoclinic /
         # rotated media is a diagonal approximation.
         eps_mat = _eps_matrix_from_inv(inv_eps)
         eps = jnp.stack([eps_mat[0, 0], eps_mat[1, 1], eps_mat[2, 2]], axis=0).astype(complex_dtype)
-        if c1 is not None and c2 is not None and c3 is not None:
-            chi = susceptibility_from_coefficients(c1=c1, c2=c2, c3=c3, omega=omega, dt=dt, c4=c4)
+        if a1 is not None and a0 is not None and b1 is not None:
+            chi = susceptibility_from_coefficients(a1=a1, a0=a0, b1=b1, omega=omega, dt=dt, c4=c4, b0=b0)
             if chi.shape[0] == 9:
                 chi = jnp.stack([chi[0], chi[4], chi[8]], axis=0)
             eps = eps + chi
@@ -1377,8 +1900,8 @@ def effective_complex_inv_permittivity(
         return 1.0 / eps
 
     eps = (1.0 / inv_eps).astype(complex_dtype)
-    if c1 is not None and c2 is not None and c3 is not None:
-        eps = eps + susceptibility_from_coefficients(c1=c1, c2=c2, c3=c3, omega=omega, dt=dt, c4=c4)
+    if a1 is not None and a0 is not None and b1 is not None:
+        eps = eps + susceptibility_from_coefficients(a1=a1, a0=a0, b1=b1, omega=omega, dt=dt, c4=c4, b0=b0)
     if electric_conductivity is not None:
         if conductivity_spacing is None:
             raise ValueError("conductivity_spacing is required when electric_conductivity is given.")

--- a/src/fdtdx/fdtd/container.py
+++ b/src/fdtdx/fdtd/container.py
@@ -9,8 +9,10 @@ from typing import Callable, Iterator, Self, TypeVar
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 from fdtdx.core.jax.pytrees import TreeClass, autoinit, frozen_field
+from fdtdx.dispersion import compute_pole_coefficients_tensor
 from fdtdx.interfaces.state import RecordingState
 from fdtdx.materials import Material
 from fdtdx.objects.boundaries.bloch import BlochBoundary
@@ -279,22 +281,31 @@ class ObjectContainer(TreeClass):
             default=0,
         )
 
-    @property
-    def has_dispersive_edot(self) -> bool:
-        """Whether any object uses a CCPR pole with a non-zero ``dE/dt`` coupling.
+    def needs_implicit_dispersion(self, dt: float) -> bool:
+        """Whether any pole yields a non-zero implicit ``c4`` at this time step.
 
-        This gates allocation of the ``dispersive_c4`` coefficient array: when
-        ``False`` (all poles are Lorentz/Drude, or there is no dispersion) the
-        ADE update takes the classic ``c4``-free path and stays bit-identical to
-        pre-CCPR behaviour.
+        This gates allocation of the ``dispersive_c4`` and ``dispersive_b0``
+        coefficient arrays together. It is ``True`` when a pole has a non-zero
+        ``dE/dt`` coupling under a central-difference scheme, and for *any* pole
+        under ``integrator="bilinear"`` (whose ``c4 = a / D_b`` is non-zero even
+        for Lorentz and Drude). When ``False`` — all poles Lorentz/Drude on a
+        central-difference scheme, or no dispersion at all — the ADE update takes
+        the explicit path and stays bit-identical to the pre-CCPR behaviour.
+
+        Args:
+            dt: Simulation time step (seconds); the coefficients depend on it.
+
+        Returns:
+            bool: Whether the implicit coefficient arrays must be allocated.
         """
 
-        def _material_has_edot(m: Material) -> bool:
-            if m.dispersion is None:
+        def _material_needs_implicit(m: Material) -> bool:
+            if m.dispersion is None or m.dispersion.num_poles == 0:
                 return False
-            return any(b != 0.0 for p in m.dispersion.poles for b in p.coupling_edot_axes)
+            _, _, _, c4, _ = compute_pole_coefficients_tensor(m.dispersion.poles, dt)
+            return bool(np.any(c4 != 0.0))
 
-        return any(_material_has_edot(m) for m in self._iter_materials())
+        return any(_material_needs_implicit(m) for m in self._iter_materials())
 
     def _is_material_fn_true_for_all(
         self,
@@ -380,13 +391,19 @@ class FieldState(TreeClass):
     #: object's name to a tuple of two arrays (each of shape ``pml.grid_shape``).
     psi_H: PmlAuxField
 
-    #: Dispersive ADE polarization state at time step ``n``. Shape
+    #: First state of the dispersive ADE at time step ``n``. Shape
     #: ``(num_poles, 3, Nx, Ny, Nz)``. ``None`` for non-dispersive simulations.
-    dispersive_P_curr: jax.Array | None = None
+    #: The polarization is recovered as ``p^n = x1^n + c4 * E^n``, so this equals
+    #: ``p^n`` exactly when ``dispersive_c4`` is ``None``.
+    dispersive_x1: jax.Array | None = None
 
-    #: Dispersive ADE polarization state at time step ``n-1``. Shape
+    #: Second state of the dispersive ADE at time step ``n``. Shape
     #: ``(num_poles, 3, Nx, Ny, Nz)``. ``None`` for non-dispersive simulations.
-    dispersive_P_prev: jax.Array | None = None
+    #: This is the delta-basis state ``y2 = x1 + x2`` — neither ``x2`` nor
+    #: ``p^{n-1}``. It is ``O(x1^{n+1} - x1^n)`` where ``x2 ~ -x1`` was ``O(x1)``,
+    #: which is what keeps the float32 recurrence accurate; see
+    #: :mod:`fdtdx.dispersion`.
+    dispersive_y2: jax.Array | None = None
 
 
 @autoinit
@@ -419,30 +436,45 @@ class ArrayContainer(TreeClass):
     #: field for magnetic conductivity terms. Defaults to None.
     magnetic_conductivity: jax.Array | None = None
 
-    #: Per-cell dispersive recurrence coefficient c1. Shape
+    #: Per-cell delta-basis oscillator coefficient ``a1 = 2 - c1``. Shape
     #: ``(num_poles, num_components, Nx, Ny, Nz)`` with ``num_components`` 1
     #: (isotropic dispersion, broadcast over the field components) or 3
     #: (per-axis / diagonally anisotropic dispersion). ``None`` for
-    #: non-dispersive simulations.
-    dispersive_c1: jax.Array | None = None
+    #: non-dispersive simulations. This is **not** ``c1``: storing the residual
+    #: rather than ``c1 ~ 2`` is what gives it full float32 relative precision
+    #: (see :mod:`fdtdx.dispersion`).
+    dispersive_a1: jax.Array | None = None
 
-    #: Per-cell dispersive recurrence coefficient c2. Shape
+    #: Per-cell delta-basis oscillator coefficient ``a0 = 1 - c1 - c2``. Shape
     #: ``(num_poles, num_components, Nx, Ny, Nz)``, ``num_components in (1, 3)``.
-    #: ``None`` for non-dispersive simulations.
-    dispersive_c2: jax.Array | None = None
+    #: ``None`` for non-dispersive simulations. This is **not** ``c2``. For a real
+    #: pole it is ``O((omega_0 dt)^2)``, i.e. far below the float32 resolution of
+    #: ``c1``/``c2`` themselves, which is precisely why it is stored directly.
+    dispersive_a0: jax.Array | None = None
 
-    #: Per-cell dispersive field coupling c3. Shape
+    #: Per-cell delta-basis field coupling ``b1 = beta1 = c3 + c1 * c4``. Shape
     #: ``(num_poles, num_components, Nx, Ny, Nz)``, ``num_components in (1, 3, 9)``
     #: — 9 encodes a row-major 3x3 coupling tensor per pole (oriented poles,
     #: off-diagonal dispersion). ``None`` for non-dispersive simulations.
-    dispersive_c3: jax.Array | None = None
+    #: This is ``beta1``, **not** the P-form ``c3``; the two coincide only when
+    #: ``dispersive_c4`` is ``None``.
+    dispersive_b1: jax.Array | None = None
 
-    #: Per-cell dispersive recurrence coefficient c4 (the ``dE/dt`` / CCPR
-    #: coupling to ``E^{n+1}``). Shape ``(num_poles, num_components, Nx, Ny, Nz)``,
-    #: ``num_components in (1, 3)``. ``None`` unless at least one CCPR pole with
-    #: non-zero ``coupling_edot`` is present; Lorentz/Drude-only sims leave it
-    #: ``None`` and skip the CCPR update path.
+    #: Per-cell dispersive recurrence coefficient c4 (the implicit coupling to
+    #: ``E^{n+1}``). Shape ``(num_poles, num_components, Nx, Ny, Nz)``,
+    #: ``num_components in (1, 3)``. ``None`` unless at least one pole has a
+    #: non-zero ``c4`` — i.e. a non-zero ``coupling_edot`` under the
+    #: central-difference schemes, or any pole under ``"bilinear"``. Lorentz and
+    #: Drude poles on the default scheme leave it ``None`` and skip the implicit
+    #: update path entirely.
     dispersive_c4: jax.Array | None = None
+
+    #: Per-cell delta-basis field coupling ``b0 = beta1 + beta0``. Shape
+    #: ``(num_poles, num_components, Nx, Ny, Nz)``, ``num_components in (1, 3)``.
+    #: Allocated together with ``dispersive_c4`` and ``None`` under the same
+    #: conditions — and when it is ``None``, ``b0`` equals ``b1`` exactly
+    #: (``c4 = c5 = 0`` implies ``beta0 = 0``), which is how the update treats it.
+    dispersive_b0: jax.Array | None = None
 
     #: Backup of inverse permittivity values array.
     #: Only used when etching a device.
@@ -469,10 +501,10 @@ class ArrayContainer(TreeClass):
         Returns:
             A new ArrayContainer with reset dynamic state.
         """
-        # FieldState now holds the dispersive ADE polarization (dispersive_P_curr/prev)
-        # alongside E/H/psi, so this single tree.map zeroes all dynamic per-timestep
-        # state at once (``None`` leaves stay ``None`` for non-dispersive sims).
-        # Coefficient arrays (c1/c2/c3/c4) are material properties and preserved.
+        # FieldState now holds the dispersive ADE state (dispersive_x1/y2) alongside
+        # E/H/psi, so this single tree.map zeroes all dynamic per-timestep state at
+        # once (``None`` leaves stay ``None`` for non-dispersive sims). Coefficient
+        # arrays (a1/a0/b1/c4/b0) are material properties and preserved.
         arrays = self.aset("fields", jax.tree.map(jnp.zeros_like, self.fields))
 
         detector_states = self.detector_states

--- a/src/fdtdx/fdtd/fdtd.py
+++ b/src/fdtdx/fdtd/fdtd.py
@@ -86,8 +86,8 @@ def reversible_fdtd(
 
     Raises:
         NotImplementedError: If the simulation contains dispersive materials. Reversing
-            the ADE polarization recurrence is not supported; use the ``"checkpointed"``
-            gradient method for dispersive simulations.
+            the ADE recurrence is not supported; use the ``"checkpointed"`` gradient
+            method for dispersive simulations.
     """
     # if arrays.magnetic_conductivity is not None or arrays.electric_conductivity is not None:
     #     raise Exception(f"Reversible FDTD does not work with Conductive Materials")
@@ -95,7 +95,7 @@ def reversible_fdtd(
     # Checked here in addition to initialization time, since the gradient config can be
     # swapped after ``place_objects`` and this function can be called directly, bypassing
     # ``run_fdtd``.
-    if arrays.dispersive_c1 is not None or arrays.fields.dispersive_P_curr is not None:
+    if arrays.dispersive_a1 is not None or arrays.fields.dispersive_x1 is not None:
         raise NotImplementedError(
             "Dispersive time-reversible gradient computation under active development. "
             "Use GradientConfig(method='checkpointed') instead."

--- a/src/fdtdx/fdtd/initialization.py
+++ b/src/fdtdx/fdtd/initialization.py
@@ -13,7 +13,7 @@ from fdtdx.core.jax.default_key import default_key
 from fdtdx.core.jax.guards import check_not_tracing
 from fdtdx.core.jax.sharding import create_named_sharded_matrix
 from fdtdx.core.jax.ste import straight_through_estimator
-from fdtdx.dispersion import compute_pole_coefficients_tensor
+from fdtdx.dispersion import compute_pole_delta_coefficients_tensor
 from fdtdx.fdtd.container import ArrayContainer, FieldState, ObjectContainer, ParameterContainer
 from fdtdx.fdtd.symmetry import apply_mode_symmetry, make_symmetry_walls, reduce_resolved_slices
 from fdtdx.materials import (
@@ -269,10 +269,11 @@ def place_objects(
     arrays, config, info = _init_arrays(objects=objects_container, config=config)
 
     # Step 11: Update object configs and apply objects if possible
-    disp_c1 = None if arrays.dispersive_c1 is None else jax.lax.stop_gradient(arrays.dispersive_c1)
-    disp_c2 = None if arrays.dispersive_c2 is None else jax.lax.stop_gradient(arrays.dispersive_c2)
-    disp_c3 = None if arrays.dispersive_c3 is None else jax.lax.stop_gradient(arrays.dispersive_c3)
+    disp_a1 = None if arrays.dispersive_a1 is None else jax.lax.stop_gradient(arrays.dispersive_a1)
+    disp_a0 = None if arrays.dispersive_a0 is None else jax.lax.stop_gradient(arrays.dispersive_a0)
+    disp_b1 = None if arrays.dispersive_b1 is None else jax.lax.stop_gradient(arrays.dispersive_b1)
     disp_c4 = None if arrays.dispersive_c4 is None else jax.lax.stop_gradient(arrays.dispersive_c4)
+    disp_b0 = None if arrays.dispersive_b0 is None else jax.lax.stop_gradient(arrays.dispersive_b0)
     sigma_e = None if arrays.electric_conductivity is None else jax.lax.stop_gradient(arrays.electric_conductivity)
     new_object_list = []
     devices = objects_container.devices
@@ -287,10 +288,11 @@ def place_objects(
                 key=subkey,
                 inv_permittivities=jax.lax.stop_gradient(arrays.inv_permittivities),
                 inv_permeabilities=jax.lax.stop_gradient(arrays.inv_permeabilities),
-                dispersive_c1=disp_c1,
-                dispersive_c2=disp_c2,
-                dispersive_c3=disp_c3,
+                dispersive_a1=disp_a1,
+                dispersive_a0=disp_a0,
+                dispersive_b1=disp_b1,
                 dispersive_c4=disp_c4,
+                dispersive_b0=disp_b0,
                 electric_conductivity=sigma_e,
             )
         new_object_list.append(obj)
@@ -332,12 +334,12 @@ def apply_params(
     isotropic = num_perm_components == 1
     diagonally_anisotropic = num_perm_components == 3
 
-    num_dispersive_poles = arrays.dispersive_c1.shape[0] if arrays.dispersive_c1 is not None else 0
-    # Component axes of the dispersive coefficient arrays: c1/c2 carry 1
-    # (isotropic, broadcast) or 3 (per-axis) components; the couplings c3/c4
+    num_dispersive_poles = arrays.dispersive_a1.shape[0] if arrays.dispersive_a1 is not None else 0
+    # Component axes of the dispersive coefficient arrays: a1/a0 carry 1
+    # (isotropic, broadcast) or 3 (per-axis) components; the couplings b1/c4/b0
     # additionally allow 9 (row-major 3x3 tensor, oriented poles).
-    num_disp_components = arrays.dispersive_c1.shape[1] if arrays.dispersive_c1 is not None else 1
-    num_disp_coupling_components = arrays.dispersive_c3.shape[1] if arrays.dispersive_c3 is not None else 1
+    num_disp_components = arrays.dispersive_a1.shape[1] if arrays.dispersive_a1 is not None else 1
+    num_disp_coupling_components = arrays.dispersive_b1.shape[1] if arrays.dispersive_b1 is not None else 1
 
     if arrays.initial_inv_permittivities is not None:
         arrays = arrays.at["inv_permittivities"].set(arrays.initial_inv_permittivities)
@@ -365,30 +367,38 @@ def apply_params(
         # coupling is present anywhere in the sim (gated at init time). When it
         # is None, every material's c4 is identically zero, so we simply skip
         # writing it.
-        write_dispersive_c4 = write_dispersive and arrays.dispersive_c4 is not None
+        write_dispersive_implicit = write_dispersive and arrays.dispersive_c4 is not None
 
         # Initialise dispersive slots; populated below when write_dispersive is True.
-        allowed_c1_arr = allowed_c2_arr = allowed_c3_arr = allowed_c4_arr = None
-        new_c1_slice = new_c2_slice = new_c3_slice = new_c4_slice = None
+        allowed_a1_arr = allowed_a0_arr = allowed_b1_arr = allowed_c4_arr = allowed_b0_arr = None
+        new_a1_slice = new_a0_slice = new_b1_slice = new_c4_slice = new_b0_slice = None
         if write_dispersive:
             assert (
-                arrays.dispersive_c1 is not None
-                and arrays.dispersive_c2 is not None
-                and arrays.dispersive_c3 is not None
+                arrays.dispersive_a1 is not None
+                and arrays.dispersive_a0 is not None
+                and arrays.dispersive_b1 is not None
             )
             dt = device._config.time_step_duration
-            allowed_c1_np, allowed_c2_np, allowed_c3_np, allowed_c4_np = compute_allowed_dispersive_coefficients(
+            (
+                allowed_a1_np,
+                allowed_a0_np,
+                allowed_b1_np,
+                allowed_c4_np,
+                allowed_b0_np,
+            ) = compute_allowed_dispersive_coefficients(
                 device.materials,
                 dt=dt,
                 max_num_poles=num_dispersive_poles,
                 num_components=num_disp_components,
                 coupling_components=num_disp_coupling_components,
             )
-            allowed_c1_arr = jnp.asarray(allowed_c1_np, dtype=arrays.dispersive_c1.dtype)
-            allowed_c2_arr = jnp.asarray(allowed_c2_np, dtype=arrays.dispersive_c2.dtype)
-            allowed_c3_arr = jnp.asarray(allowed_c3_np, dtype=arrays.dispersive_c3.dtype)
-            if write_dispersive_c4:
+            allowed_a1_arr = jnp.asarray(allowed_a1_np, dtype=arrays.dispersive_a1.dtype)
+            allowed_a0_arr = jnp.asarray(allowed_a0_np, dtype=arrays.dispersive_a0.dtype)
+            allowed_b1_arr = jnp.asarray(allowed_b1_np, dtype=arrays.dispersive_b1.dtype)
+            if write_dispersive_implicit:
+                assert arrays.dispersive_c4 is not None and arrays.dispersive_b0 is not None
                 allowed_c4_arr = jnp.asarray(allowed_c4_np, dtype=arrays.dispersive_c4.dtype)
+                allowed_b0_arr = jnp.asarray(allowed_b0_np, dtype=arrays.dispersive_b0.dtype)
 
         if device.output_type == ParameterType.CONTINUOUS:
             # Linear interpolation between two materials via their permittivities
@@ -406,27 +416,30 @@ def apply_params(
             new_inv_perm_slice = _invert_property(perm_slice)
 
             if write_dispersive:
-                assert allowed_c1_arr is not None and allowed_c2_arr is not None and allowed_c3_arr is not None
+                assert allowed_a1_arr is not None and allowed_a0_arr is not None and allowed_b1_arr is not None
                 # Linear interpolation of dispersive coefficients between the two bracketing materials.
                 # allowed_cN_arr: (num_materials, num_poles, num_components) — here num_materials == 2.
                 # reshape to (num_poles, num_components, 1, 1, 1) for broadcast over
                 # (num_poles, num_components, Nx, Ny, Nz)
                 w0 = (1 - cur_material_indices)[None, None, ...]  # (1, 1, Nx, Ny, Nz)
                 w1 = cur_material_indices[None, None, ...]
-                c1_0 = allowed_c1_arr[0][:, :, None, None, None]  # (num_poles, num_components, 1, 1, 1)
-                c1_1 = allowed_c1_arr[1][:, :, None, None, None]
-                c2_0 = allowed_c2_arr[0][:, :, None, None, None]
-                c2_1 = allowed_c2_arr[1][:, :, None, None, None]
-                c3_0 = allowed_c3_arr[0][:, :, None, None, None]
-                c3_1 = allowed_c3_arr[1][:, :, None, None, None]
-                new_c1_slice = w0 * c1_0 + w1 * c1_1
-                new_c2_slice = w0 * c2_0 + w1 * c2_1
-                new_c3_slice = w0 * c3_0 + w1 * c3_1
-                if write_dispersive_c4:
-                    assert allowed_c4_arr is not None
+                a1_0 = allowed_a1_arr[0][:, :, None, None, None]  # (num_poles, num_components, 1, 1, 1)
+                a1_1 = allowed_a1_arr[1][:, :, None, None, None]
+                a0_0 = allowed_a0_arr[0][:, :, None, None, None]
+                a0_1 = allowed_a0_arr[1][:, :, None, None, None]
+                b1_0 = allowed_b1_arr[0][:, :, None, None, None]
+                b1_1 = allowed_b1_arr[1][:, :, None, None, None]
+                new_a1_slice = w0 * a1_0 + w1 * a1_1
+                new_a0_slice = w0 * a0_0 + w1 * a0_1
+                new_b1_slice = w0 * b1_0 + w1 * b1_1
+                if write_dispersive_implicit:
+                    assert allowed_c4_arr is not None and allowed_b0_arr is not None
                     c4_0 = allowed_c4_arr[0][:, :, None, None, None]
                     c4_1 = allowed_c4_arr[1][:, :, None, None, None]
                     new_c4_slice = w0 * c4_0 + w1 * c4_1
+                    b0_0 = allowed_b0_arr[0][:, :, None, None, None]
+                    b0_1 = allowed_b0_arr[1][:, :, None, None, None]
+                    new_b0_slice = w0 * b0_0 + w1 * b0_1
         else:
             # Discrete material selection
             # Precompute inverse permittivities since the selection result is binary
@@ -441,16 +454,17 @@ def apply_params(
             new_inv_perm_slice = straight_through_estimator(cur_material_indices, component_values)
 
             if write_dispersive:
-                assert allowed_c1_arr is not None and allowed_c2_arr is not None and allowed_c3_arr is not None
+                assert allowed_a1_arr is not None and allowed_a0_arr is not None and allowed_b1_arr is not None
                 int_idx = cur_material_indices.astype(jnp.int32)
                 # allowed_cN_arr[int_idx]: (Nx, Ny, Nz, num_poles, num_components)
                 # -> moveaxis -> (num_poles, num_components, Nx, Ny, Nz)
-                new_c1_slice = jnp.moveaxis(allowed_c1_arr[int_idx], (-2, -1), (0, 1))
-                new_c2_slice = jnp.moveaxis(allowed_c2_arr[int_idx], (-2, -1), (0, 1))
-                new_c3_slice = jnp.moveaxis(allowed_c3_arr[int_idx], (-2, -1), (0, 1))
-                if write_dispersive_c4:
-                    assert allowed_c4_arr is not None
+                new_a1_slice = jnp.moveaxis(allowed_a1_arr[int_idx], (-2, -1), (0, 1))
+                new_a0_slice = jnp.moveaxis(allowed_a0_arr[int_idx], (-2, -1), (0, 1))
+                new_b1_slice = jnp.moveaxis(allowed_b1_arr[int_idx], (-2, -1), (0, 1))
+                if write_dispersive_implicit:
+                    assert allowed_c4_arr is not None and allowed_b0_arr is not None
                     new_c4_slice = jnp.moveaxis(allowed_c4_arr[int_idx], (-2, -1), (0, 1))
+                    new_b0_slice = jnp.moveaxis(allowed_b0_arr[int_idx], (-2, -1), (0, 1))
 
         # Update all components of inv_permittivities array at once
         new_inv_perm = arrays.inv_permittivities.at[:, *device.grid_slice].set(new_inv_perm_slice)
@@ -458,20 +472,22 @@ def apply_params(
 
         if write_dispersive:
             assert (
-                arrays.dispersive_c1 is not None
-                and arrays.dispersive_c2 is not None
-                and arrays.dispersive_c3 is not None
+                arrays.dispersive_a1 is not None
+                and arrays.dispersive_a0 is not None
+                and arrays.dispersive_b1 is not None
             )
-            new_c1 = arrays.dispersive_c1.at[:, :, *device.grid_slice].set(new_c1_slice)
-            new_c2 = arrays.dispersive_c2.at[:, :, *device.grid_slice].set(new_c2_slice)
-            new_c3 = arrays.dispersive_c3.at[:, :, *device.grid_slice].set(new_c3_slice)
-            arrays = arrays.at["dispersive_c1"].set(new_c1)
-            arrays = arrays.at["dispersive_c2"].set(new_c2)
-            arrays = arrays.at["dispersive_c3"].set(new_c3)
-            if write_dispersive_c4:
-                assert arrays.dispersive_c4 is not None
+            new_a1 = arrays.dispersive_a1.at[:, :, *device.grid_slice].set(new_a1_slice)
+            new_a0 = arrays.dispersive_a0.at[:, :, *device.grid_slice].set(new_a0_slice)
+            new_b1 = arrays.dispersive_b1.at[:, :, *device.grid_slice].set(new_b1_slice)
+            arrays = arrays.at["dispersive_a1"].set(new_a1)
+            arrays = arrays.at["dispersive_a0"].set(new_a0)
+            arrays = arrays.at["dispersive_b1"].set(new_b1)
+            if write_dispersive_implicit:
+                assert arrays.dispersive_c4 is not None and arrays.dispersive_b0 is not None
                 new_c4 = arrays.dispersive_c4.at[:, :, *device.grid_slice].set(new_c4_slice)
                 arrays = arrays.at["dispersive_c4"].set(new_c4)
+                new_b0 = arrays.dispersive_b0.at[:, :, *device.grid_slice].set(new_b0_slice)
+                arrays = arrays.at["dispersive_b0"].set(new_b0)
 
     # apply random key to sources. Source-side sampling of the dispersion
     # coefficients (used only for carrier-frequency impedance / energy
@@ -479,10 +495,11 @@ def apply_params(
     # ``inv_permittivities`` — the FDTD VJP itself still propagates gradient
     # through the coefficients, so this only avoids noise from the source
     # amplitude path.
-    disp_c1 = None if arrays.dispersive_c1 is None else jax.lax.stop_gradient(arrays.dispersive_c1)
-    disp_c2 = None if arrays.dispersive_c2 is None else jax.lax.stop_gradient(arrays.dispersive_c2)
-    disp_c3 = None if arrays.dispersive_c3 is None else jax.lax.stop_gradient(arrays.dispersive_c3)
+    disp_a1 = None if arrays.dispersive_a1 is None else jax.lax.stop_gradient(arrays.dispersive_a1)
+    disp_a0 = None if arrays.dispersive_a0 is None else jax.lax.stop_gradient(arrays.dispersive_a0)
+    disp_b1 = None if arrays.dispersive_b1 is None else jax.lax.stop_gradient(arrays.dispersive_b1)
     disp_c4 = None if arrays.dispersive_c4 is None else jax.lax.stop_gradient(arrays.dispersive_c4)
+    disp_b0 = None if arrays.dispersive_b0 is None else jax.lax.stop_gradient(arrays.dispersive_b0)
     sigma_e = None if arrays.electric_conductivity is None else jax.lax.stop_gradient(arrays.electric_conductivity)
     new_objects = []
     devices = objects.devices
@@ -495,10 +512,11 @@ def apply_params(
                 key=subkey,
                 inv_permittivities=jax.lax.stop_gradient(arrays.inv_permittivities),
                 inv_permeabilities=jax.lax.stop_gradient(arrays.inv_permeabilities),
-                dispersive_c1=disp_c1,
-                dispersive_c2=disp_c2,
-                dispersive_c3=disp_c3,
+                dispersive_a1=disp_a1,
+                dispersive_a0=disp_a0,
+                dispersive_b1=disp_b1,
                 dispersive_c4=disp_c4,
+                dispersive_b0=disp_b0,
                 electric_conductivity=sigma_e,
             )
         new_objects.append(obj)
@@ -652,18 +670,18 @@ def _init_arrays(
         isotropic_permittivity = False
         diagonally_anisotropic_permittivity = not subpixel_full_tensor
 
-    # Dispersion tiers. The recurrence coefficients c1/c2 carry 1 (isotropic,
-    # broadcast) or 3 (per-axis) components; the field couplings c3/c4
+    # Dispersion tiers. The oscillator coefficients a1/a0 carry 1 (isotropic,
+    # broadcast) or 3 (per-axis) components; the field couplings b1/c4/b0
     # additionally widen to 9 (row-major 3x3 tensor per pole) when any pole is
     # oriented. Oriented dispersion — and dispersion combined with fully
     # anisotropic material tensors — runs through the fully anisotropic update
-    # kernel, which carries its own ADE block but no CCPR dE/dt solve.
+    # kernel, which carries its own ADE block but no implicit c4 solve.
     num_dispersive_poles = objects.max_num_dispersive_poles
 
     # Dispersive materials support only the checkpointed gradient method. Reversing the
-    # ADE polarization recurrence is not currently supported. Checked here for the
-    # earliest possible error; ``reversible_fdtd`` repeats the check because the gradient
-    # config can be swapped after ``place_objects``.
+    # ADE recurrence is not currently supported. Checked here for the earliest possible
+    # error; ``reversible_fdtd`` repeats the check because the gradient config can be
+    # swapped after ``place_objects``.
     if (
         num_dispersive_poles > 0
         and config.gradient_config is not None
@@ -683,10 +701,12 @@ def _init_arrays(
         or not (isotropic_electric_conductivity or diagonally_anisotropic_electric_conductivity)
     )
     if tensor_dispersion_path:
-        if objects.has_dispersive_edot:
+        if objects.needs_implicit_dispersion(config.time_step_duration):
             raise NotImplementedError(
-                "CCPR poles with a dE/dt coupling (non-zero Re(residue)) cannot be combined with "
-                "oriented poles or fully anisotropic (off-diagonal) material tensors."
+                "Poles with a non-zero implicit c4 coupling — a non-zero dE/dt coupling (CCPR / modified "
+                "Lorentz), or any pole under integrator='bilinear' — cannot be combined with oriented "
+                "poles or fully anisotropic (off-diagonal) material tensors: the implicit E^{n+1} term "
+                "would become a per-cell 3x3 solve entangled with the off-diagonal Yee averaging."
             )
         if not axis_aligned_dispersion and config.has_nonuniform_grid:
             raise NotImplementedError(
@@ -775,54 +795,64 @@ def _init_arrays(
         conductivity_spacing = constants.c * config.time_step_duration / config.courant_number
 
     # dispersive ADE auxiliary arrays - all None unless any material is dispersive.
-    # ``dispersive_c4`` (the CCPR dE/dt coupling) is only allocated when at least
-    # one pole in the sim has a non-zero ``coupling_edot``. Lorentz/Drude-only
-    # sims leave it None so the ADE update takes the classic path unchanged.
-    allocate_c4 = num_dispersive_poles > 0 and objects.has_dispersive_edot
-    dispersive_P_curr = None
-    dispersive_P_prev = None
-    dispersive_c1 = None
-    dispersive_c2 = None
-    dispersive_c3 = None
+    # ``dispersive_c4`` and ``dispersive_b0`` are allocated together, and only
+    # when at least one pole in the sim yields a non-zero ``c4``: a non-zero
+    # ``coupling_edot`` under the central-difference schemes, or any pole under
+    # ``integrator="bilinear"``. Lorentz/Drude-only sims on a central-difference
+    # scheme leave both None so the ADE update takes the explicit path unchanged.
+    allocate_implicit = num_dispersive_poles > 0 and objects.needs_implicit_dispersion(config.time_step_duration)
+    dispersive_x1 = None
+    dispersive_y2 = None
+    dispersive_a1 = None
+    dispersive_a0 = None
+    dispersive_b1 = None
     dispersive_c4 = None
+    dispersive_b0 = None
     if num_dispersive_poles > 0:
-        dispersive_P_curr = create_named_sharded_matrix(
+        dispersive_x1 = create_named_sharded_matrix(
             (num_dispersive_poles, 3, *volume_shape),
             value=0.0,
             dtype=field_dtype,
             sharding_axis=2,
             backend=config.backend,
         )
-        dispersive_P_prev = create_named_sharded_matrix(
+        dispersive_y2 = create_named_sharded_matrix(
             (num_dispersive_poles, 3, *volume_shape),
             value=0.0,
             dtype=field_dtype,
             sharding_axis=2,
             backend=config.backend,
         )
-        dispersive_c1 = create_named_sharded_matrix(
+        dispersive_a1 = create_named_sharded_matrix(
             (num_dispersive_poles, num_disp_components, *volume_shape),
             value=0.0,
             dtype=config.dtype,
             sharding_axis=2,
             backend=config.backend,
         )
-        dispersive_c2 = create_named_sharded_matrix(
+        dispersive_a0 = create_named_sharded_matrix(
             (num_dispersive_poles, num_disp_components, *volume_shape),
             value=0.0,
             dtype=config.dtype,
             sharding_axis=2,
             backend=config.backend,
         )
-        dispersive_c3 = create_named_sharded_matrix(
+        dispersive_b1 = create_named_sharded_matrix(
             (num_dispersive_poles, num_disp_coupling_components, *volume_shape),
             value=0.0,
             dtype=config.dtype,
             sharding_axis=2,
             backend=config.backend,
         )
-        if allocate_c4:
+        if allocate_implicit:
             dispersive_c4 = create_named_sharded_matrix(
+                (num_dispersive_poles, num_disp_coupling_components, *volume_shape),
+                value=0.0,
+                dtype=config.dtype,
+                sharding_axis=2,
+                backend=config.backend,
+            )
+            dispersive_b0 = create_named_sharded_matrix(
                 (num_dispersive_poles, num_disp_coupling_components, *volume_shape),
                 value=0.0,
                 dtype=config.dtype,
@@ -931,14 +961,17 @@ def _init_arrays(
                 # Without this, a non-dispersive UniformMaterialObject stacked over
                 # a dispersive one would leave stale pole coefficients in the overlap
                 # and drive an ADE update on cells that shouldn't have one.
-                assert dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None
+                assert dispersive_a1 is not None and dispersive_a0 is not None and dispersive_b1 is not None
                 poles = o.material.dispersion.poles if o.material.dispersion is not None else ()
-                c1_vals, c2_vals, c3_vals, c4_vals = compute_pole_coefficients_tensor(poles, config.time_step_duration)
+                a1_vals, a0_vals, b1_vals, c4_vals, b0_vals = compute_pole_delta_coefficients_tensor(
+                    poles, config.time_step_duration
+                )
                 n = len(poles)
-                c1_padded = jnp.zeros((num_dispersive_poles, num_disp_components), dtype=config.dtype)
-                c2_padded = jnp.zeros((num_dispersive_poles, num_disp_components), dtype=config.dtype)
-                c3_padded = jnp.zeros((num_dispersive_poles, num_disp_coupling_components), dtype=config.dtype)
+                a1_padded = jnp.zeros((num_dispersive_poles, num_disp_components), dtype=config.dtype)
+                a0_padded = jnp.zeros((num_dispersive_poles, num_disp_components), dtype=config.dtype)
+                b1_padded = jnp.zeros((num_dispersive_poles, num_disp_coupling_components), dtype=config.dtype)
                 c4_padded = jnp.zeros((num_dispersive_poles, num_disp_coupling_components), dtype=config.dtype)
+                b0_padded = jnp.zeros((num_dispersive_poles, num_disp_coupling_components), dtype=config.dtype)
                 if n > 0:
                     # For num_disp_components == 1 all poles in the simulation are
                     # isotropic (per all_objects_isotropic_dispersion), so the
@@ -946,29 +979,34 @@ def _init_arrays(
                     # is exact. Likewise a coupling tier < 9 implies axis-aligned
                     # dispersion, so keeping diagonal coupling entries is exact.
                     if num_disp_coupling_components == 9:
-                        c3_reduced, c4_reduced = c3_vals, c4_vals
+                        b1_reduced, c4_reduced, b0_reduced = b1_vals, c4_vals, b0_vals
                     else:
                         diag_entries = (0, 4, 8)[:num_disp_coupling_components]
-                        c3_reduced = c3_vals[:, diag_entries]
+                        b1_reduced = b1_vals[:, diag_entries]
                         c4_reduced = c4_vals[:, diag_entries]
-                    c1_padded = c1_padded.at[:n].set(jnp.asarray(c1_vals[:, :num_disp_components], dtype=config.dtype))
-                    c2_padded = c2_padded.at[:n].set(jnp.asarray(c2_vals[:, :num_disp_components], dtype=config.dtype))
-                    c3_padded = c3_padded.at[:n].set(jnp.asarray(c3_reduced, dtype=config.dtype))
+                        b0_reduced = b0_vals[:, diag_entries]
+                    a1_padded = a1_padded.at[:n].set(jnp.asarray(a1_vals[:, :num_disp_components], dtype=config.dtype))
+                    a0_padded = a0_padded.at[:n].set(jnp.asarray(a0_vals[:, :num_disp_components], dtype=config.dtype))
+                    b1_padded = b1_padded.at[:n].set(jnp.asarray(b1_reduced, dtype=config.dtype))
                     c4_padded = c4_padded.at[:n].set(jnp.asarray(c4_reduced, dtype=config.dtype))
+                    b0_padded = b0_padded.at[:n].set(jnp.asarray(b0_reduced, dtype=config.dtype))
                 # Broadcast (num_poles, num_components) → (num_poles, num_components, Nx, Ny, Nz) over grid_slice.
                 # The recurrence coefficients and field couplings can carry
                 # different component counts (e.g. 3 vs 9 for oriented poles).
-                slice_shape = dispersive_c1[:, :, *o.grid_slice].shape
-                coupling_slice_shape = dispersive_c3[:, :, *o.grid_slice].shape
-                c1_block = jnp.broadcast_to(c1_padded[:, :, None, None, None], slice_shape)
-                c2_block = jnp.broadcast_to(c2_padded[:, :, None, None, None], slice_shape)
-                c3_block = jnp.broadcast_to(c3_padded[:, :, None, None, None], coupling_slice_shape)
-                dispersive_c1 = dispersive_c1.at[:, :, *o.grid_slice].set(c1_block)
-                dispersive_c2 = dispersive_c2.at[:, :, *o.grid_slice].set(c2_block)
-                dispersive_c3 = dispersive_c3.at[:, :, *o.grid_slice].set(c3_block)
+                slice_shape = dispersive_a1[:, :, *o.grid_slice].shape
+                coupling_slice_shape = dispersive_b1[:, :, *o.grid_slice].shape
+                a1_block = jnp.broadcast_to(a1_padded[:, :, None, None, None], slice_shape)
+                a0_block = jnp.broadcast_to(a0_padded[:, :, None, None, None], slice_shape)
+                b1_block = jnp.broadcast_to(b1_padded[:, :, None, None, None], coupling_slice_shape)
+                dispersive_a1 = dispersive_a1.at[:, :, *o.grid_slice].set(a1_block)
+                dispersive_a0 = dispersive_a0.at[:, :, *o.grid_slice].set(a0_block)
+                dispersive_b1 = dispersive_b1.at[:, :, *o.grid_slice].set(b1_block)
                 if dispersive_c4 is not None:
+                    assert dispersive_b0 is not None
                     c4_block = jnp.broadcast_to(c4_padded[:, :, None, None, None], coupling_slice_shape)
                     dispersive_c4 = dispersive_c4.at[:, :, *o.grid_slice].set(c4_block)
+                    b0_block = jnp.broadcast_to(b0_padded[:, :, None, None, None], coupling_slice_shape)
+                    dispersive_b0 = dispersive_b0.at[:, :, *o.grid_slice].set(b0_block)
 
         elif isinstance(o, (StaticMultiMaterialObject)):
             indices = o.get_material_mapping()
@@ -1066,8 +1104,14 @@ def _init_arrays(
             # zero the inherited coefficients in its mask. compute_allowed_dispersive_coefficients
             # zero-pads non-dispersive materials, so this still cleanly overwrites.
             if num_dispersive_poles > 0:
-                assert dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None
-                allowed_c1, allowed_c2, allowed_c3, allowed_c4 = compute_allowed_dispersive_coefficients(
+                assert dispersive_a1 is not None and dispersive_a0 is not None and dispersive_b1 is not None
+                (
+                    allowed_a1,
+                    allowed_a0,
+                    allowed_b1,
+                    allowed_c4,
+                    allowed_b0,
+                ) = compute_allowed_dispersive_coefficients(
                     o.materials,
                     dt=config.time_step_duration,
                     max_num_poles=num_dispersive_poles,
@@ -1076,20 +1120,24 @@ def _init_arrays(
                 )
                 # Shape (num_materials, num_poles, num_components) -> index by (Nx, Ny, Nz) ->
                 # (Nx, Ny, Nz, num_poles, num_components) -> moveaxis -> (num_poles, num_components, Nx, Ny, Nz)
-                c1_voxels = jnp.moveaxis(jnp.asarray(allowed_c1, dtype=config.dtype)[indices], (-2, -1), (0, 1))
-                c2_voxels = jnp.moveaxis(jnp.asarray(allowed_c2, dtype=config.dtype)[indices], (-2, -1), (0, 1))
-                c3_voxels = jnp.moveaxis(jnp.asarray(allowed_c3, dtype=config.dtype)[indices], (-2, -1), (0, 1))
+                a1_voxels = jnp.moveaxis(jnp.asarray(allowed_a1, dtype=config.dtype)[indices], (-2, -1), (0, 1))
+                a0_voxels = jnp.moveaxis(jnp.asarray(allowed_a0, dtype=config.dtype)[indices], (-2, -1), (0, 1))
+                b1_voxels = jnp.moveaxis(jnp.asarray(allowed_b1, dtype=config.dtype)[indices], (-2, -1), (0, 1))
                 mask_bc = mask[None, None, ...]
-                diff = c1_voxels - dispersive_c1[:, :, *o.grid_slice]
-                dispersive_c1 = dispersive_c1.at[:, :, *o.grid_slice].add(mask_bc * diff)
-                diff = c2_voxels - dispersive_c2[:, :, *o.grid_slice]
-                dispersive_c2 = dispersive_c2.at[:, :, *o.grid_slice].add(mask_bc * diff)
-                diff = c3_voxels - dispersive_c3[:, :, *o.grid_slice]
-                dispersive_c3 = dispersive_c3.at[:, :, *o.grid_slice].add(mask_bc * diff)
+                diff = a1_voxels - dispersive_a1[:, :, *o.grid_slice]
+                dispersive_a1 = dispersive_a1.at[:, :, *o.grid_slice].add(mask_bc * diff)
+                diff = a0_voxels - dispersive_a0[:, :, *o.grid_slice]
+                dispersive_a0 = dispersive_a0.at[:, :, *o.grid_slice].add(mask_bc * diff)
+                diff = b1_voxels - dispersive_b1[:, :, *o.grid_slice]
+                dispersive_b1 = dispersive_b1.at[:, :, *o.grid_slice].add(mask_bc * diff)
                 if dispersive_c4 is not None:
+                    assert dispersive_b0 is not None
                     c4_voxels = jnp.moveaxis(jnp.asarray(allowed_c4, dtype=config.dtype)[indices], (-2, -1), (0, 1))
                     diff = c4_voxels - dispersive_c4[:, :, *o.grid_slice]
                     dispersive_c4 = dispersive_c4.at[:, :, *o.grid_slice].add(mask_bc * diff)
+                    b0_voxels = jnp.moveaxis(jnp.asarray(allowed_b0, dtype=config.dtype)[indices], (-2, -1), (0, 1))
+                    diff = b0_voxels - dispersive_b0[:, :, *o.grid_slice]
+                    dispersive_b0 = dispersive_b0.at[:, :, *o.grid_slice].add(mask_bc * diff)
         else:
             raise Exception(f"Unknown object type: {o}")
 
@@ -1119,13 +1167,13 @@ def _init_arrays(
         )
         config = config.aset("gradient_config", grad_cfg)
 
-    # Validate CCPR dispersive stability once, on concrete host values. Only CCPR
-    # (non-zero dE/dt coupling) poles have a non-trivial implicit divisor, so the
-    # gate keeps Lorentz/Drude-only sims free of this cost. CCPR poles on the
-    # full-tensor path are already rejected by the NotImplementedError guard above,
-    # so this only runs on the 1/3-component paths whose divisor is exactly what
-    # update_E computes.
-    if objects.has_dispersive_edot:
+    # Validate dispersive stability once, on concrete host values. Only poles with a
+    # non-zero implicit ``c4`` have a non-trivial divisor, so the gate keeps
+    # Lorentz/Drude-only sims on a central-difference scheme free of this cost. The
+    # full-tensor path (which has no implicit solve) is already rejected for such
+    # poles by the NotImplementedError guard above, so this only runs on the
+    # ADE-active 1/3-component paths whose divisor is exactly what update_E computes.
+    if allocate_implicit:
         validate_dispersive_divisor_stability(
             _collect_labeled_materials(objects),
             dt=config.time_step_duration,
@@ -1142,8 +1190,8 @@ def _init_arrays(
             H=H,
             psi_E=psi_E,
             psi_H=psi_H,
-            dispersive_P_curr=dispersive_P_curr,
-            dispersive_P_prev=dispersive_P_prev,
+            dispersive_x1=dispersive_x1,
+            dispersive_y2=dispersive_y2,
         ),
         inv_permittivities=inv_permittivities,
         inv_permeabilities=inv_permeabilities,
@@ -1151,10 +1199,11 @@ def _init_arrays(
         recording_state=recording_state,
         electric_conductivity=electric_conductivity,
         magnetic_conductivity=magnetic_conductivity,
-        dispersive_c1=dispersive_c1,
-        dispersive_c2=dispersive_c2,
-        dispersive_c3=dispersive_c3,
+        dispersive_a1=dispersive_a1,
+        dispersive_a0=dispersive_a0,
+        dispersive_b1=dispersive_b1,
         dispersive_c4=dispersive_c4,
+        dispersive_b0=dispersive_b0,
         initial_inv_permittivities=initial_inv_permittivities,
     )
     return arrays, config, info

--- a/src/fdtdx/fdtd/update.py
+++ b/src/fdtdx/fdtd/update.py
@@ -232,45 +232,61 @@ def update_E(
         # E[i, x, y, z] = factor * E[i, x, y, z] + c * curl[i, x, y, z] * inv_eps[i, x, y, z]
         E = factor * arrays.fields.E + c * curl * inv_eps
 
-        # Dispersive (ADE) correction. Non-dispersive cells have c3 = 0, so P_hat =
-        # c1*P_curr + c2*P_prev and (P_curr - P_hat) reduces to a purely historical
-        # term that is also zero when P_curr and P_prev start at zero — so it's a
+        # Dispersive (ADE) correction, marched in the delta (zeta = z - 1) basis
+        #   dx1^n     = y2^n - a1 x1^n + b1 E^n      (= x1^{n+1} - x1^n)
+        #   y2^{n+1}  = y2^n - a0 x1^n + b0 E^n
+        #   x1^{n+1}  = x1^n + dx1^n
+        #   p^{n+1}   = x1^{n+1} + c4 E^{n+1}
+        # with the state y2 = x1 + x2 relative to the observer form. See
+        # fdtdx.dispersion for the derivation and for why this basis — not
+        # (c1, c2, beta1, c4, beta0) — is what keeps float32 usable: a0 is
+        # O((omega_0 dt)^2) and is *stored*, where 1 - c1 - c2 would be pure
+        # round-off. Non-dispersive cells have all coefficients zero, so
+        # b1 = b0 = 0 pins x1/y2 at zero and the polarization term vanishes — a
         # no-op outside dispersive regions. Only active when arrays are allocated.
-        if arrays.fields.dispersive_P_curr is not None:
-            P_curr = arrays.fields.dispersive_P_curr
-            P_prev = arrays.fields.dispersive_P_prev
-            disp_c1 = arrays.dispersive_c1
-            disp_c2 = arrays.dispersive_c2
-            disp_c3 = arrays.dispersive_c3
+        if arrays.fields.dispersive_x1 is not None:
+            x1 = arrays.fields.dispersive_x1
+            y2 = arrays.fields.dispersive_y2
+            disp_a1 = arrays.dispersive_a1
+            disp_a0 = arrays.dispersive_a0
+            disp_b1 = arrays.dispersive_b1
             disp_c4 = arrays.dispersive_c4
-            assert P_prev is not None and disp_c1 is not None and disp_c2 is not None and disp_c3 is not None
-            # disp_c* are (num_poles, 1|3, Nx, Ny, Nz) — the component axis is 1
-            # (isotropic dispersion, broadcast) or 3 (per-axis anisotropic
+            disp_b0 = arrays.dispersive_b0
+            assert y2 is not None and disp_a1 is not None and disp_a0 is not None and disp_b1 is not None
+            # Coefficients are (num_poles, 1|3, Nx, Ny, Nz) — the component axis is
+            # 1 (isotropic dispersion, broadcast) or 3 (per-axis anisotropic
             # dispersion); arrays.fields.E is (3, Nx, Ny, Nz). Right-aligned
             # broadcasting produces (num_poles, 3, Nx, Ny, Nz) either way without
             # an explicit newaxis — skip the reshape so the HLO stays flat.
-            # P_hat is the explicit part of the recurrence (independent of E^{n+1}).
-            P_hat = disp_c1 * P_curr + disp_c2 * P_prev + disp_c3 * arrays.fields.E
-            delta_hat = jnp.sum(P_curr - P_hat, axis=0)
-            E = E + inv_eps * delta_hat
+            E_n = arrays.fields.E
+            # b0 == b1 exactly when no pole is implicit (c4 = c5 = 0 => beta0 = 0),
+            # which is precisely when the b0 array is not allocated.
+            b0_eff = disp_b1 if disp_b0 is None else disp_b0
+            # dx1 is fully explicit; the implicit c4*E^{n+1} of p^{n+1} is folded
+            # into the divisor below.
+            dx1 = y2 - disp_a1 * x1 + disp_b1 * E_n
+            y2_new = y2 - disp_a0 * x1 + b0_eff * E_n
+            x1_new = x1 + dx1
+            # p^n - x1^{n+1} = c4 E^n - dx1. Computed from dx1 rather than by
+            # differencing p^n against x1^{n+1}: those are two nearly equal large
+            # numbers for a metal (|x1| ~ 400 |E|), and the subtraction would throw
+            # away most of the increment's significant digits. The c4 E^n term is
+            # what makes the E^n coefficient (1 - kappa + inv_eps*sum(c4)).
+            delta_p = -dx1 if disp_c4 is None else disp_c4 * E_n - dx1
+            E = E + inv_eps * jnp.sum(delta_p, axis=0)
             if disp_c4 is not None:
-                # CCPR: the polarization couples to E^{n+1} through c4. Fold the
-                # per-cell D_kappa = inv_eps*sum(c4) into the implicit divide
-                # (alongside the conductivity loss factor), then reconstruct the
-                # full P^{n+1} = P_hat + c4*E^{n+1} once E^{n+1} is known.
+                # The polarization couples to E^{n+1} through c4. Fold the per-cell
+                # inv_eps*sum(c4) into the implicit divide, alongside the
+                # conductivity loss factor.
                 divisor = 1 + inv_eps * jnp.sum(disp_c4, axis=0)
                 if sigma_E is not None:
                     divisor = divisor + c * sigma_E * eta0 * inv_eps / 2
                 E = E / divisor
-                P_new = P_hat + disp_c4 * E
-                arrays = arrays.aset("fields->dispersive_P_prev", P_curr)
-                arrays = arrays.aset("fields->dispersive_P_curr", P_new)
-            else:
-                arrays = arrays.aset("fields->dispersive_P_prev", P_curr)
-                arrays = arrays.aset("fields->dispersive_P_curr", P_hat)
-                if sigma_E is not None:
-                    # lossy update formula. Noop for conductivity = 0; see Schneider 3.12
-                    E = E / (1 + c * sigma_E * eta0 * inv_eps / 2)
+            elif sigma_E is not None:
+                # lossy update formula. Noop for conductivity = 0; see Schneider 3.12
+                E = E / (1 + c * sigma_E * eta0 * inv_eps / 2)
+            arrays = arrays.aset("fields->dispersive_x1", x1_new)
+            arrays = arrays.aset("fields->dispersive_y2", y2_new)
         elif sigma_E is not None:
             # update formula for lossy material. Simplifies to Noop for conductivity = 0
             # for details see Schneider, chapter 3.12
@@ -318,16 +334,18 @@ def update_E(
         # the RHS of Ampere's law): since B = c * M1^-1 @ inv_eps, folding
         # curl += delta / c before the curl averages yields M1^-1 @ inv_eps @ delta
         # including its off-diagonal spatial averaging — no extra solve needed.
-        # CCPR c4 poles are rejected at initialization for this branch.
-        if arrays.fields.dispersive_P_curr is not None:
-            P_curr = arrays.fields.dispersive_P_curr
-            P_prev = arrays.fields.dispersive_P_prev
-            disp_c1 = arrays.dispersive_c1
-            disp_c2 = arrays.dispersive_c2
-            disp_c3 = arrays.dispersive_c3
-            assert P_prev is not None and disp_c1 is not None and disp_c2 is not None and disp_c3 is not None
-            assert arrays.dispersive_c4 is None
-            if disp_c3.shape[1] == 9:
+        # Poles with a non-zero c4 (any dE/dt coupling, or any pole under the
+        # "bilinear" integrator) are rejected at initialization for this branch, so
+        # here c4 = beta0 = 0, hence b1 == b0 == c3 and p^n == x1^n.
+        if arrays.fields.dispersive_x1 is not None:
+            x1 = arrays.fields.dispersive_x1
+            y2 = arrays.fields.dispersive_y2
+            disp_a1 = arrays.dispersive_a1
+            disp_a0 = arrays.dispersive_a0
+            disp_b1 = arrays.dispersive_b1
+            assert y2 is not None and disp_a1 is not None and disp_a0 is not None and disp_b1 is not None
+            assert arrays.dispersive_c4 is None and arrays.dispersive_b0 is None
+            if disp_b1.shape[1] == 9:
                 # E at each row's Yee location: diagonal entries use the local
                 # component, off-diagonal entries the averaged neighbor with
                 # symmetrized pair weights restricted to material cells,
@@ -354,11 +372,11 @@ def update_E(
                 periodic_axes = get_wrap_padding_axes(objects)
                 rows = []
                 for i in range(3):
-                    row = disp_c3[:, 3 * i + i] * arrays.fields.E[i]
+                    row = disp_b1[:, 3 * i + i] * arrays.fields.E[i]
                     for j in range(3):
                         if j == i:
                             continue
-                        cij = disp_c3[:, 3 * i + j]
+                        cij = disp_b1[:, 3 * i + j]
                         cij_pad = pad_offdiag_coefficients(cij, periodic_axes)
                         mask_pad = (cij_pad != 0.0).astype(cij.dtype)
                         row = row + 0.5 * (
@@ -368,12 +386,15 @@ def update_E(
                     rows.append(row)
                 coupling = jnp.stack(rows, axis=1)
             else:
-                coupling = disp_c3 * arrays.fields.E
-            P_hat = disp_c1 * P_curr + disp_c2 * P_prev + coupling
-            delta = jnp.sum(P_curr - P_hat, axis=0)
+                coupling = disp_b1 * arrays.fields.E
+            # Delta basis, as in the diagonal branch. b0 == b1 here, so the same
+            # `coupling` term drives both states.
+            dx1 = y2 - disp_a1 * x1 + coupling
+            # c4 = 0 on this branch, so p^n == x1^n and p^{n+1} - p^n == dx1.
+            delta = -jnp.sum(dx1, axis=0)
             curl = curl + delta / c
-            arrays = arrays.aset("fields->dispersive_P_prev", P_curr)
-            arrays = arrays.aset("fields->dispersive_P_curr", P_hat)
+            arrays = arrays.aset("fields->dispersive_x1", x1 + dx1)
+            arrays = arrays.aset("fields->dispersive_y2", y2 - disp_a0 * x1 + coupling)
 
         curl_pad = pad_fields_for_boundaries(curl, objects, config)
         curlHx_y_avg = avg_anisotropic_E_component(
@@ -469,10 +490,10 @@ def update_E_reverse(
 
     Raises:
         NotImplementedError: If the simulation contains dispersive materials. The ADE
-            polarization state has no supported time reversal, so neither this update
-            nor the ``full_backward`` / ``backward`` API can reconstruct it.
+            state has no supported time reversal, so neither this update nor the
+            ``full_backward`` / ``backward`` API can reconstruct it.
     """
-    if arrays.fields.dispersive_P_curr is not None:
+    if arrays.fields.dispersive_x1 is not None:
         raise NotImplementedError(
             "Dispersive time-reversible gradient computation under active development. "
             "Use GradientConfig(method='checkpointed') instead."

--- a/src/fdtdx/materials.py
+++ b/src/fdtdx/materials.py
@@ -7,7 +7,11 @@ import numpy as np
 from fdtdx import constants
 from fdtdx.core.jax.pytrees import TreeClass, frozen_field
 from fdtdx.core.wavelength import WaveCharacter
-from fdtdx.dispersion import DispersionModel, compute_pole_coefficients_tensor
+from fdtdx.dispersion import (
+    DispersionModel,
+    compute_pole_coefficients_tensor,
+    compute_pole_delta_coefficients_tensor,
+)
 
 
 def _normalize_material_property(
@@ -898,34 +902,35 @@ def compute_allowed_dispersive_coefficients(
     max_num_poles: int,
     num_components: int,
     coupling_components: int | None = None,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Compute per-material discrete-time dispersive recurrence coefficients.
 
-    For each material (in the canonical sorted order used elsewhere), returns
-    the ``c1``, ``c2``, ``c3``, ``c4`` coefficients from
-    :func:`fdtdx.dispersion.compute_pole_coefficients_tensor`. Materials with
-    fewer poles than ``max_num_poles``, or non-dispersive materials, get
-    zero-padded slots (so the polarization term automatically vanishes on those
-    voxels). ``c4`` is zero for Lorentz/Drude poles and only non-zero for CCPR
-    poles.
+    For each material (in the canonical sorted order used elsewhere), returns the
+    **delta-basis** coefficients ``a1``, ``a0``, ``b1``, ``c4``, ``b0`` from
+    :func:`fdtdx.dispersion.compute_pole_delta_coefficients_tensor` — the set the
+    FDTD loop marches. Materials with fewer poles than ``max_num_poles``, or
+    non-dispersive materials, get zero-padded slots, which stay inert because
+    ``b1 = b0 = 0`` pins their state at zero. ``c4`` is zero for Lorentz/Drude
+    poles under the central-difference schemes (and then ``b0`` equals ``b1``),
+    and non-zero for every pole under ``integrator="bilinear"``.
 
     Args:
         materials: Dictionary mapping material names to Material objects.
         dt: Simulation time step (seconds).
         max_num_poles: Maximum pole count to pad every material to. When 0,
             returns zero-pole arrays.
-        num_components: Size of the trailing component axis of the recurrence
-            coefficients ``c1``/``c2`` — 1 when all materials have isotropic
+        num_components: Size of the trailing component axis of the oscillator
+            coefficients ``a1``/``a0`` — 1 when all materials have isotropic
             dispersion, 3 for per-axis dispersion.
         coupling_components: Size of the trailing axis of the field couplings
-            ``c3``/``c4`` — additionally allows 9 (row-major 3x3 coupling
-            tensor) when any material has oriented poles. Defaults to
+            ``b1``/``c4``/``b0`` — additionally allows 9 (row-major 3x3
+            coupling tensor) when any material has oriented poles. Defaults to
             ``num_components``.
 
     Returns:
-        Four numpy arrays: ``c1``, ``c2`` of shape
-        ``(num_materials, max_num_poles, num_components)`` and ``c3``, ``c4``
-        of shape ``(num_materials, max_num_poles, coupling_components)``.
+        Five numpy arrays: ``a1``, ``a0`` of shape
+        ``(num_materials, max_num_poles, num_components)`` and ``b1``, ``c4``,
+        ``b0`` of shape ``(num_materials, max_num_poles, coupling_components)``.
     """
     if coupling_components is None:
         coupling_components = num_components
@@ -935,12 +940,13 @@ def compute_allowed_dispersive_coefficients(
         raise ValueError(f"coupling_components must be 1, 3 or 9, got {coupling_components}.")
     ordered = compute_ordered_material_name_tuples(materials)
     num_mats = len(ordered)
-    c1 = np.zeros((num_mats, max_num_poles, num_components), dtype=np.float64)
-    c2 = np.zeros((num_mats, max_num_poles, num_components), dtype=np.float64)
-    c3 = np.zeros((num_mats, max_num_poles, coupling_components), dtype=np.float64)
+    a1 = np.zeros((num_mats, max_num_poles, num_components), dtype=np.float64)
+    a0 = np.zeros((num_mats, max_num_poles, num_components), dtype=np.float64)
+    b1 = np.zeros((num_mats, max_num_poles, coupling_components), dtype=np.float64)
     c4 = np.zeros((num_mats, max_num_poles, coupling_components), dtype=np.float64)
+    b0 = np.zeros((num_mats, max_num_poles, coupling_components), dtype=np.float64)
     if max_num_poles == 0:
-        return c1, c2, c3, c4
+        return a1, a0, b1, c4, b0
     diag_entries = (0, 4, 8)
     for m_idx, (_, mat) in enumerate(ordered):
         if mat.dispersion is None:
@@ -954,21 +960,24 @@ def compute_allowed_dispersive_coefficients(
                 "coupling_components < 9 requires axis-aligned dispersion, but a material has oriented poles."
             )
         poles = mat.dispersion.poles
-        c1_vals, c2_vals, c3_vals, c4_vals = compute_pole_coefficients_tensor(poles, dt)
+        a1_vals, a0_vals, b1_vals, c4_vals, b0_vals = compute_pole_delta_coefficients_tensor(poles, dt)
         n = len(poles)
         # For num_components == 1 the isotropy check above guarantees all three
         # axis columns are identical, so keeping only the first is exact. For
         # coupling_components < 9 the axis-alignment check guarantees the
         # coupling tensors are diagonal, so keeping diagonal entries is exact.
-        c1[m_idx, :n] = c1_vals[:, :num_components]
-        c2[m_idx, :n] = c2_vals[:, :num_components]
+        a1[m_idx, :n] = a1_vals[:, :num_components]
+        a0[m_idx, :n] = a0_vals[:, :num_components]
         if coupling_components == 9:
-            c3[m_idx, :n] = c3_vals
+            b1[m_idx, :n] = b1_vals
             c4[m_idx, :n] = c4_vals
+            b0[m_idx, :n] = b0_vals
         else:
-            c3[m_idx, :n] = c3_vals[:, diag_entries[:coupling_components]]
-            c4[m_idx, :n] = c4_vals[:, diag_entries[:coupling_components]]
-    return c1, c2, c3, c4
+            sel = diag_entries[:coupling_components]
+            b1[m_idx, :n] = b1_vals[:, sel]
+            c4[m_idx, :n] = c4_vals[:, sel]
+            b0[m_idx, :n] = b0_vals[:, sel]
+    return a1, a0, b1, c4, b0
 
 
 def _min_dispersive_divisor(mat: Material, dt: float) -> tuple[float, int]:
@@ -998,7 +1007,7 @@ def _min_dispersive_divisor(mat: Material, dt: float) -> tuple[float, int]:
     assert mat.dispersion is not None
     # tensor variant handles every pole type; oriented poles have no dE/dt
     # coupling, so their diagonal c4 entries are zero and drop out here
-    _, _, _, c4 = compute_pole_coefficients_tensor(mat.dispersion.poles, dt)
+    _, _, _, c4, _ = compute_pole_coefficients_tensor(mat.dispersion.poles, dt)
     sum_c4 = c4[:, (0, 4, 8)].sum(axis=0)  # (3,) diagonal c4 summed over poles, per axis
     eps_inf = (mat.permittivity[0], mat.permittivity[4], mat.permittivity[8])
     sigma = (mat.electric_conductivity[0], mat.electric_conductivity[4], mat.electric_conductivity[8])
@@ -1022,16 +1031,28 @@ def _max_safe_courant_factor(
     """Largest ``courant_factor`` below which ``mat`` stays stable at every step.
 
     ``dt`` is proportional to ``courant_factor`` on every grid type, so scaling
-    the time step by ``s`` scales directly to a ``courant_factor``. Each pole's
+    the time step by ``s`` scales directly to a ``courant_factor``. Under the
+    central-difference schemes each pole's
     ``c4_p(s) = b_p * (s * dt) / (1 + gamma_p * s * dt / 2)`` is individually
     monotonic in ``s`` (its sign is that of ``b_p``), but the *sum* over poles
     with mixed ``b_p`` signs and dampings — plus the linearly growing
     conductivity term — is not necessarily monotonic and may cross ``threshold``
-    several times. To keep it genuinely safe (every value below ``X``
-    stable), we search for the *first* crossing from ``s = 0`` (where the
-    divisor is ``~ 1``): a forward scan brackets it, then bisection refines.
-    Recomputing the divisor at each ``s * dt`` handles the weak
-    ``D = 1 + gamma * dt / 2`` nonlinearity exactly.
+    several times. Under ``"bilinear"`` the pole term instead *saturates* at
+    ``sum_p chi_p(0)`` as ``s`` grows, so it may never cross at all. To keep the
+    answer genuinely safe (every value below ``X`` stable), we search for the
+    *first* crossing from ``s = 0`` (where the divisor is ``~ 1``): a forward
+    scan brackets it, then bisection refines. Recomputing the divisor at each
+    ``s * dt`` handles the weak ``D = 1 + gamma * dt / 2`` nonlinearity exactly.
+
+    Args:
+        mat: A dispersive material.
+        dt: Simulation time step (seconds) at the configured ``courant_factor``.
+        courant_factor: The configured Courant factor.
+        threshold: Divisor value below which the material counts as unsafe.
+        scan_steps: Resolution of the initial bracketing scan.
+
+    Returns:
+        float: Largest safe ``courant_factor``, floored to 3 significant figures.
     """
     n = max(1, scan_steps)
     prev = 0.0  # last safe scale (divisor >= threshold); s = 0 gives divisor ~ 1
@@ -1044,9 +1065,10 @@ def _max_safe_courant_factor(
             break
         prev = s
     if hi is None:
-        # No sub-threshold scan point found. Unreachable via the validator (it
-        # only calls this when the divisor at s = 1 is already below threshold),
-        # but stay conservative if invoked directly.
+        # No sub-threshold scan point found anywhere in (0, 1]. The validator only
+        # calls this when the divisor at s = 1 is already below threshold, so this
+        # is reachable only for a non-monotonic divisor that dips below threshold
+        # between scan points; stay conservative.
         return 0.5 * courant_factor
     lo = prev  # bracket [lo, hi]: divisor(lo) >= threshold, divisor(hi) < threshold
     for _ in range(50):
@@ -1071,14 +1093,18 @@ def validate_dispersive_divisor_stability(
     courant_factor: float,
     near_zero_threshold: float = 0.01,
 ) -> None:
-    r"""Validate the per-cell implicit-update divisor of CCPR dispersive materials.
+    r"""Validate the per-cell implicit-update divisor of dispersive materials.
 
-    For CCPR poles (non-zero ``dE/dt`` coupling) the E-field update divides by a
-    per-cell factor ``1 + inv_eps * sum(c4) [+ conductivity term]`` (see
+    Whenever a pole has a non-zero ``c4`` the E-field update divides by a per-cell
+    factor ``1 + inv_eps * sum(c4) [+ conductivity term]`` (see
     :func:`fdtdx.fdtd.update.update_E`). This must stay positive; as it approaches
     ``0^+`` the transient gain (``~ 1/divisor``) explodes and accuracy collapses.
-    Lorentz and Drude poles have ``c4 = 0``, so their divisor is always ``>= 1``
-    and they are skipped.
+
+    Which poles have a non-zero ``c4`` is scheme-dependent, so it is resolved
+    through each pole's own :attr:`~fdtdx.dispersion.Pole.integrator` rather than
+    from the ``dE/dt`` coupling alone: Lorentz and Drude poles are safe under the
+    central-difference schemes (``c4 = 0``, divisor identically 1), but *not*
+    under ``"bilinear"``, whose ``c4 = a / D_b`` is non-zero for every pole.
 
     Checked per distinct material rather than per assembled cell: a cell holds one
     material's coefficients, so this covers every static cell, names the offending
@@ -1099,22 +1125,34 @@ def validate_dispersive_divisor_stability(
             unstable / NaN).
     """
     for name, mat in materials.items():
-        if mat.dispersion is None:
+        if mat.dispersion is None or mat.dispersion.num_poles == 0:
             continue
-        # c4 != 0 only for CCPR / non-zero dE/dt coupling; Lorentz & Drude are safe.
-        if not any(b != 0.0 for p in mat.dispersion.poles for b in p.coupling_edot_axes):
+        # A pole only constrains the divisor when its c4 is non-zero; resolve that
+        # through the pole's own integrator instead of assuming the central-scheme
+        # relation c4 != 0 <=> coupling_edot != 0 (false under "bilinear").
+        _, _, _, c4_all, _ = compute_pole_coefficients_tensor(mat.dispersion.poles, dt)
+        if not np.any(c4_all != 0.0):
             continue
         min_div, worst_ax = _min_dispersive_divisor(mat, dt)
         if min_div >= near_zero_threshold:
             continue
         cf_max = _max_safe_courant_factor(mat, dt, courant_factor, near_zero_threshold)
-        axis_note = f" on axis {'xyz'[worst_ax]}" if not (mat.is_all_isotropic and mat.dispersion.is_isotropic) else ""
+        isotropic = mat.is_all_isotropic and mat.dispersion.is_isotropic
+        axis_note = f" on axis {'xyz'[worst_ax]}" if not isotropic else ""
+        schemes = sorted({p.integrator for p in mat.dispersion.poles})
         detail = (
             f"Dispersive material '{name}' has an implicit E-update divisor = {min_div:.4g}{axis_note} "
             "(1 + inv_eps * sum(c4) [+ conductivity term]); this factor divides the E-field update, so as "
             "it approaches 0 the transient gain (~1/divisor) explodes and accuracy collapses. The divisor "
-            f"scales with the time step, so lower courant_factor to <= {cf_max:.3g} (currently {courant_factor:.3g})."
+            f"scales with the time step, so lower courant_factor to <= {cf_max:.3g} "
+            f"(currently {courant_factor:.3g})."
         )
+        if "central" in schemes:
+            detail += (
+                " This material uses integrator='central', which is only first-order accurate for a "
+                "non-zero dE/dt coupling and puts twice the correct weight on E^{n+1}; switching to "
+                "'centered_edot' halves c4 and typically restores a divisor near 1."
+            )
         if min_div <= 0.0:
             raise ValueError(
                 detail + " The divisor is non-positive, which makes the ADE update unconditionally unstable (NaN)."

--- a/src/fdtdx/objects/detectors/mode.py
+++ b/src/fdtdx/objects/detectors/mode.py
@@ -149,11 +149,12 @@ class ModeOverlapDetector(PhasorDetector):
         key: jax.Array,
         inv_permittivities: jax.Array,
         inv_permeabilities: jax.Array | float,
-        dispersive_c1: jax.Array | None = None,
-        dispersive_c2: jax.Array | None = None,
-        dispersive_c3: jax.Array | None = None,
+        dispersive_a1: jax.Array | None = None,
+        dispersive_a0: jax.Array | None = None,
+        dispersive_b1: jax.Array | None = None,
         electric_conductivity: jax.Array | None = None,
         dispersive_c4: jax.Array | None = None,
+        dispersive_b0: jax.Array | None = None,
     ) -> Self:
         del key
         inv_permittivity_slice = inv_permittivities[:, *self.grid_slice]
@@ -162,12 +163,13 @@ class ModeOverlapDetector(PhasorDetector):
         else:
             inv_permeability_slice = inv_permeabilities
 
-        c1_slice = c2_slice = c3_slice = c4_slice = None
-        if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
-            c1_slice = dispersive_c1[:, :, *self.grid_slice]
-            c2_slice = dispersive_c2[:, :, *self.grid_slice]
-            c3_slice = dispersive_c3[:, :, *self.grid_slice]
+        a1_slice = a0_slice = b1_slice = c4_slice = b0_slice = None
+        if dispersive_a1 is not None and dispersive_a0 is not None and dispersive_b1 is not None:
+            a1_slice = dispersive_a1[:, :, *self.grid_slice]
+            a0_slice = dispersive_a0[:, :, *self.grid_slice]
+            b1_slice = dispersive_b1[:, :, *self.grid_slice]
             c4_slice = None if dispersive_c4 is None else dispersive_c4[:, :, *self.grid_slice]
+            b0_slice = None if dispersive_b0 is None else dispersive_b0[:, :, *self.grid_slice]
 
         # The reference mode is solved against the FULL complex epsilon at each
         # carrier frequency (eps_inf + chi(omega) + i*sigma/(eps0*omega)), so the
@@ -183,15 +185,16 @@ class ModeOverlapDetector(PhasorDetector):
         all_mode_neffs: list[jax.Array] = []
         for wc in self.wave_characters:
             inv_eps_i = inv_permittivity_slice
-            if c1_slice is not None or sigma_slice is not None:
+            if a1_slice is not None or sigma_slice is not None:
                 inv_eps_i = effective_complex_inv_permittivity(
                     inv_eps=inv_permittivity_slice,
                     omega=2.0 * np.pi * wc.get_frequency(),
                     dt=self._config.time_step_duration,
-                    c1=c1_slice,
-                    c2=c2_slice,
-                    c3=c3_slice,
+                    a1=a1_slice,
+                    a0=a0_slice,
+                    b1=b1_slice,
                     c4=c4_slice,
+                    b0=b0_slice,
                     electric_conductivity=sigma_slice,
                     conductivity_spacing=conductivity_spacing,
                 )

--- a/src/fdtdx/objects/object.py
+++ b/src/fdtdx/objects/object.py
@@ -318,14 +318,15 @@ class SimulationObject(TreeClass, ABC):
         key: jax.Array,
         inv_permittivities: jax.Array,
         inv_permeabilities: jax.Array | float,
-        dispersive_c1: jax.Array | None = None,
-        dispersive_c2: jax.Array | None = None,
-        dispersive_c3: jax.Array | None = None,
+        dispersive_a1: jax.Array | None = None,
+        dispersive_a0: jax.Array | None = None,
+        dispersive_b1: jax.Array | None = None,
         electric_conductivity: jax.Array | None = None,
         dispersive_c4: jax.Array | None = None,
+        dispersive_b0: jax.Array | None = None,
     ) -> Self:
         del key, inv_permittivities, inv_permeabilities
-        del dispersive_c1, dispersive_c2, dispersive_c3, dispersive_c4
+        del dispersive_a1, dispersive_a0, dispersive_b1, dispersive_c4, dispersive_b0
         del electric_conductivity
         return self
 

--- a/src/fdtdx/objects/sources/dipole.py
+++ b/src/fdtdx/objects/sources/dipole.py
@@ -132,30 +132,33 @@ class PointDipoleSource(Source):
         key: jax.Array,
         inv_permittivities: jax.Array,
         inv_permeabilities: jax.Array | float,
-        dispersive_c1: jax.Array | None = None,
-        dispersive_c2: jax.Array | None = None,
-        dispersive_c3: jax.Array | None = None,
+        dispersive_a1: jax.Array | None = None,
+        dispersive_a0: jax.Array | None = None,
+        dispersive_b1: jax.Array | None = None,
         electric_conductivity: jax.Array | None = None,
         dispersive_c4: jax.Array | None = None,
+        dispersive_b0: jax.Array | None = None,
     ) -> Self:
         del key, electric_conductivity
 
         # inv_permittivities shape: (num_components, Nx, Ny, Nz)
         inv_eps_slice = inv_permittivities[:, *self.grid_slice]
 
-        if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
-            c1_slice = dispersive_c1[:, :, *self.grid_slice]
-            c2_slice = dispersive_c2[:, :, *self.grid_slice]
-            c3_slice = dispersive_c3[:, :, *self.grid_slice]
+        if dispersive_a1 is not None and dispersive_a0 is not None and dispersive_b1 is not None:
+            a1_slice = dispersive_a1[:, :, *self.grid_slice]
+            a0_slice = dispersive_a0[:, :, *self.grid_slice]
+            b1_slice = dispersive_b1[:, :, *self.grid_slice]
             c4_slice = None if dispersive_c4 is None else dispersive_c4[:, :, *self.grid_slice]
+            b0_slice = None if dispersive_b0 is None else dispersive_b0[:, :, *self.grid_slice]
             inv_eps_slice = effective_inv_permittivity(
                 inv_eps=inv_eps_slice,
-                c1=c1_slice,
-                c2=c2_slice,
-                c3=c3_slice,
+                a1=a1_slice,
+                a0=a0_slice,
+                b1=b1_slice,
                 omega=2.0 * np.pi * self.wave_character.get_frequency(),
                 dt=self._config.time_step_duration,
                 c4=c4_slice,
+                b0=b0_slice,
             )
 
         if isinstance(inv_permeabilities, jax.Array) and inv_permeabilities.ndim > 0:

--- a/src/fdtdx/objects/sources/linear_polarization.py
+++ b/src/fdtdx/objects/sources/linear_polarization.py
@@ -122,11 +122,12 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
         key: jax.Array,
         inv_permittivities: jax.Array,
         inv_permeabilities: jax.Array | float,
-        dispersive_c1: jax.Array | None = None,
-        dispersive_c2: jax.Array | None = None,
-        dispersive_c3: jax.Array | None = None,
+        dispersive_a1: jax.Array | None = None,
+        dispersive_a0: jax.Array | None = None,
+        dispersive_b1: jax.Array | None = None,
         electric_conductivity: jax.Array | None = None,
         dispersive_c4: jax.Array | None = None,
+        dispersive_b0: jax.Array | None = None,
     ):
         del electric_conductivity
         # inv_permittivities shape: (3, Nx, Ny, Nz) - slice with component dimension
@@ -144,21 +145,23 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
         # permittivity at the source carrier frequency so that the impedance and
         # energy normalization reflect the true medium the source sits in,
         # not just the high-frequency permittivity epsilon_infinity.
-        c1_slice = c2_slice = c3_slice = c4_slice = None
-        if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
+        a1_slice = a0_slice = b1_slice = c4_slice = b0_slice = None
+        if dispersive_a1 is not None and dispersive_a0 is not None and dispersive_b1 is not None:
             # dispersive_c* shape: (num_poles, 1, Nx, Ny, Nz) → slice spatial axes
-            c1_slice = dispersive_c1[:, :, *self.grid_slice]
-            c2_slice = dispersive_c2[:, :, *self.grid_slice]
-            c3_slice = dispersive_c3[:, :, *self.grid_slice]
+            a1_slice = dispersive_a1[:, :, *self.grid_slice]
+            a0_slice = dispersive_a0[:, :, *self.grid_slice]
+            b1_slice = dispersive_b1[:, :, *self.grid_slice]
             c4_slice = None if dispersive_c4 is None else dispersive_c4[:, :, *self.grid_slice]
+            b0_slice = None if dispersive_b0 is None else dispersive_b0[:, :, *self.grid_slice]
             inv_permittivities = effective_inv_permittivity(
                 inv_eps=inv_permittivities,
-                c1=c1_slice,
-                c2=c2_slice,
-                c3=c3_slice,
+                a1=a1_slice,
+                a0=a0_slice,
+                b1=b1_slice,
                 omega=2.0 * np.pi * self.wave_character.get_frequency(),
                 dt=self._config.time_step_duration,
                 c4=c4_slice,
+                b0=b0_slice,
             )
 
         # determine E/H polarization
@@ -284,18 +287,19 @@ class LinearlyPolarizedPlaneSource(TFSFPlaneSource, ABC):
         # ω_c. Precompute a filtered H-side temporal profile s_H(t) whose
         # spectrum is S(ω)·√(ε(ω)/ε(ω_c)) so that the injected H field has
         # the frequency-dependent impedance correction baked in.
-        if c1_slice is not None and c2_slice is not None and c3_slice is not None:
+        if a1_slice is not None and a0_slice is not None and b1_slice is not None:
             filtered = _build_dispersive_H_filter(
                 temporal_profile=self.temporal_profile,
                 wave_character=self.wave_character,
                 dt=self._config.time_step_duration,
                 num_time_steps=self._config.time_steps_total,
-                c1_slice=c1_slice,
-                c2_slice=c2_slice,
-                c3_slice=c3_slice,
+                a1_slice=a1_slice,
+                a0_slice=a0_slice,
+                b1_slice=b1_slice,
                 inv_eps_inf_slice=inv_eps_inf_slice,
                 dtype=self._config.dtype,
                 c4_slice=c4_slice,
+                b0_slice=b0_slice,
             )
             self = self.aset("_temporal_H_filter", filtered, create_new_ok=True)
         else:

--- a/src/fdtdx/objects/sources/mode.py
+++ b/src/fdtdx/objects/sources/mode.py
@@ -95,11 +95,12 @@ class ModePlaneSource(TFSFPlaneSource):
         key: jax.Array,
         inv_permittivities: jax.Array,
         inv_permeabilities: jax.Array | float,
-        dispersive_c1: jax.Array | None = None,
-        dispersive_c2: jax.Array | None = None,
-        dispersive_c3: jax.Array | None = None,
+        dispersive_a1: jax.Array | None = None,
+        dispersive_a0: jax.Array | None = None,
+        dispersive_b1: jax.Array | None = None,
         electric_conductivity: jax.Array | None = None,
         dispersive_c4: jax.Array | None = None,
+        dispersive_b0: jax.Array | None = None,
     ) -> Self:
         del key
         if (
@@ -126,20 +127,22 @@ class ModePlaneSource(TFSFPlaneSource):
         # Frequency-correct the permittivity seen by the mode solver so that
         # mode profiles computed inside a dispersive medium reflect the true
         # epsilon at the carrier frequency, not epsilon_infinity.
-        c1_slice = c2_slice = c3_slice = c4_slice = None
-        if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
-            c1_slice = dispersive_c1[:, :, *self.grid_slice]
-            c2_slice = dispersive_c2[:, :, *self.grid_slice]
-            c3_slice = dispersive_c3[:, :, *self.grid_slice]
+        a1_slice = a0_slice = b1_slice = c4_slice = b0_slice = None
+        if dispersive_a1 is not None and dispersive_a0 is not None and dispersive_b1 is not None:
+            a1_slice = dispersive_a1[:, :, *self.grid_slice]
+            a0_slice = dispersive_a0[:, :, *self.grid_slice]
+            b1_slice = dispersive_b1[:, :, *self.grid_slice]
             c4_slice = None if dispersive_c4 is None else dispersive_c4[:, :, *self.grid_slice]
+            b0_slice = None if dispersive_b0 is None else dispersive_b0[:, :, *self.grid_slice]
             inv_permittivity_slice = effective_inv_permittivity(
                 inv_eps=inv_permittivity_slice,
-                c1=c1_slice,
-                c2=c2_slice,
-                c3=c3_slice,
+                a1=a1_slice,
+                a0=a0_slice,
+                b1=b1_slice,
                 omega=2.0 * np.pi * self.wave_character.get_frequency(),
                 dt=self._config.time_step_duration,
                 c4=c4_slice,
+                b0=b0_slice,
             )
 
         self = self.aset("_inv_permittivity", inv_permittivity_slice, create_new_ok=True)
@@ -153,15 +156,16 @@ class ModePlaneSource(TFSFPlaneSource):
         # double-count the absorption already integrated by the FDTD update.
         sigma_slice = None if electric_conductivity is None else electric_conductivity[:, *self.grid_slice]
         mode_inv_permittivity = inv_eps_inf_slice
-        if sigma_slice is not None or c1_slice is not None:
+        if sigma_slice is not None or a1_slice is not None:
             mode_inv_permittivity = effective_complex_inv_permittivity(
                 inv_eps=inv_eps_inf_slice,
                 omega=2.0 * np.pi * self.wave_character.get_frequency(),
                 dt=self._config.time_step_duration,
-                c1=c1_slice,
-                c2=c2_slice,
-                c3=c3_slice,
+                a1=a1_slice,
+                a0=a0_slice,
+                b1=b1_slice,
                 c4=c4_slice,
+                b0=b0_slice,
                 electric_conductivity=sigma_slice,
                 conductivity_spacing=(
                     None
@@ -190,7 +194,7 @@ class ModePlaneSource(TFSFPlaneSource):
         # modes are projected to real (bit-identical to before). The dispersive
         # path also stays real here because its broadband H-filter assumes a real
         # temporal profile.
-        keep_complex_mode = sigma_slice is not None and c1_slice is None
+        keep_complex_mode = sigma_slice is not None and a1_slice is None
         if not keep_complex_mode:
             mode_E, mode_H = jnp.real(mode_E), jnp.real(mode_H)
 
@@ -233,18 +237,19 @@ class ModePlaneSource(TFSFPlaneSource):
         # Note: bulk ε(ω) is averaged uniformly over the source cells; this
         # does not capture geometric modal dispersion (the fact that a
         # waveguide mode's effective index also depends on frequency).
-        if c1_slice is not None and c2_slice is not None and c3_slice is not None:
+        if a1_slice is not None and a0_slice is not None and b1_slice is not None:
             filtered = _build_dispersive_H_filter(
                 temporal_profile=self.temporal_profile,
                 wave_character=self.wave_character,
                 dt=self._config.time_step_duration,
                 num_time_steps=self._config.time_steps_total,
-                c1_slice=c1_slice,
-                c2_slice=c2_slice,
-                c3_slice=c3_slice,
+                a1_slice=a1_slice,
+                a0_slice=a0_slice,
+                b1_slice=b1_slice,
                 inv_eps_inf_slice=inv_eps_inf_slice,
                 dtype=self._config.dtype,
                 c4_slice=c4_slice,
+                b0_slice=b0_slice,
             )
             self = self.aset("_temporal_H_filter", filtered, create_new_ok=True)
         else:

--- a/src/fdtdx/objects/sources/source.py
+++ b/src/fdtdx/objects/sources/source.py
@@ -70,21 +70,23 @@ class Source(SimulationObject, ABC):
         key: jax.Array,
         inv_permittivities: jax.Array,
         inv_permeabilities: jax.Array | float,
-        dispersive_c1: jax.Array | None = None,
-        dispersive_c2: jax.Array | None = None,
-        dispersive_c3: jax.Array | None = None,
+        dispersive_a1: jax.Array | None = None,
+        dispersive_a0: jax.Array | None = None,
+        dispersive_b1: jax.Array | None = None,
         electric_conductivity: jax.Array | None = None,
         dispersive_c4: jax.Array | None = None,
+        dispersive_b0: jax.Array | None = None,
     ) -> Self:
         self = super().apply(
             key=key,
             inv_permittivities=inv_permittivities,
             inv_permeabilities=inv_permeabilities,
-            dispersive_c1=dispersive_c1,
-            dispersive_c2=dispersive_c2,
-            dispersive_c3=dispersive_c3,
+            dispersive_a1=dispersive_a1,
+            dispersive_a0=dispersive_a0,
+            dispersive_b1=dispersive_b1,
             electric_conductivity=electric_conductivity,
             dispersive_c4=dispersive_c4,
+            dispersive_b0=dispersive_b0,
         )
         self = self._update_on_arrays()
         return self

--- a/src/fdtdx/objects/sources/tfsf.py
+++ b/src/fdtdx/objects/sources/tfsf.py
@@ -23,12 +23,13 @@ def _build_dispersive_H_filter(
     wave_character,
     dt: float,
     num_time_steps: int,
-    c1_slice: jax.Array,
-    c2_slice: jax.Array,
-    c3_slice: jax.Array,
+    a1_slice: jax.Array,
+    a0_slice: jax.Array,
+    b1_slice: jax.Array,
     inv_eps_inf_slice: jax.Array,
     dtype: jnp.dtype = jnp.float32,
     c4_slice: jax.Array | None = None,
+    b0_slice: jax.Array | None = None,
 ) -> jax.Array:
     """Precompute the broadband-corrected H-side temporal profile for a TFSF source.
 
@@ -51,14 +52,17 @@ def _build_dispersive_H_filter(
         dt: Simulation time step (seconds).
         num_time_steps: ``config.time_steps_total`` — the length of the
             returned filter array.
-        c1_slice: ADE coefficient array sliced to the source cells.
-        c2_slice: ADE coefficient array sliced to the source cells.
-        c3_slice: ADE coefficient array sliced to the source cells.
+        a1_slice: Delta-basis ADE coefficient ``a1`` sliced to the source cells.
+        a0_slice: Delta-basis ADE coefficient ``a0`` sliced to the source cells.
+        b1_slice: Delta-basis field coupling ``b1`` sliced to the source cells.
         inv_eps_inf_slice: Raw ``1/ε∞`` at the source cells
             (before any carrier-frequency correction).
         dtype: Output dtype for the filtered profile. Should match the
             simulation's field dtype so float64 simulations are not
             silently downcast to float32. Defaults to float32.
+        c4_slice: Optional implicit-coupling array sliced to the source cells.
+        b0_slice: Optional delta-basis field coupling ``b0`` sliced to the
+            source cells. ``None`` means "equal to ``b1``".
 
     Returns:
         JAX array of shape ``(num_time_steps,)`` in ``dtype`` — the filtered
@@ -79,16 +83,17 @@ def _build_dispersive_H_filter(
     )
     raw_samples = np.asarray(raw_samples_jax, dtype=np.float64)
 
-    c1_np = np.asarray(c1_slice)
-    c2_np = np.asarray(c2_slice)
-    c3_np = np.asarray(c3_slice)
+    a1_np = np.asarray(a1_slice)
+    a0_np = np.asarray(a0_slice)
+    b1_np = np.asarray(b1_slice)
     c4_np = None if c4_slice is None else np.asarray(c4_slice)
+    b0_np = None if b0_slice is None else np.asarray(b0_slice)
     inv_eps_inf_np = np.asarray(inv_eps_inf_slice)
 
     # All-zero coupling in the source slice (non-dispersive material at the
     # source plane) means eps(omega) is flat and the filter is the identity —
     # skip it rather than allocate the broadband spectrum.
-    if c3_np.size == 0 or (not np.any(c3_np) and (c4_np is None or not np.any(c4_np))):
+    if b1_np.size == 0 or (not np.any(b1_np) and (c4_np is None or not np.any(c4_np))):
         return jnp.asarray(raw_samples, dtype=dtype)
 
     # Length-M zero-padded FFT for linear convolution.
@@ -100,10 +105,10 @@ def _build_dispersive_H_filter(
     # With per-axis (anisotropic) dispersion the coefficient arrays carry one
     # value per component; the scalar impedance filter below can only use a
     # component average. Warn once at setup so the approximation is visible.
-    if c1_np.shape[0] > 0 and c1_np.shape[1] > 1:
-        anisotropic = any(
-            bool(np.any(arr != arr[:, :1])) for arr in (c1_np, c2_np, c3_np) + (() if c4_np is None else (c4_np,))
-        )
+    if a1_np.shape[0] > 0 and a1_np.shape[1] > 1:
+        component_arrays = [a1_np, a0_np, b1_np]
+        component_arrays += [arr for arr in (c4_np, b0_np) if arr is not None]
+        anisotropic = any(bool(np.any(arr != arr[:, :1])) for arr in component_arrays)
         if anisotropic:
             logger.warning(
                 "TFSF source overlaps a material with per-axis (anisotropic) dispersion; the broadband "
@@ -112,23 +117,25 @@ def _build_dispersive_H_filter(
             )
 
     eps_spectrum = compute_eps_spectrum_from_coefficients(
-        c1=c1_np,
-        c2=c2_np,
-        c3=c3_np,
+        a1=a1_np,
+        a0=a0_np,
+        b1=b1_np,
         inv_eps_inf=inv_eps_inf_np,
         omegas=omegas_rfft,
         dt=dt,
         c4=c4_np,
+        b0=b0_np,
     )
     omega_c = 2.0 * np.pi * wave_character.get_frequency()
     eps_center_arr = compute_eps_spectrum_from_coefficients(
-        c1=c1_np,
-        c2=c2_np,
-        c3=c3_np,
+        a1=a1_np,
+        a0=a0_np,
+        b1=b1_np,
         inv_eps_inf=inv_eps_inf_np,
         omegas=np.array([omega_c], dtype=np.float64),
         dt=dt,
         c4=c4_np,
+        b0=b0_np,
     )
     eps_center = complex(eps_center_arr[0])
 
@@ -586,11 +593,12 @@ class TFSFPlaneSource(DirectionalPlaneSourceBase, ABC):
         key: jax.Array,
         inv_permittivities: jax.Array,
         inv_permeabilities: jax.Array | float,
-        dispersive_c1: jax.Array | None = None,
-        dispersive_c2: jax.Array | None = None,
-        dispersive_c3: jax.Array | None = None,
+        dispersive_a1: jax.Array | None = None,
+        dispersive_a0: jax.Array | None = None,
+        dispersive_b1: jax.Array | None = None,
         electric_conductivity: jax.Array | None = None,
         dispersive_c4: jax.Array | None = None,
+        dispersive_b0: jax.Array | None = None,
     ) -> Self:
         # Must populate self._E, self._H, self._time_offset_E, and self._time_offset_H.
         # When dispersive_* are provided, the concrete implementation is expected

--- a/src/fdtdx/objects/sources/tfsf_region.py
+++ b/src/fdtdx/objects/sources/tfsf_region.py
@@ -166,11 +166,12 @@ class TFSFPlaneSourceRegion(TFSFPlaneSource):
         key: jax.Array,
         inv_permittivities: jax.Array,
         inv_permeabilities: jax.Array | float,
-        dispersive_c1: jax.Array | None = None,
-        dispersive_c2: jax.Array | None = None,
-        dispersive_c3: jax.Array | None = None,
+        dispersive_a1: jax.Array | None = None,
+        dispersive_a0: jax.Array | None = None,
+        dispersive_b1: jax.Array | None = None,
         electric_conductivity: jax.Array | None = None,
         dispersive_c4: jax.Array | None = None,
+        dispersive_b0: jax.Array | None = None,
     ) -> Self:
         del electric_conductivity
         config = self._config
@@ -247,20 +248,22 @@ class TFSFPlaneSourceRegion(TFSFPlaneSource):
             inv_eps_inf_face = inv_eps_face  # raw ε∞ before any carrier correction
 
             # dispersive carrier-frequency correction (matches the single-plane source)
-            c1_s = c2_s = c3_s = c4_s = None
-            if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
-                c1_s = dispersive_c1[:, :, *e_face_slice]
-                c2_s = dispersive_c2[:, :, *e_face_slice]
-                c3_s = dispersive_c3[:, :, *e_face_slice]
+            a1_s = a0_s = b1_s = c4_s = b0_s = None
+            if dispersive_a1 is not None and dispersive_a0 is not None and dispersive_b1 is not None:
+                a1_s = dispersive_a1[:, :, *e_face_slice]
+                a0_s = dispersive_a0[:, :, *e_face_slice]
+                b1_s = dispersive_b1[:, :, *e_face_slice]
                 c4_s = None if dispersive_c4 is None else dispersive_c4[:, :, *e_face_slice]
+                b0_s = None if dispersive_b0 is None else dispersive_b0[:, :, *e_face_slice]
                 inv_eps_face = effective_inv_permittivity(
                     inv_eps=inv_eps_face,
-                    c1=c1_s,
-                    c2=c2_s,
-                    c3=c3_s,
+                    a1=a1_s,
+                    a0=a0_s,
+                    b1=b1_s,
                     omega=omega_c,
                     dt=config.time_step_duration,
                     c4=c4_s,
+                    b0=b0_s,
                 )
 
             impedance = _source_impedance(inv_eps_face, inv_mu_face, e_pol, h_pol)
@@ -299,18 +302,19 @@ class TFSFPlaneSourceRegion(TFSFPlaneSource):
             )
 
             filt = None
-            if c1_s is not None and c2_s is not None and c3_s is not None:
+            if a1_s is not None and a0_s is not None and b1_s is not None:
                 filt = _build_dispersive_H_filter(
                     temporal_profile=self.temporal_profile,
                     wave_character=self.wave_character,
                     dt=config.time_step_duration,
                     num_time_steps=config.time_steps_total,
-                    c1_slice=c1_s,
-                    c2_slice=c2_s,
-                    c3_slice=c3_s,
+                    a1_slice=a1_s,
+                    a0_slice=a0_s,
+                    b1_slice=b1_s,
                     inv_eps_inf_slice=inv_eps_inf_face,
                     dtype=config.dtype,
                     c4_slice=c4_s,
+                    b0_slice=b0_s,
                 )
 
             normal_axes.append(normal_axis)

--- a/tests/integration/fdtd/test_dispersive_init.py
+++ b/tests/integration/fdtd/test_dispersive_init.py
@@ -11,7 +11,14 @@ import pytest
 
 from fdtdx.config import SimulationConfig
 from fdtdx.constants import c as c0
-from fdtdx.dispersion import CCPRPole, DispersionModel, DrudePole, LorentzPole, compute_pole_coefficients
+from fdtdx.dispersion import (
+    CCPRPole,
+    DispersionModel,
+    DrudePole,
+    LorentzPole,
+    compute_pole_delta_coefficients_per_axis,
+    compute_pole_delta_coefficients_tensor,
+)
 from fdtdx.fdtd.initialization import apply_params, place_objects
 from fdtdx.materials import Material
 from fdtdx.objects.device.device import Device
@@ -19,6 +26,16 @@ from fdtdx.objects.device.parameters.discretization import ClosestIndex
 from fdtdx.objects.object import GridCoordinateConstraint
 from fdtdx.objects.static_material.sphere import Sphere
 from fdtdx.objects.static_material.static import SimulationVolume, UniformMaterialObject
+
+
+def _delta_coeffs(poles, dt):
+    """Delta-basis coefficients ``(a1, a0, b1, c4, b0)``, one scalar per pole.
+
+    The stored arrays hold the delta basis (see :mod:`fdtdx.dispersion`), so
+    reference values must come from there rather than from the P-form c1/c2.
+    Valid for isotropic poles, where all three axis columns coincide.
+    """
+    return tuple(v[:, 0] for v in compute_pole_delta_coefficients_per_axis(poles, dt))
 
 
 def _placed(container, name):
@@ -87,33 +104,33 @@ def test_dispersive_arrays_allocated(simple_config, simple_volume):
     placed = _placed(objects, "slab")
 
     Nx, Ny, Nz = simple_volume.partial_grid_shape  # type: ignore[misc]
-    assert arrays.fields.dispersive_P_curr is not None
-    assert arrays.fields.dispersive_P_prev is not None
-    assert arrays.dispersive_c1 is not None
-    assert arrays.dispersive_c2 is not None
-    assert arrays.dispersive_c3 is not None
-    assert arrays.fields.dispersive_P_curr.shape == (1, 3, Nx, Ny, Nz)
-    assert arrays.fields.dispersive_P_prev.shape == (1, 3, Nx, Ny, Nz)
-    assert arrays.dispersive_c1.shape == (1, 1, Nx, Ny, Nz)
-    assert arrays.dispersive_c2.shape == (1, 1, Nx, Ny, Nz)
-    assert arrays.dispersive_c3.shape == (1, 1, Nx, Ny, Nz)
+    assert arrays.fields.dispersive_x1 is not None
+    assert arrays.fields.dispersive_y2 is not None
+    assert arrays.dispersive_a1 is not None
+    assert arrays.dispersive_a0 is not None
+    assert arrays.dispersive_b1 is not None
+    assert arrays.fields.dispersive_x1.shape == (1, 3, Nx, Ny, Nz)
+    assert arrays.fields.dispersive_y2.shape == (1, 3, Nx, Ny, Nz)
+    assert arrays.dispersive_a1.shape == (1, 1, Nx, Ny, Nz)
+    assert arrays.dispersive_a0.shape == (1, 1, Nx, Ny, Nz)
+    assert arrays.dispersive_b1.shape == (1, 1, Nx, Ny, Nz)
     # polarization always starts at zero
-    assert jnp.all(arrays.fields.dispersive_P_curr == 0)
-    assert jnp.all(arrays.fields.dispersive_P_prev == 0)
+    assert jnp.all(arrays.fields.dispersive_x1 == 0)
+    assert jnp.all(arrays.fields.dispersive_y2 == 0)
 
     # Coefficient values inside the slab should match compute_pole_coefficients.
-    c1_ref, c2_ref, c3_ref, _c4_ref = compute_pole_coefficients(
+    a1_ref, a0_ref, b1_ref, _c4_ref, _ = _delta_coeffs(
         material.dispersion.poles,
         config.time_step_duration,  # type: ignore[union-attr]
     )
     xs, ys, zs = placed.grid_slice
-    assert jnp.allclose(arrays.dispersive_c1[0, 0, xs, ys, zs], c1_ref[0])
-    assert jnp.allclose(arrays.dispersive_c2[0, 0, xs, ys, zs], c2_ref[0])
-    assert jnp.allclose(arrays.dispersive_c3[0, 0, xs, ys, zs], c3_ref[0])
+    assert jnp.allclose(arrays.dispersive_a1[0, 0, xs, ys, zs], a1_ref[0])
+    assert jnp.allclose(arrays.dispersive_a0[0, 0, xs, ys, zs], a0_ref[0])
+    assert jnp.allclose(arrays.dispersive_b1[0, 0, xs, ys, zs], b1_ref[0])
 
     # c3 should be zero outside the slab (vacuum cells have no polarization)
     inside_mask = jnp.zeros((Nx, Ny, Nz), dtype=bool).at[xs, ys, zs].set(True)
-    assert jnp.all(arrays.dispersive_c3[0, 0][~inside_mask] == 0.0)
+    assert jnp.all(arrays.dispersive_b1[0, 0][~inside_mask] == 0.0)
 
 
 def test_no_dispersive_arrays_when_unused(simple_config, simple_volume):
@@ -126,11 +143,11 @@ def test_no_dispersive_arrays_when_unused(simple_config, simple_volume):
     key = jax.random.PRNGKey(0)
     _, arrays, _, _, _ = place_objects([simple_volume, obj], simple_config, [constraint], key)
 
-    assert arrays.fields.dispersive_P_curr is None
-    assert arrays.fields.dispersive_P_prev is None
-    assert arrays.dispersive_c1 is None
-    assert arrays.dispersive_c2 is None
-    assert arrays.dispersive_c3 is None
+    assert arrays.fields.dispersive_x1 is None
+    assert arrays.fields.dispersive_y2 is None
+    assert arrays.dispersive_a1 is None
+    assert arrays.dispersive_a0 is None
+    assert arrays.dispersive_b1 is None
 
 
 def test_pole_padding_mixed_pole_counts(simple_config, simple_volume):
@@ -152,17 +169,17 @@ def test_pole_padding_mixed_pole_counts(simple_config, simple_volume):
     placed2 = _placed(objects, "three_pole_slab")
 
     Nx, Ny, Nz = simple_volume.partial_grid_shape  # type: ignore[misc]
-    assert arrays.dispersive_c1.shape == (3, 1, Nx, Ny, Nz)
-    assert arrays.fields.dispersive_P_curr.shape == (3, 3, Nx, Ny, Nz)
+    assert arrays.dispersive_a1.shape == (3, 1, Nx, Ny, Nz)
+    assert arrays.fields.dispersive_x1.shape == (3, 3, Nx, Ny, Nz)
 
     # Inside the 1-pole slab: pole slot 0 is populated, slots 1 and 2 are zero.
     xs1, ys1, zs1 = placed1.grid_slice
-    c1_1p_slot0 = arrays.dispersive_c1[0, 0, xs1, ys1, zs1]
-    c1_1p_slot1 = arrays.dispersive_c1[1, 0, xs1, ys1, zs1]
-    c1_1p_slot2 = arrays.dispersive_c1[2, 0, xs1, ys1, zs1]
-    c3_1p_slot0 = arrays.dispersive_c3[0, 0, xs1, ys1, zs1]
-    c3_1p_slot1 = arrays.dispersive_c3[1, 0, xs1, ys1, zs1]
-    c3_1p_slot2 = arrays.dispersive_c3[2, 0, xs1, ys1, zs1]
+    c1_1p_slot0 = arrays.dispersive_a1[0, 0, xs1, ys1, zs1]
+    c1_1p_slot1 = arrays.dispersive_a1[1, 0, xs1, ys1, zs1]
+    c1_1p_slot2 = arrays.dispersive_a1[2, 0, xs1, ys1, zs1]
+    c3_1p_slot0 = arrays.dispersive_b1[0, 0, xs1, ys1, zs1]
+    c3_1p_slot1 = arrays.dispersive_b1[1, 0, xs1, ys1, zs1]
+    c3_1p_slot2 = arrays.dispersive_b1[2, 0, xs1, ys1, zs1]
     assert jnp.all(c1_1p_slot0 != 0.0)
     assert jnp.all(c1_1p_slot1 == 0.0)
     assert jnp.all(c1_1p_slot2 == 0.0)
@@ -173,7 +190,7 @@ def test_pole_padding_mixed_pole_counts(simple_config, simple_volume):
     # Inside the 3-pole slab: all three slots populated.
     xs2, ys2, zs2 = placed2.grid_slice
     for p in range(3):
-        c3_slot = arrays.dispersive_c3[p, 0, xs2, ys2, zs2]
+        c3_slot = arrays.dispersive_b1[p, 0, xs2, ys2, zs2]
         assert jnp.all(c3_slot > 0.0)
 
 
@@ -202,8 +219,8 @@ def test_non_dispersive_overlap_clears_dispersive_coefficients(simple_config, si
     placed_disp = _placed(objects, "disp")
     placed_plain = _placed(objects, "plain")
 
-    assert arrays.dispersive_c1 is not None
-    assert arrays.dispersive_c3 is not None
+    assert arrays.dispersive_a1 is not None
+    assert arrays.dispersive_b1 is not None
 
     Nx, Ny, Nz = simple_volume.partial_grid_shape  # type: ignore[misc]
     disp_mask = jnp.zeros((Nx, Ny, Nz), dtype=bool).at[placed_disp.grid_slice].set(True)
@@ -216,15 +233,15 @@ def test_non_dispersive_overlap_clears_dispersive_coefficients(simple_config, si
     assert jnp.any(disp_only_mask), "test setup: expected a disp-only region"
 
     # Overlap: coefficients must be zero (plain slab cleared them).
-    assert jnp.all(arrays.dispersive_c1[0, 0][overlap_mask] == 0.0), (
+    assert jnp.all(arrays.dispersive_a1[0, 0][overlap_mask] == 0.0), (
         "Non-dispersive overlap failed to clear c1 — stale pole coefficients remain"
     )
-    assert jnp.all(arrays.dispersive_c3[0, 0][overlap_mask] == 0.0), (
+    assert jnp.all(arrays.dispersive_b1[0, 0][overlap_mask] == 0.0), (
         "Non-dispersive overlap failed to clear c3 — ADE recurrence would fire on plain cells"
     )
 
     # Disp-only region: coefficients must still be populated.
-    assert jnp.all(arrays.dispersive_c3[0, 0][disp_only_mask] > 0.0)
+    assert jnp.all(arrays.dispersive_b1[0, 0][disp_only_mask] > 0.0)
 
 
 def test_dispersive_with_non_dispersive_object(simple_config, simple_volume):
@@ -243,13 +260,13 @@ def test_dispersive_with_non_dispersive_object(simple_config, simple_volume):
     placed_disp = _placed(objects, "disp")
     placed_plain = _placed(objects, "plain")
 
-    assert arrays.dispersive_c1 is not None
+    assert arrays.dispersive_a1 is not None
     xs_d, ys_d, zs_d = placed_disp.grid_slice
     xs_p, ys_p, zs_p = placed_plain.grid_slice
     # Dispersive slab: c3 non-zero
-    assert jnp.all(arrays.dispersive_c3[0, 0, xs_d, ys_d, zs_d] > 0.0)
+    assert jnp.all(arrays.dispersive_b1[0, 0, xs_d, ys_d, zs_d] > 0.0)
     # Non-dispersive slab: c3 zero
-    assert jnp.all(arrays.dispersive_c3[0, 0, xs_p, ys_p, zs_p] == 0.0)
+    assert jnp.all(arrays.dispersive_b1[0, 0, xs_p, ys_p, zs_p] == 0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -275,18 +292,18 @@ def test_static_multi_material_dispersive(simple_config, simple_volume):
     objects, arrays, _, _, _ = place_objects([simple_volume, sphere], simple_config, [constraint], key)
     placed = _placed(objects, "sphere")
 
-    assert arrays.dispersive_c3 is not None
-    assert arrays.dispersive_c3.shape[0] == 1  # one pole total (Drude)
+    assert arrays.dispersive_b1 is not None
+    assert arrays.dispersive_b1.shape[0] == 1  # one pole total (Drude)
 
     # Outside the bounding box → strictly zero
     Nx, Ny, Nz = simple_volume.partial_grid_shape  # type: ignore[misc]
     xs, ys, zs = placed.grid_slice
     inside_mask = jnp.zeros((Nx, Ny, Nz), dtype=bool).at[xs, ys, zs].set(True)
-    assert jnp.all(arrays.dispersive_c3[0, 0][~inside_mask] == 0.0)
+    assert jnp.all(arrays.dispersive_b1[0, 0][~inside_mask] == 0.0)
 
     # Inside the voxel mask → non-zero
     voxel_mask = placed.get_voxel_mask_for_shape().astype(bool)
-    inside_slab = arrays.dispersive_c3[0, 0, xs, ys, zs]
+    inside_slab = arrays.dispersive_b1[0, 0, xs, ys, zs]
     assert jnp.any(inside_slab[voxel_mask] > 0.0)
     # Cells inside the bounding box but outside the sphere remain zero
     assert jnp.all(inside_slab[~voxel_mask] == 0.0)
@@ -323,29 +340,29 @@ def test_device_dispersive_continuous(simple_config, simple_volume):
     drude_params = {name: jnp.ones_like(p) for name, p in params.items()}
     arrays, objects, _ = apply_params(arrays, objects, drude_params, key)
 
-    assert arrays.dispersive_c1 is not None
-    assert arrays.dispersive_c1.shape == (1, 1, 30, 30, 30)
+    assert arrays.dispersive_a1 is not None
+    assert arrays.dispersive_a1.shape == (1, 1, 30, 30, 30)
 
     # Inside the device: coefficients should equal the drude coefficients.
-    c1_ref, c2_ref, c3_ref, _c4_ref = compute_pole_coefficients(
+    a1_ref, a0_ref, b1_ref, _c4_ref, _ = _delta_coeffs(
         materials["drude"].dispersion.poles,  # type: ignore[union-attr]
         config.time_step_duration,
     )
-    assert jnp.allclose(arrays.dispersive_c1[0, 0, xs, ys, zs], c1_ref[0])
-    assert jnp.allclose(arrays.dispersive_c2[0, 0, xs, ys, zs], c2_ref[0])
-    assert jnp.allclose(arrays.dispersive_c3[0, 0, xs, ys, zs], c3_ref[0])
+    assert jnp.allclose(arrays.dispersive_a1[0, 0, xs, ys, zs], a1_ref[0])
+    assert jnp.allclose(arrays.dispersive_a0[0, 0, xs, ys, zs], a0_ref[0])
+    assert jnp.allclose(arrays.dispersive_b1[0, 0, xs, ys, zs], b1_ref[0])
 
     # All-air: params=0 -> coefficients should be zero (air has no dispersion)
     air_params = {name: jnp.zeros_like(p) for name, p in params.items()}
     arrays2, _, _ = apply_params(arrays, objects, air_params, key)
-    assert jnp.all(arrays2.dispersive_c1[0, 0, xs, ys, zs] == 0.0)
-    assert jnp.all(arrays2.dispersive_c3[0, 0, xs, ys, zs] == 0.0)
+    assert jnp.all(arrays2.dispersive_a1[0, 0, xs, ys, zs] == 0.0)
+    assert jnp.all(arrays2.dispersive_b1[0, 0, xs, ys, zs] == 0.0)
 
     # Half interpolation: params=0.5 -> coefficients should be half the drude values
     half_params = {name: 0.5 * jnp.ones_like(p) for name, p in params.items()}
     arrays3, _, _ = apply_params(arrays, objects, half_params, key)
-    assert jnp.allclose(arrays3.dispersive_c1[0, 0, xs, ys, zs], 0.5 * c1_ref[0])
-    assert jnp.allclose(arrays3.dispersive_c3[0, 0, xs, ys, zs], 0.5 * c3_ref[0])
+    assert jnp.allclose(arrays3.dispersive_a1[0, 0, xs, ys, zs], 0.5 * a1_ref[0])
+    assert jnp.allclose(arrays3.dispersive_b1[0, 0, xs, ys, zs], 0.5 * b1_ref[0])
 
 
 def test_device_dispersive_discrete(simple_config, simple_volume):
@@ -374,17 +391,17 @@ def test_device_dispersive_discrete(simple_config, simple_volume):
     drude_params = {name: jnp.ones_like(p) for name, p in params.items()}
     arrays, objects, _ = apply_params(arrays, objects, drude_params, key)
 
-    c1_ref, _, c3_ref, _ = compute_pole_coefficients(
+    a1_ref, _, b1_ref, _, _ = _delta_coeffs(
         materials["drude"].dispersion.poles,  # type: ignore[union-attr]
         config.time_step_duration,
     )
-    assert jnp.allclose(arrays.dispersive_c1[0, 0, xs, ys, zs], c1_ref[0])
-    assert jnp.allclose(arrays.dispersive_c3[0, 0, xs, ys, zs], c3_ref[0])
+    assert jnp.allclose(arrays.dispersive_a1[0, 0, xs, ys, zs], a1_ref[0])
+    assert jnp.allclose(arrays.dispersive_b1[0, 0, xs, ys, zs], b1_ref[0])
 
     # All air: coefficients should be zero
     air_params = {name: jnp.zeros_like(p) for name, p in params.items()}
     arrays2, _, _ = apply_params(arrays, objects, air_params, key)
-    assert jnp.all(arrays2.dispersive_c3[0, 0, xs, ys, zs] == 0.0)
+    assert jnp.all(arrays2.dispersive_b1[0, 0, xs, ys, zs] == 0.0)
 
 
 def _aniso_plus_dispersive_scene(simple_volume):
@@ -410,9 +427,9 @@ def test_fully_anisotropic_plus_dispersive_allocates(simple_config, simple_volum
     key = jax.random.PRNGKey(0)
     _, arrays, _, _, _ = place_objects(objects_list, simple_config, constraints, key)
     assert arrays.inv_permittivities.shape[0] == 9
-    assert arrays.dispersive_c1 is not None
-    assert arrays.dispersive_c1.shape[1] == 1
-    assert arrays.dispersive_c3.shape[1] == 1
+    assert arrays.dispersive_a1 is not None
+    assert arrays.dispersive_a1.shape[1] == 1
+    assert arrays.dispersive_b1.shape[1] == 1
 
 
 def test_isotropic_dispersive_reversible_raises(simple_config, simple_volume):
@@ -439,15 +456,35 @@ def test_fully_anisotropic_plus_dispersive_reversible_raises(simple_config, simp
     objects_list, constraints = _aniso_plus_dispersive_scene(simple_volume)
     config = simple_config.aset("gradient_config", GradientConfig(method="reversible", recorder=Recorder(modules=[])))
     key = jax.random.PRNGKey(0)
-    with pytest.raises(NotImplementedError, match="checkpointed"):
+    with pytest.raises(NotImplementedError, match="under active development"):
         place_objects(objects_list, config, constraints, key)
 
 
-def _unstable_ccpr_material(eps_inf=2.0):
+def _unstable_ccpr_material(eps_inf=2.0, integrator="central"):
     """CCPR material whose implicit-update divisor goes non-positive at the
-    ``simple_config`` time step (~1.9e-16 s), i.e. large negative Re(residue)."""
-    pole = CCPRPole(pole=complex(-1e13, -2e15), residue=complex(-6e15, 1e15))
+    ``simple_config`` time step (~1.9e-16 s), i.e. large negative Re(residue).
+
+    Pinned to ``integrator="central"``: its forward-difference dE/dt term puts the
+    full ``b*dt`` on ``E^{n+1}``, which is what drives the divisor negative. The
+    default ``"centered_edot"`` halves that and keeps the same pole runnable, so
+    the rejection path can only be exercised with the legacy scheme.
+    """
+    pole = CCPRPole(pole=complex(-1e13, -2e15), residue=complex(-6e15, 1e15), integrator=integrator)
     return Material(permittivity=eps_inf, dispersion=DispersionModel(poles=(pole,)))
+
+
+def test_centered_edot_places_the_material_central_rejects(simple_config, simple_volume):
+    """The same pole that ``"central"`` cannot place is accepted under the default
+    scheme — the resolution ceiling the forward difference imposes is lifted."""
+    mat = _unstable_ccpr_material(integrator="centered_edot")
+    obj = UniformMaterialObject(name="gold", partial_grid_shape=(10, 10, 10), material=mat)
+    constraint = GridCoordinateConstraint(
+        object="gold", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[10, 10, 10]
+    )
+    key = jax.random.PRNGKey(0)
+    _, arrays, _, _, _ = place_objects([simple_volume, obj], simple_config, [constraint], key)
+    assert arrays.dispersive_c4 is not None
+    assert arrays.dispersive_b0 is not None
 
 
 def test_unstable_ccpr_material_raises_at_placement(simple_config, simple_volume):
@@ -543,16 +580,16 @@ def test_device_continuous_half_interpolation(simple_config, simple_volume):
     half_params = {name: 0.5 * jnp.ones_like(p) for name, p in params.items()}
     arrays_half, _, _ = apply_params(arrays, objects, half_params, key)
 
-    c1_ref, _, c3_ref, _ = compute_pole_coefficients(
+    a1_ref, _, b1_ref, _, _ = _delta_coeffs(
         materials["drude"].dispersion.poles,  # type: ignore[union-attr]
         config.time_step_duration,
     )
     # 0.5 * (air_coeffs = 0) + 0.5 * (drude_coeffs)
-    assert jnp.allclose(arrays_half.dispersive_c1[0, 0, xs, ys, zs], 0.5 * c1_ref[0])
-    assert jnp.allclose(arrays_half.dispersive_c3[0, 0, xs, ys, zs], 0.5 * c3_ref[0])
+    assert jnp.allclose(arrays_half.dispersive_a1[0, 0, xs, ys, zs], 0.5 * a1_ref[0])
+    assert jnp.allclose(arrays_half.dispersive_b1[0, 0, xs, ys, zs], 0.5 * b1_ref[0])
     # All coefficients outside the device slice remain zero
     mask = jnp.zeros(simple_volume.partial_grid_shape, dtype=bool).at[xs, ys, zs].set(True)  # type: ignore[misc]
-    assert jnp.all(arrays_half.dispersive_c1[0, 0][~mask] == 0.0)
+    assert jnp.all(arrays_half.dispersive_a1[0, 0][~mask] == 0.0)
 
 
 def test_dipole_source_samples_frequency_corrected_permittivity(simple_config, simple_volume):
@@ -674,7 +711,6 @@ def _per_axis_lorentz_material(eps_inf=(2.0, 2.0, 3.0)):
 def test_per_axis_dispersion_allocates_3_component_coefficients(simple_config, simple_volume):
     """A per-axis dispersive material widens the coefficient arrays to a
     3-entry component axis and bakes per-axis values inside the object slice."""
-    from fdtdx.dispersion import compute_pole_coefficients_per_axis
 
     material = _per_axis_lorentz_material()
     obj = UniformMaterialObject(name="slab", partial_grid_shape=(10, 10, 10), material=material)
@@ -686,27 +722,27 @@ def test_per_axis_dispersion_allocates_3_component_coefficients(simple_config, s
     placed = _placed(objects, "slab")
 
     Nx, Ny, Nz = simple_volume.partial_grid_shape  # type: ignore[misc]
-    assert arrays.dispersive_c1 is not None
-    assert arrays.dispersive_c1.shape == (1, 3, Nx, Ny, Nz)
-    assert arrays.dispersive_c2.shape == (1, 3, Nx, Ny, Nz)
-    assert arrays.dispersive_c3.shape == (1, 3, Nx, Ny, Nz)
+    assert arrays.dispersive_a1 is not None
+    assert arrays.dispersive_a1.shape == (1, 3, Nx, Ny, Nz)
+    assert arrays.dispersive_a0.shape == (1, 3, Nx, Ny, Nz)
+    assert arrays.dispersive_b1.shape == (1, 3, Nx, Ny, Nz)
     # polarization state keeps its (num_poles, 3, ...) shape
-    assert arrays.fields.dispersive_P_curr.shape == (1, 3, Nx, Ny, Nz)
+    assert arrays.fields.dispersive_x1.shape == (1, 3, Nx, Ny, Nz)
 
-    c1_ref, c2_ref, c3_ref, _ = compute_pole_coefficients_per_axis(
+    a1_ref, a0_ref, b1_ref, _, _ = compute_pole_delta_coefficients_per_axis(
         material.dispersion.poles,  # type: ignore[union-attr]
         config.time_step_duration,
     )
     xs, ys, zs = placed.grid_slice
     for ax in range(3):
-        assert jnp.allclose(arrays.dispersive_c1[0, ax, xs, ys, zs], c1_ref[0, ax])
-        assert jnp.allclose(arrays.dispersive_c2[0, ax, xs, ys, zs], c2_ref[0, ax])
-        assert jnp.allclose(arrays.dispersive_c3[0, ax, xs, ys, zs], c3_ref[0, ax])
+        assert jnp.allclose(arrays.dispersive_a1[0, ax, xs, ys, zs], a1_ref[0, ax])
+        assert jnp.allclose(arrays.dispersive_a0[0, ax, xs, ys, zs], a0_ref[0, ax])
+        assert jnp.allclose(arrays.dispersive_b1[0, ax, xs, ys, zs], b1_ref[0, ax])
     # the axis columns genuinely differ (x vs z resonance)
-    assert not jnp.allclose(arrays.dispersive_c1[0, 0, xs, ys, zs], arrays.dispersive_c1[0, 2, xs, ys, zs])
+    assert not jnp.allclose(arrays.dispersive_a1[0, 0, xs, ys, zs], arrays.dispersive_a1[0, 2, xs, ys, zs])
     # outside the slab everything is zero
     inside_mask = jnp.zeros((Nx, Ny, Nz), dtype=bool).at[xs, ys, zs].set(True)
-    assert jnp.all(arrays.dispersive_c3[0, :, ~inside_mask] == 0.0)
+    assert jnp.all(arrays.dispersive_b1[0, :, ~inside_mask] == 0.0)
 
 
 def test_isotropic_dispersion_keeps_1_component_axis(simple_config, simple_volume):
@@ -718,13 +754,12 @@ def test_isotropic_dispersion_keeps_1_component_axis(simple_config, simple_volum
     )
     key = jax.random.PRNGKey(0)
     _, arrays, _, _, _ = place_objects([simple_volume, obj], simple_config, [constraint], key)
-    assert arrays.dispersive_c1.shape[1] == 1
+    assert arrays.dispersive_a1.shape[1] == 1
 
 
 def test_static_multi_material_per_axis_coefficients(simple_config, simple_volume):
     """A Sphere with a per-axis Drude material bakes per-axis coefficients
     through the multi-material indexing path."""
-    from fdtdx.dispersion import compute_pole_coefficients_per_axis
 
     per_axis_drude = Material(
         permittivity=1.0,
@@ -745,29 +780,28 @@ def test_static_multi_material_per_axis_coefficients(simple_config, simple_volum
     objects, arrays, _, config, _ = place_objects([simple_volume, sphere], simple_config, [constraint], key)
     placed = _placed(objects, "sphere")
 
-    assert arrays.dispersive_c3 is not None
-    assert arrays.dispersive_c3.shape[1] == 3
+    assert arrays.dispersive_b1 is not None
+    assert arrays.dispersive_b1.shape[1] == 3
 
-    c1_ref, _, c3_ref, _ = compute_pole_coefficients_per_axis(
+    a1_ref, _, b1_ref, _, _ = compute_pole_delta_coefficients_per_axis(
         per_axis_drude.dispersion.poles,  # type: ignore[union-attr]
         config.time_step_duration,
     )
     xs, ys, zs = placed.grid_slice
     voxel_mask = placed.get_voxel_mask_for_shape().astype(bool)
-    inside_x = arrays.dispersive_c3[0, 0, xs, ys, zs]
-    inside_y = arrays.dispersive_c3[0, 1, xs, ys, zs]
+    inside_x = arrays.dispersive_b1[0, 0, xs, ys, zs]
+    inside_y = arrays.dispersive_b1[0, 1, xs, ys, zs]
     # x axis carries the plasma coupling, y axis has none
-    assert jnp.allclose(inside_x[voxel_mask], c3_ref[0, 0])
-    assert c3_ref[0, 0] > 0.0
+    assert jnp.allclose(inside_x[voxel_mask], b1_ref[0, 0])
+    assert b1_ref[0, 0] > 0.0
     assert jnp.all(inside_y[voxel_mask] == 0.0)
     # c1 is still non-zero on the y axis (recurrence exists, zero coupling)
-    assert jnp.allclose(arrays.dispersive_c1[0, 1, xs, ys, zs][voxel_mask], c1_ref[0, 1])
+    assert jnp.allclose(arrays.dispersive_a1[0, 1, xs, ys, zs][voxel_mask], a1_ref[0, 1])
 
 
 def test_device_per_axis_dispersive_continuous_and_discrete(simple_config, simple_volume):
     """Devices write per-axis coefficient stacks through both the CONTINUOUS
     interpolation branch and the DISCRETE selection branch."""
-    from fdtdx.dispersion import compute_pole_coefficients_per_axis
 
     per_axis_drude = Material(
         permittivity=1.0,
@@ -796,16 +830,16 @@ def test_device_per_axis_dispersive_continuous_and_discrete(simple_config, simpl
         drude_params = {name: jnp.ones_like(p) for name, p in params.items()}
         arrays, objects, _ = apply_params(arrays, objects, drude_params, key)
 
-        assert arrays.dispersive_c1.shape[1] == 3
-        c1_ref, _, c3_ref, _ = compute_pole_coefficients_per_axis(
+        assert arrays.dispersive_a1.shape[1] == 3
+        a1_ref, _, b1_ref, _, _ = compute_pole_delta_coefficients_per_axis(
             per_axis_drude.dispersion.poles,  # type: ignore[union-attr]
             config.time_step_duration,
         )
         for ax in range(3):
-            assert jnp.allclose(arrays.dispersive_c1[0, ax, xs, ys, zs], c1_ref[0, ax])
-            assert jnp.allclose(arrays.dispersive_c3[0, ax, xs, ys, zs], c3_ref[0, ax])
+            assert jnp.allclose(arrays.dispersive_a1[0, ax, xs, ys, zs], a1_ref[0, ax])
+            assert jnp.allclose(arrays.dispersive_b1[0, ax, xs, ys, zs], b1_ref[0, ax])
         # x and z couplings differ by construction
-        assert c3_ref[0, 0] != c3_ref[0, 2]
+        assert b1_ref[0, 0] != b1_ref[0, 2]
 
 
 def test_full_tensor_sigma_plus_dispersive_allocates(simple_config, simple_volume):
@@ -826,9 +860,9 @@ def test_full_tensor_sigma_plus_dispersive_allocates(simple_config, simple_volum
     _, arrays, _, _, _ = place_objects([simple_volume, obj1, obj2], simple_config, constraints, key)
     assert arrays.electric_conductivity is not None
     assert arrays.electric_conductivity.shape[0] == 9
-    assert arrays.dispersive_c3 is not None
+    assert arrays.dispersive_b1 is not None
     # axis-aligned dispersion keeps its natural coupling tier
-    assert arrays.dispersive_c3.shape[1] == 1
+    assert arrays.dispersive_b1.shape[1] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -857,7 +891,6 @@ def _oriented_lorentz_material(eps_inf=2.0):
 def test_oriented_dispersion_forces_tensor_tiers(simple_config, simple_volume):
     """An oriented pole widens the coupling to 9 components and forces the
     9-component permittivity tier so the fully anisotropic kernel runs."""
-    from fdtdx.dispersion import compute_pole_coefficients_tensor
 
     material = _oriented_lorentz_material()
     obj = UniformMaterialObject(name="slab", partial_grid_shape=(10, 10, 10), material=material)
@@ -869,21 +902,21 @@ def test_oriented_dispersion_forces_tensor_tiers(simple_config, simple_volume):
     placed = _placed(objects, "slab")
 
     assert arrays.inv_permittivities.shape[0] == 9
-    assert arrays.dispersive_c1.shape[1] == 3
-    assert arrays.dispersive_c3.shape[1] == 9
-    assert arrays.fields.dispersive_P_curr.shape[1] == 3
+    assert arrays.dispersive_a1.shape[1] == 3
+    assert arrays.dispersive_b1.shape[1] == 9
+    assert arrays.fields.dispersive_x1.shape[1] == 3
 
-    c1_ref, _, c3_ref, _ = compute_pole_coefficients_tensor(
+    a1_ref, _, b1_ref, _, _ = compute_pole_delta_coefficients_tensor(
         material.dispersion.poles,  # type: ignore[union-attr]
         config.time_step_duration,
     )
     xs, ys, zs = placed.grid_slice
     for entry in range(9):
-        assert jnp.allclose(arrays.dispersive_c3[0, entry, xs, ys, zs], c3_ref[0, entry])
+        assert jnp.allclose(arrays.dispersive_b1[0, entry, xs, ys, zs], b1_ref[0, entry])
     # the coupling tensor genuinely has off-diagonal weight (u = (1,1,0)/sqrt(2))
-    assert c3_ref[0, 1] != 0.0
+    assert b1_ref[0, 1] != 0.0
     for ax in range(3):
-        assert jnp.allclose(arrays.dispersive_c1[0, ax, xs, ys, zs], c1_ref[0, ax])
+        assert jnp.allclose(arrays.dispersive_a1[0, ax, xs, ys, zs], a1_ref[0, ax])
 
 
 def test_oriented_dispersion_reversible_raises(simple_config, simple_volume):
@@ -897,7 +930,7 @@ def test_oriented_dispersion_reversible_raises(simple_config, simple_volume):
     )
     config = simple_config.aset("gradient_config", GradientConfig(method="reversible", recorder=Recorder(modules=[])))
     key = jax.random.PRNGKey(0)
-    with pytest.raises(NotImplementedError, match="checkpointed"):
+    with pytest.raises(NotImplementedError, match="under active development"):
         place_objects([simple_volume, obj], config, [constraint], key)
 
 
@@ -939,7 +972,6 @@ def test_ccpr_edot_plus_tensor_path_raises(simple_config, simple_volume):
 def test_oriented_static_multi_material_and_device(simple_config, simple_volume):
     """Oriented coupling tensors bake correctly through the multi-material
     indexing path and the Device apply_params path."""
-    from fdtdx.dispersion import compute_pole_coefficients_tensor
 
     oriented = _oriented_lorentz_material(eps_inf=1.0)
     materials = {
@@ -957,16 +989,16 @@ def test_oriented_static_multi_material_and_device(simple_config, simple_volume)
     objects, arrays, _, config, _ = place_objects([simple_volume, sphere], simple_config, [constraint], key)
     placed = _placed(objects, "sphere")
 
-    assert arrays.dispersive_c3.shape[1] == 9
-    _, _, c3_ref, _ = compute_pole_coefficients_tensor(
+    assert arrays.dispersive_b1.shape[1] == 9
+    _, _, b1_ref, _, _ = compute_pole_delta_coefficients_tensor(
         oriented.dispersion.poles,  # type: ignore[union-attr]
         config.time_step_duration,
     )
     xs, ys, zs = placed.grid_slice
     voxel_mask = placed.get_voxel_mask_for_shape().astype(bool)
-    inside_xy = arrays.dispersive_c3[0, 1, xs, ys, zs]
-    assert jnp.allclose(inside_xy[voxel_mask], c3_ref[0, 1])
-    assert c3_ref[0, 1] != 0.0
+    inside_xy = arrays.dispersive_b1[0, 1, xs, ys, zs]
+    assert jnp.allclose(inside_xy[voxel_mask], b1_ref[0, 1])
+    assert b1_ref[0, 1] != 0.0
 
     device = Device(
         name="device",
@@ -983,5 +1015,73 @@ def test_oriented_static_multi_material_and_device(simple_config, simple_volume)
     xs, ys, zs = placed_device.grid_slice
     full_params = {name: jnp.ones_like(p) for name, p in params.items()}
     arrays, objects, _ = apply_params(arrays, objects, full_params, key)
-    assert arrays.dispersive_c3.shape[1] == 9
-    assert jnp.allclose(arrays.dispersive_c3[0, 1, xs, ys, zs], c3_ref[0, 1])
+    assert arrays.dispersive_b1.shape[1] == 9
+    assert jnp.allclose(arrays.dispersive_b1[0, 1, xs, ys, zs], b1_ref[0, 1])
+
+
+@pytest.mark.parametrize("integrator", ["centered_edot", "bilinear"])
+def test_min_dispersive_divisor_matches_what_the_kernel_forms(simple_config, simple_volume, integrator):
+    """``materials._min_dispersive_divisor`` must describe the divisor ``update_E``
+    actually builds from the STORED arrays.
+
+    The helper works from the P-form (c1..c5) in float64 and was deliberately left
+    alone by the delta-basis change, so nothing in the type system ties it to the
+    kernel any more — only this test does.
+    """
+    from fdtdx.constants import eta0
+    from fdtdx.materials import _min_dispersive_divisor
+
+    # Ag CCPR fit + static conductivity, i.e. c4 != 0 and the divisor non-trivial.
+    poles = tuple(
+        CCPRPole(pole=q, residue=r, integrator=integrator)
+        for q, r in (
+            (complex(-1.89e14, 0.0), complex(-1.00e18, 0.0)),
+            (complex(-5.46e14, -6.37e15), complex(1.30e15, 1.54e15)),
+            (complex(-5.68e14, -3.43e14), complex(1.61e17, 1.00e12)),
+        )
+    )
+    mat = Material(permittivity=3.07, electric_conductivity=1.49e7, dispersion=DispersionModel(poles=poles))
+    obj = UniformMaterialObject(name="silver", partial_grid_shape=(10, 10, 10), material=mat)
+    constraint = GridCoordinateConstraint(
+        object="silver", axes=[0, 1, 2], sides=["-", "-", "-"], coordinates=[10, 10, 10]
+    )
+    _, arrays, _, config, _ = place_objects([simple_volume, obj], simple_config, [constraint], jax.random.PRNGKey(0))
+    sl = (slice(10, 20), slice(10, 20), slice(10, 20))
+
+    c = config.courant_number
+    inv_eps = arrays.inv_permittivities[(slice(None), *sl)]
+    sigma_E = arrays.electric_conductivity[(slice(None), *sl)]
+    kappa = c * sigma_E * eta0 * inv_eps / 2
+    c4 = arrays.dispersive_c4[(slice(None), slice(None), *sl)]
+
+    kernel_fwd = 1 + inv_eps * jnp.sum(c4, axis=0) + kappa
+
+    dt = config.time_step_duration
+    helper_fwd, _ = _min_dispersive_divisor(mat, dt)
+
+    # isotropic material -> uniform over components and cells inside the slab
+    assert jnp.allclose(kernel_fwd, kernel_fwd.min(), rtol=1e-6)
+    # The helper is float64; the kernel expression above is rebuilt from the
+    # float32 stored arrays. `simple_config` has a very coarse dt, so the pole and
+    # conductivity terms are ~60x larger than the divisor they sum to (asserted
+    # below), and float32 caps the agreement at ~1e-5 relative. That gap is the
+    # test's own arithmetic, not a discrepancy in the helper.
+    assert float(kernel_fwd.min()) == pytest.approx(helper_fwd, rel=3e-4)
+    # not vacuous: the conductivity and pole terms are individually large and only
+    # nearly cancel, so a dropped or mis-signed term would move the divisor a lot
+    pole_term = float(jnp.abs(inv_eps * jnp.sum(c4, axis=0)).max())
+    assert pole_term > 10.0 * abs(helper_fwd)
+    assert float(jnp.abs(kappa).max()) > 10.0 * abs(helper_fwd)
+
+
+def test_lorentz_divisor_is_exactly_one():
+    """Lorentz/Drude poles on a central-difference scheme have c4 = 0, so the
+    divisor must be *exactly* 1 — no float drift from the delta-basis rewrite."""
+    from fdtdx.materials import _min_dispersive_divisor
+
+    for integrator in ("central", "centered_edot"):
+        model = DispersionModel(
+            poles=(LorentzPole(resonance_frequency=3e15, damping=1e14, delta_epsilon=2.0, integrator=integrator),)
+        )
+        mat = Material(permittivity=2.25, dispersion=model)
+        assert _min_dispersive_divisor(mat, 1e-18)[0] == 1.0

--- a/tests/simulation/fdtd/test_fdtd.py
+++ b/tests/simulation/fdtd/test_fdtd.py
@@ -499,7 +499,7 @@ class TestReversibleVsCheckpointedGradient:
 
 
 class TestPerAxisDispersiveGradientCheckpointed:
-    """PER-AXIS (diagonally anisotropic) dispersion: the ``c3`` coefficient array
+    """PER-AXIS (diagonally anisotropic) dispersion: the ``b1`` coefficient array
     carries a 3-entry component axis instead of the broadcast size-1 axis, and
     each axis has different pole parameters.
 
@@ -527,18 +527,18 @@ class TestPerAxisDispersiveGradientCheckpointed:
     def test_gradient_matches_finite_difference_per_axis_float64(self):
         with _x64_enabled():
             obj, arrays, config = _build_slab_scene(dtype=jnp.float64, material=self._material())
-            assert arrays.dispersive_c3 is not None and arrays.dispersive_c3.shape[1] == 3
+            assert arrays.dispersive_b1 is not None and arrays.dispersive_b1.shape[1] == 3
             arrays, config = _attach_gradient(arrays, config, obj, method="checkpointed")
 
-            def loss_fn(c3):
+            def loss_fn(b1):
                 arr = ArrayContainer(
                     fields=FieldState(
                         E=arrays.fields.E,
                         H=arrays.fields.H,
                         psi_E=arrays.fields.psi_E,
                         psi_H=arrays.fields.psi_H,
-                        dispersive_P_curr=arrays.fields.dispersive_P_curr,
-                        dispersive_P_prev=arrays.fields.dispersive_P_prev,
+                        dispersive_x1=arrays.fields.dispersive_x1,
+                        dispersive_y2=arrays.fields.dispersive_y2,
                     ),
                     inv_permittivities=arrays.inv_permittivities,
                     inv_permeabilities=arrays.inv_permeabilities,
@@ -546,23 +546,23 @@ class TestPerAxisDispersiveGradientCheckpointed:
                     recording_state=arrays.recording_state,
                     electric_conductivity=arrays.electric_conductivity,
                     magnetic_conductivity=arrays.magnetic_conductivity,
-                    dispersive_c1=arrays.dispersive_c1,
-                    dispersive_c2=arrays.dispersive_c2,
-                    dispersive_c3=c3,
+                    dispersive_a1=arrays.dispersive_a1,
+                    dispersive_a0=arrays.dispersive_a0,
+                    dispersive_b1=b1,
                 )
                 _, out = checkpointed_fdtd(arr, obj, config, jax.random.PRNGKey(99), show_progress=False)
                 return jnp.sum(jnp.real(out.fields.E) ** 2)
 
-            c3 = arrays.dispersive_c3
-            loss, grad = jax.value_and_grad(loss_fn)(c3)
+            b1 = arrays.dispersive_b1
+            loss, grad = jax.value_and_grad(loss_fn)(b1)
             assert jnp.isfinite(loss) and jnp.all(jnp.isfinite(grad))
 
             # One active voxel per component axis: AD must match a central FD.
             for ax in range(3):
-                xs, ys, zs = jnp.where(c3[0, ax] != 0, size=1, fill_value=0)
+                xs, ys, zs = jnp.where(b1[0, ax] != 0, size=1, fill_value=0)
                 idx = (0, ax, int(xs[0]), int(ys[0]), int(zs[0]))
-                h = 1e-4 * float(jnp.abs(c3[idx])) + 1e-10
-                fd = (loss_fn(c3.at[idx].add(h)) - loss_fn(c3.at[idx].add(-h))) / (2.0 * h)
+                h = 1e-4 * float(jnp.abs(b1[idx])) + 1e-10
+                fd = (loss_fn(b1.at[idx].add(h)) - loss_fn(b1.at[idx].add(-h))) / (2.0 * h)
                 ad = grad[idx]
                 diff = float(jnp.abs(ad - fd))
                 rel = diff / (float(jnp.abs(ad) + jnp.abs(fd)) + 1e-30)
@@ -721,18 +721,18 @@ class TestOrientedDispersionGradients:
         )
 
         obj, arrays, config = _build_slab_scene(dtype=jnp.float32, material=oriented_material)
-        assert arrays.dispersive_c3 is not None and arrays.dispersive_c3.shape[1] == 9
+        assert arrays.dispersive_b1 is not None and arrays.dispersive_b1.shape[1] == 9
         arrays, config = _attach_gradient(arrays, config, obj, method="checkpointed")
 
-        def loss_fn(c3):
+        def loss_fn(b1):
             arr = ArrayContainer(
                 fields=FieldState(
                     E=arrays.fields.E,
                     H=arrays.fields.H,
                     psi_E=arrays.fields.psi_E,
                     psi_H=arrays.fields.psi_H,
-                    dispersive_P_curr=arrays.fields.dispersive_P_curr,
-                    dispersive_P_prev=arrays.fields.dispersive_P_prev,
+                    dispersive_x1=arrays.fields.dispersive_x1,
+                    dispersive_y2=arrays.fields.dispersive_y2,
                 ),
                 inv_permittivities=arrays.inv_permittivities,
                 inv_permeabilities=arrays.inv_permeabilities,
@@ -740,14 +740,14 @@ class TestOrientedDispersionGradients:
                 recording_state=arrays.recording_state,
                 electric_conductivity=arrays.electric_conductivity,
                 magnetic_conductivity=arrays.magnetic_conductivity,
-                dispersive_c1=arrays.dispersive_c1,
-                dispersive_c2=arrays.dispersive_c2,
-                dispersive_c3=c3,
+                dispersive_a1=arrays.dispersive_a1,
+                dispersive_a0=arrays.dispersive_a0,
+                dispersive_b1=b1,
             )
             _, out = checkpointed_fdtd(arr, obj, config, jax.random.PRNGKey(99), show_progress=False)
             return jnp.sum(jnp.real(out.fields.E) ** 2)
 
-        loss, grads = jax.value_and_grad(loss_fn)(arrays.dispersive_c3)
+        loss, grads = jax.value_and_grad(loss_fn)(arrays.dispersive_b1)
         assert jnp.isfinite(loss)
         assert bool(jnp.all(jnp.isfinite(grads)))
         # gradient reaches the off-diagonal coupling entries

--- a/tests/simulation/fdtd/test_time_reversal.py
+++ b/tests/simulation/fdtd/test_time_reversal.py
@@ -892,7 +892,7 @@ def _build_lossy_dispersive_scene():
 
 
 def _make_disp_loss_fn(coef_name):
-    """Build a loss-fn closure that differentiates w.r.t. one of c1/c2/c3.
+    """Build a loss-fn closure that differentiates w.r.t. one of a1/a0/b1.
 
     Returns a static function compatible with ``jax.value_and_grad`` whose
     first positional argument is the chosen coefficient array. The remaining
@@ -901,10 +901,13 @@ def _make_disp_loss_fn(coef_name):
 
     def loss_fn(coef_value, arrays, objects, config, key, _fdtd):
         kwargs = {
-            "dispersive_c1": arrays.dispersive_c1,
-            "dispersive_c2": arrays.dispersive_c2,
-            "dispersive_c3": arrays.dispersive_c3,
+            "dispersive_a1": arrays.dispersive_a1,
+            "dispersive_a0": arrays.dispersive_a0,
+            "dispersive_b1": arrays.dispersive_b1,
             "dispersive_c4": arrays.dispersive_c4,
+            # c4 and b0 are allocated together; passing only c4 would make the
+            # update silently substitute b1 for b0 and change the physics.
+            "dispersive_b0": arrays.dispersive_b0,
         }
         kwargs[f"dispersive_{coef_name}"] = coef_value
         arr = ArrayContainer(
@@ -913,8 +916,8 @@ def _make_disp_loss_fn(coef_name):
                 H=arrays.fields.H,
                 psi_E=arrays.fields.psi_E,
                 psi_H=arrays.fields.psi_H,
-                dispersive_P_curr=arrays.fields.dispersive_P_curr,
-                dispersive_P_prev=arrays.fields.dispersive_P_prev,
+                dispersive_x1=arrays.fields.dispersive_x1,
+                dispersive_y2=arrays.fields.dispersive_y2,
             ),
             inv_permittivities=arrays.inv_permittivities,
             inv_permeabilities=arrays.inv_permeabilities,
@@ -953,7 +956,7 @@ def _coef_fd_check(coef_arr, loss_fn, arrays, obj, config, key, h_scale, h_floor
 
 
 class TestDispersiveCoefficientGradientCheckpointed:
-    """Verify that ``dispersive_c1/c2/c3`` are genuine differentiable inputs of
+    """Verify that ``dispersive_a1/a0/b1`` are genuine differentiable inputs of
     the checkpointed FDTD path: the AD gradient w.r.t. each coefficient at an
     interior dispersive voxel matches a central finite-difference estimate.
     """
@@ -963,15 +966,15 @@ class TestDispersiveCoefficientGradientCheckpointed:
         return _build_lossy_dispersive_scene()
 
     @staticmethod
-    def _loss_fn(dispersive_c3, arrays, objects, config, key):
+    def _loss_fn(dispersive_b1, arrays, objects, config, key):
         arrays = ArrayContainer(
             fields=FieldState(
                 E=arrays.fields.E,
                 H=arrays.fields.H,
                 psi_E=arrays.fields.psi_E,
                 psi_H=arrays.fields.psi_H,
-                dispersive_P_curr=arrays.fields.dispersive_P_curr,
-                dispersive_P_prev=arrays.fields.dispersive_P_prev,
+                dispersive_x1=arrays.fields.dispersive_x1,
+                dispersive_y2=arrays.fields.dispersive_y2,
             ),
             inv_permittivities=arrays.inv_permittivities,
             inv_permeabilities=arrays.inv_permeabilities,
@@ -979,9 +982,9 @@ class TestDispersiveCoefficientGradientCheckpointed:
             recording_state=arrays.recording_state,
             electric_conductivity=arrays.electric_conductivity,
             magnetic_conductivity=arrays.magnetic_conductivity,
-            dispersive_c1=arrays.dispersive_c1,
-            dispersive_c2=arrays.dispersive_c2,
-            dispersive_c3=dispersive_c3,
+            dispersive_a1=arrays.dispersive_a1,
+            dispersive_a0=arrays.dispersive_a0,
+            dispersive_b1=dispersive_b1,
         )
         _, out = checkpointed_fdtd(arrays, objects, config, key, show_progress=False)
         return jnp.sum(jnp.real(out.fields.E) ** 2)
@@ -989,7 +992,7 @@ class TestDispersiveCoefficientGradientCheckpointed:
     def test_gradient_through_c3_matches_finite_difference(self):
         obj, arrays, config = self._build()
         key = jax.random.PRNGKey(99)
-        c3 = arrays.dispersive_c3
+        c3 = arrays.dispersive_b1
         assert c3 is not None
 
         _, grads = jax.value_and_grad(self._loss_fn)(c3, arrays, obj, config, key)
@@ -1013,33 +1016,33 @@ class TestDispersiveCoefficientGradientCheckpointed:
             f"AD vs FD mismatch at {idx}: AD={float(ad):.6e}, FD={float(fd):.6e}, rel_err={float(rel_err):.3e}"
         )
 
-    def test_gradient_through_c1_matches_finite_difference(self):
+    def test_gradient_through_a1_matches_finite_difference(self):
         """Checkpointed path uses standard autodiff through ``eqxi.while_loop``
-        so c1 gradient flows naturally. Mirrors the reversible-path test."""
+        so the a1 gradient flows naturally. Mirrors the reversible-path test."""
         obj, arrays, config = self._build()
         key = jax.random.PRNGKey(99)
-        c1 = arrays.dispersive_c1
-        assert c1 is not None
-        loss_fn = _make_disp_loss_fn("c1")
+        a1 = arrays.dispersive_a1
+        assert a1 is not None
+        loss_fn = _make_disp_loss_fn("a1")
         ad, fd, rel_err, diff, idx = _coef_fd_check(
-            c1, loss_fn, arrays, obj, config, key, h_scale=1e-3, h_floor=1e-6, fdtd_impl=checkpointed_fdtd
+            a1, loss_fn, arrays, obj, config, key, h_scale=1e-3, h_floor=1e-6, fdtd_impl=checkpointed_fdtd
         )
         assert rel_err < 0.1 or diff < 1e-5, (
-            f"AD vs FD mismatch (c1) at {idx}: AD={float(ad):.6e}, FD={float(fd):.6e}, rel_err={float(rel_err):.3e}"
+            f"AD vs FD mismatch (a1) at {idx}: AD={float(ad):.6e}, FD={float(fd):.6e}, rel_err={float(rel_err):.3e}"
         )
 
-    def test_gradient_through_c2_matches_finite_difference(self):
-        """Checkpointed-path c2 gradient via standard autodiff."""
+    def test_gradient_through_a0_matches_finite_difference(self):
+        """Checkpointed-path a0 gradient via standard autodiff."""
         obj, arrays, config = self._build()
         key = jax.random.PRNGKey(99)
-        c2 = arrays.dispersive_c2
-        assert c2 is not None
-        loss_fn = _make_disp_loss_fn("c2")
+        a0 = arrays.dispersive_a0
+        assert a0 is not None
+        loss_fn = _make_disp_loss_fn("a0")
         ad, fd, rel_err, diff, idx = _coef_fd_check(
-            c2, loss_fn, arrays, obj, config, key, h_scale=1e-3, h_floor=1e-6, fdtd_impl=checkpointed_fdtd
+            a0, loss_fn, arrays, obj, config, key, h_scale=1e-3, h_floor=1e-6, fdtd_impl=checkpointed_fdtd
         )
         assert rel_err < 0.1 or diff < 1e-5, (
-            f"AD vs FD mismatch (c2) at {idx}: AD={float(ad):.6e}, FD={float(fd):.6e}, rel_err={float(rel_err):.3e}"
+            f"AD vs FD mismatch (a0) at {idx}: AD={float(ad):.6e}, FD={float(fd):.6e}, rel_err={float(rel_err):.3e}"
         )
 
 
@@ -1204,7 +1207,7 @@ class TestDispersiveReversibleRejected:
         obj, arrays, config = _build_lossy_dispersive_scene()
         # backward() restores recorded interfaces first, which needs a recorder.
         arrays, config = _add_gradient_config(arrays, config, obj)
-        assert arrays.fields.dispersive_P_curr is not None
+        assert arrays.fields.dispersive_x1 is not None
         with pytest.raises(NotImplementedError, match=self._MATCH):
             backward(
                 state=(jnp.asarray(1, dtype=jnp.int32), arrays),

--- a/tests/simulation/physics/test_dispersion.py
+++ b/tests/simulation/physics/test_dispersion.py
@@ -12,6 +12,7 @@ Layout mirrors ``test_fresnel.py`` — 3x3 periodic transverse, PMLs in z,
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 import fdtdx
 from fdtdx.constants import c as c0
@@ -469,4 +470,45 @@ def test_ccpr_matches_equivalent_complex_permittivity():
     assert rel_err < _TOLERANCE, (
         f"CCPR transmission T={T_ccpr:.4f} disagrees with equivalent complex-ε "
         f"T={T_equiv:.4f} (ε(ω)={eps_omega:.3f}), rel_err={rel_err:.3f} > {_TOLERANCE}"
+    )
+
+
+@pytest.mark.parametrize("integrator", ["central", "centered_edot", "bilinear"])
+def test_ccpr_matches_equivalent_complex_permittivity_all_integrators(integrator):
+    """Every integrator must reproduce the same target ε(ω) on the grid.
+
+    Same construction as :func:`test_ccpr_matches_equivalent_complex_permittivity`
+    but per scheme. The three schemes place the discrete pole differently — and
+    ``"bilinear"`` additionally routes a plain-Lorentz-shaped material through the
+    implicit divisor — so agreement with the equivalent non-dispersive lossy
+    half-space is an end-to-end check that each one integrates the ADE correctly,
+    not just that the coefficients look right on the host.
+    """
+    model = _ccpr_model().with_integrator(integrator)
+    assert all(p.integrator == integrator for p in model.poles)
+    eps_inf = 1.0
+    eps_omega = eps_inf + complex(model.susceptibility(_OMEGA))
+
+    obj0, con0, cfg0, vol0 = _build_base()
+    _add_flux_det("flux_t", _DET_CCPR_Z, vol0, obj0, con0)
+    S0 = _mean_flux(_run(obj0, con0, cfg0), "flux_t")
+    assert S0 > 0
+
+    obj1, con1, cfg1, vol1 = _build_base()
+    _add_half_space(fdtdx.Material(permittivity=eps_inf, dispersion=model), vol1, obj1, con1)
+    _add_flux_det("flux_t", _DET_CCPR_Z, vol1, obj1, con1)
+    S_ccpr = _mean_flux(_run(obj1, con1, cfg1), "flux_t")
+
+    obj2, con2, cfg2, vol2 = _build_base()
+    equiv = fdtdx.Material.from_complex_permittivity(eps_omega, frequency=c0 / _WAVELENGTH)
+    _add_half_space(equiv, vol2, obj2, con2)
+    _add_flux_det("flux_t", _DET_CCPR_Z, vol2, obj2, con2)
+    S_equiv = _mean_flux(_run(obj2, con2, cfg2), "flux_t")
+
+    assert S_ccpr > 0 and S_equiv > 0, f"{integrator}: flux vanished"
+    T_ccpr, T_equiv = S_ccpr / S0, S_equiv / S0
+    rel_err = abs(T_ccpr - T_equiv) / T_equiv
+    assert rel_err < _TOLERANCE, (
+        f"{integrator}: CCPR T={T_ccpr:.4f} vs equivalent complex-ε T={T_equiv:.4f} "
+        f"(ε(ω)={eps_omega:.3f}), rel_err={rel_err:.3f} > {_TOLERANCE}"
     )

--- a/tests/simulation/physics/test_oriented_dispersion.py
+++ b/tests/simulation/physics/test_oriented_dispersion.py
@@ -265,7 +265,7 @@ def test_monoclinic_oscillator_pair_is_stable():
     _, arrays = fdtdx.run_fdtd(arrays=arrays, objects=obj_container, config=cfg, key=key)
 
     assert bool(jnp.all(jnp.isfinite(arrays.fields.E))), "fields blew up in monoclinic medium"
-    assert bool(jnp.all(jnp.isfinite(arrays.fields.dispersive_P_curr)))
+    assert bool(jnp.all(jnp.isfinite(arrays.fields.dispersive_x1)))
     s_vac = _transmitted_flux(None, (_SQRT_HALF, _SQRT_HALF, 0.0))
     s_t = _mean_flux(arrays, "flux_t")
     assert 0.0 < s_t < s_vac, f"unphysical transmission through lossy monoclinic slab: {s_t} vs vacuum {s_vac}"

--- a/tests/unit/fdtd/test_initialization.py
+++ b/tests/unit/fdtd/test_initialization.py
@@ -697,13 +697,14 @@ def _make_arrays_mock(shape=(10, 10, 10)):
     arrays = Mock(spec=ArrayContainer)
     arrays.inv_permittivities = inv_perm
     arrays.inv_permeabilities = inv_permeab
-    arrays.dispersive_c1 = None
-    arrays.dispersive_c2 = None
-    arrays.dispersive_c3 = None
+    arrays.dispersive_a1 = None
+    arrays.dispersive_a0 = None
+    arrays.dispersive_b1 = None
     arrays.dispersive_c4 = None
+    arrays.dispersive_b0 = None
     arrays.electric_conductivity = None
-    arrays.dispersive_P_curr = None
-    arrays.dispersive_P_prev = None
+    arrays.dispersive_x1 = None
+    arrays.dispersive_y2 = None
     arrays.initial_inv_permittivities = None
     at_accessor = MagicMock()
 
@@ -714,10 +715,11 @@ def _make_arrays_mock(shape=(10, 10, 10)):
             result = Mock(spec=ArrayContainer)
             result.inv_permittivities = value if key == "inv_permittivities" else inv_perm
             result.inv_permeabilities = inv_permeab
-            result.dispersive_c1 = None
-            result.dispersive_c2 = None
-            result.dispersive_c3 = None
+            result.dispersive_a1 = None
+            result.dispersive_a0 = None
+            result.dispersive_b1 = None
             result.dispersive_c4 = None
+            result.dispersive_b0 = None
             result.electric_conductivity = None
             result.at = at_accessor
             return result
@@ -814,13 +816,14 @@ def test_apply_params_isotropic_components(mock_compute_perm):
     arrays = Mock(spec=ArrayContainer)
     arrays.inv_permittivities = inv_perm
     arrays.inv_permeabilities = inv_permeab
-    arrays.dispersive_c1 = None
-    arrays.dispersive_c2 = None
-    arrays.dispersive_c3 = None
+    arrays.dispersive_a1 = None
+    arrays.dispersive_a0 = None
+    arrays.dispersive_b1 = None
     arrays.dispersive_c4 = None
+    arrays.dispersive_b0 = None
     arrays.electric_conductivity = None
-    arrays.dispersive_P_curr = None
-    arrays.dispersive_P_prev = None
+    arrays.dispersive_x1 = None
+    arrays.dispersive_y2 = None
     arrays.initial_inv_permittivities = None
     at_accessor = MagicMock()
 
@@ -830,10 +833,11 @@ def test_apply_params_isotropic_components(mock_compute_perm):
             spec=ArrayContainer,
             inv_permittivities=v,
             inv_permeabilities=inv_permeab,
-            dispersive_c1=None,
-            dispersive_c2=None,
-            dispersive_c3=None,
+            dispersive_a1=None,
+            dispersive_a0=None,
+            dispersive_b1=None,
             dispersive_c4=None,
+            dispersive_b0=None,
             electric_conductivity=None,
             at=at_accessor,
         )
@@ -875,13 +879,14 @@ def test_apply_params_fully_anisotropic_continuous(mock_compute_perm):
     arrays = Mock(spec=ArrayContainer)
     arrays.inv_permittivities = inv_perm
     arrays.inv_permeabilities = inv_permeab
-    arrays.dispersive_c1 = None
-    arrays.dispersive_c2 = None
-    arrays.dispersive_c3 = None
+    arrays.dispersive_a1 = None
+    arrays.dispersive_a0 = None
+    arrays.dispersive_b1 = None
     arrays.dispersive_c4 = None
+    arrays.dispersive_b0 = None
     arrays.electric_conductivity = None
-    arrays.dispersive_P_curr = None
-    arrays.dispersive_P_prev = None
+    arrays.dispersive_x1 = None
+    arrays.dispersive_y2 = None
     arrays.initial_inv_permittivities = None
     at_accessor = MagicMock()
 
@@ -891,10 +896,11 @@ def test_apply_params_fully_anisotropic_continuous(mock_compute_perm):
             spec=ArrayContainer,
             inv_permittivities=v,
             inv_permeabilities=inv_permeab,
-            dispersive_c1=None,
-            dispersive_c2=None,
-            dispersive_c3=None,
+            dispersive_a1=None,
+            dispersive_a0=None,
+            dispersive_b1=None,
             dispersive_c4=None,
+            dispersive_b0=None,
             electric_conductivity=None,
             at=at_accessor,
         )
@@ -937,13 +943,14 @@ def test_apply_params_fully_anisotropic_discrete(mock_ste, mock_compute_perm):
     arrays = Mock(spec=ArrayContainer)
     arrays.inv_permittivities = inv_perm
     arrays.inv_permeabilities = inv_permeab
-    arrays.dispersive_c1 = None
-    arrays.dispersive_c2 = None
-    arrays.dispersive_c3 = None
+    arrays.dispersive_a1 = None
+    arrays.dispersive_a0 = None
+    arrays.dispersive_b1 = None
     arrays.dispersive_c4 = None
+    arrays.dispersive_b0 = None
     arrays.electric_conductivity = None
-    arrays.dispersive_P_curr = None
-    arrays.dispersive_P_prev = None
+    arrays.dispersive_x1 = None
+    arrays.dispersive_y2 = None
     arrays.initial_inv_permittivities = None
     at_accessor = MagicMock()
 
@@ -953,10 +960,11 @@ def test_apply_params_fully_anisotropic_discrete(mock_ste, mock_compute_perm):
             spec=ArrayContainer,
             inv_permittivities=v,
             inv_permeabilities=inv_permeab,
-            dispersive_c1=None,
-            dispersive_c2=None,
-            dispersive_c3=None,
+            dispersive_a1=None,
+            dispersive_a0=None,
+            dispersive_b1=None,
             dispersive_c4=None,
+            dispersive_b0=None,
             electric_conductivity=None,
             at=at_accessor,
         )
@@ -1003,13 +1011,14 @@ def test_apply_params_use_etching_continuous_isotropic(mock_compute_perm):
     arrays.initial_inv_permittivities = init_inv_perm
     arrays.inv_permittivities = init_inv_perm
     arrays.inv_permeabilities = inv_permeab
-    arrays.dispersive_c1 = None
-    arrays.dispersive_c2 = None
-    arrays.dispersive_c3 = None
+    arrays.dispersive_a1 = None
+    arrays.dispersive_a0 = None
+    arrays.dispersive_b1 = None
     arrays.dispersive_c4 = None
+    arrays.dispersive_b0 = None
     arrays.electric_conductivity = None
-    arrays.dispersive_P_curr = None
-    arrays.dispersive_P_prev = None
+    arrays.dispersive_x1 = None
+    arrays.dispersive_y2 = None
 
     at_accessor = MagicMock()
 
@@ -1021,13 +1030,14 @@ def test_apply_params_use_etching_continuous_isotropic(mock_compute_perm):
             result.inv_permittivities = value if key == "inv_permittivities" else arrays.inv_permittivities
             result.initial_inv_permittivities = arrays.initial_inv_permittivities
             result.inv_permeabilities = inv_permeab
-            result.dispersive_c1 = None
-            result.dispersive_c2 = None
-            result.dispersive_c3 = None
+            result.dispersive_a1 = None
+            result.dispersive_a0 = None
+            result.dispersive_b1 = None
             result.dispersive_c4 = None
+            result.dispersive_b0 = None
             result.electric_conductivity = None
-            result.dispersive_P_curr = None
-            result.dispersive_P_prev = None
+            result.dispersive_x1 = None
+            result.dispersive_y2 = None
             result.at = at_accessor
             return result
 
@@ -1084,13 +1094,14 @@ def test_apply_params_use_etching_continuous_fully_anisotropic(mock_compute_perm
     arrays.initial_inv_permittivities = init_inv_perm
     arrays.inv_permittivities = init_inv_perm
     arrays.inv_permeabilities = inv_permeab
-    arrays.dispersive_c1 = None
-    arrays.dispersive_c2 = None
-    arrays.dispersive_c3 = None
+    arrays.dispersive_a1 = None
+    arrays.dispersive_a0 = None
+    arrays.dispersive_b1 = None
     arrays.dispersive_c4 = None
+    arrays.dispersive_b0 = None
     arrays.electric_conductivity = None
-    arrays.dispersive_P_curr = None
-    arrays.dispersive_P_prev = None
+    arrays.dispersive_x1 = None
+    arrays.dispersive_y2 = None
 
     at_accessor = MagicMock()
 
@@ -1102,13 +1113,14 @@ def test_apply_params_use_etching_continuous_fully_anisotropic(mock_compute_perm
             result.inv_permittivities = value if key == "inv_permittivities" else arrays.inv_permittivities
             result.initial_inv_permittivities = arrays.initial_inv_permittivities
             result.inv_permeabilities = inv_permeab
-            result.dispersive_c1 = None
-            result.dispersive_c2 = None
-            result.dispersive_c3 = None
+            result.dispersive_a1 = None
+            result.dispersive_a0 = None
+            result.dispersive_b1 = None
             result.dispersive_c4 = None
+            result.dispersive_b0 = None
             result.electric_conductivity = None
-            result.dispersive_P_curr = None
-            result.dispersive_P_prev = None
+            result.dispersive_x1 = None
+            result.dispersive_y2 = None
             result.at = at_accessor
             return result
 

--- a/tests/unit/objects/detectors/test_mode_custom.py
+++ b/tests/unit/objects/detectors/test_mode_custom.py
@@ -14,7 +14,7 @@ import pytest
 
 from fdtdx.core.physics.metrics import compute_poynting_flux
 from fdtdx.core.wavelength import WaveCharacter
-from fdtdx.dispersion import LorentzPole, compute_pole_coefficients, effective_inv_permittivity
+from fdtdx.dispersion import LorentzPole, compute_pole_delta_coefficients_per_axis, effective_inv_permittivity
 from fdtdx.objects.detectors.mode import (
     BaseModeOverlapDetector,
     CustomModeOverlapDetector,
@@ -234,15 +234,15 @@ class TestDispersionHandling:
 
     @staticmethod
     def _dispersive_coeffs(det, pole):
-        """Single-pole Lorentz ADE coefficients for a test medium."""
+        """Single-pole Lorentz ADE coefficients (delta basis) for a test medium."""
         dt = det._config.time_step_duration
-        c1, c2, c3, c4 = compute_pole_coefficients((pole,), dt)
+        a1, a0, b1, c4, b0 = compute_pole_delta_coefficients_per_axis((pole,), dt)
 
         def mk(a):  # broadcast a per-pole scalar to (num_poles, 1, Nx, Ny, Nz)
             """Build a placed detector for the given mode function."""
-            return jnp.full((1, 1, 8, 8, 8), float(a[0]), dtype=jnp.float32)
+            return jnp.full((1, 1, 8, 8, 8), float(a[0, 0]), dtype=jnp.float32)  # isotropic -> axis x
 
-        return mk(c1), mk(c2), mk(c3), mk(c4), dt
+        return mk(a1), mk(a0), mk(b1), mk(c4), mk(b0), dt
 
     def test_gaussian_and_custom_use_effective_permittivity(self, simulation_config, plane_grid_slice, random_key):
         """Both analytic detectors see eps(omega_c), not eps_infinity."""
@@ -254,20 +254,29 @@ class TestDispersionHandling:
 
         det = GaussianModeOverlapDetector(wave_characters=[wc], mode_radius=3e-7, direction="+")
         det = det.place_on_grid(plane_grid_slice, simulation_config, random_key)
-        c1, c2, c3, c4, dt = self._dispersive_coeffs(det, pole)
+        a1, a0, b1, c4, b0, dt = self._dispersive_coeffs(det, pole)
 
         # Independently compute the expected effective index on the detector plane slice,
         # using the very same helper apply() calls internally.
         sl = (slice(None), slice(0, 8), slice(0, 8), slice(0, 1))
         csl = (slice(None), slice(None), slice(0, 8), slice(0, 8), slice(0, 1))
-        inv_eps_eff = effective_inv_permittivity(inv_eps[sl], c1[csl], c2[csl], c3[csl], omega, dt, c4=c4[csl])
+        inv_eps_eff = effective_inv_permittivity(
+            inv_eps[sl], a1[csl], a0[csl], b1[csl], omega, dt, c4=c4[csl], b0=b0[csl]
+        )
         n_eff_expected = float(jnp.sqrt(jnp.mean(1.0 / inv_eps_eff)))
         assert abs(n_eff_expected - eps_inf**0.5) > 1e-3  # the pole genuinely shifts the index
 
         # Gaussian: without dispersion args -> ε∞; with them -> ε(ω_c).
         n_inf = det.apply(random_key, inv_eps, 1.0)._mode_neff[0]
         n_disp = det.apply(
-            random_key, inv_eps, 1.0, dispersive_c1=c1, dispersive_c2=c2, dispersive_c3=c3, dispersive_c4=c4
+            random_key,
+            inv_eps,
+            1.0,
+            dispersive_a1=a1,
+            dispersive_a0=a0,
+            dispersive_b1=b1,
+            dispersive_c4=c4,
+            dispersive_b0=b0,
         )._mode_neff[0]
         assert float(jnp.real(n_inf)) == pytest.approx(eps_inf**0.5, rel=1e-5)
         assert float(jnp.real(n_disp)) == pytest.approx(n_eff_expected, rel=1e-4)
@@ -276,7 +285,14 @@ class TestDispersionHandling:
         cdet = CustomModeOverlapDetector(wave_characters=[wc], mode_function=_constant_mode_function)
         cdet = cdet.place_on_grid(plane_grid_slice, simulation_config, random_key)
         cdet = cdet.apply(
-            random_key, inv_eps, 1.0, dispersive_c1=c1, dispersive_c2=c2, dispersive_c3=c3, dispersive_c4=c4
+            random_key,
+            inv_eps,
+            1.0,
+            dispersive_a1=a1,
+            dispersive_a0=a0,
+            dispersive_b1=b1,
+            dispersive_c4=c4,
+            dispersive_b0=b0,
         )
         assert float(jnp.real(cdet._mode_neff[0])) == pytest.approx(n_eff_expected, rel=1e-4)
 

--- a/tests/unit/test_dispersion.py
+++ b/tests/unit/test_dispersion.py
@@ -13,7 +13,11 @@ from fdtdx.dispersion import (
     compute_pole_coefficients,
     compute_pole_coefficients_per_axis,
     compute_pole_coefficients_tensor,
+    compute_pole_delta_coefficients_per_axis,
+    compute_pole_delta_coefficients_tensor,
     susceptibility_from_coefficients,
+    to_delta_form,
+    to_observer_form,
 )
 from fdtdx.materials import (
     Material,
@@ -86,7 +90,7 @@ class TestDispersionModel:
 
 class TestComputePoleCoefficients:
     def test_empty_poles_returns_empty_arrays(self):
-        c1, c2, c3, c4 = compute_pole_coefficients((), dt=1e-17)
+        c1, c2, c3, c4, _ = compute_pole_coefficients((), dt=1e-17)
         assert c1.shape == (0,)
         assert c2.shape == (0,)
         assert c3.shape == (0,)
@@ -95,7 +99,7 @@ class TestComputePoleCoefficients:
     def test_lorentz_coefficients_closed_form(self):
         p = LorentzPole(resonance_frequency=2e15, damping=3e13, delta_epsilon=1.5)
         dt = 5e-18
-        c1, c2, c3, c4 = compute_pole_coefficients((p,), dt=dt)
+        c1, c2, c3, c4, _ = compute_pole_coefficients((p,), dt=dt)
         denom = 1.0 + 0.5 * p.gamma * dt
         exp_c1 = (2.0 - p.omega_0**2 * dt**2) / denom
         exp_c2 = -(1.0 - 0.5 * p.gamma * dt) / denom
@@ -109,7 +113,7 @@ class TestComputePoleCoefficients:
     def test_drude_coefficients_closed_form(self):
         p = DrudePole(plasma_frequency=1e16, damping=1e14)
         dt = 2e-18
-        c1, c2, c3, c4 = compute_pole_coefficients((p,), dt=dt)
+        c1, c2, c3, c4, _ = compute_pole_coefficients((p,), dt=dt)
         denom = 1.0 + 0.5 * p.gamma * dt
         # omega_0 = 0 for Drude -> c1 = 2/denom
         assert c1[0] == pytest.approx(2.0 / denom, rel=1e-12)
@@ -118,10 +122,10 @@ class TestComputePoleCoefficients:
         assert c4[0] == 0.0
 
     def test_coefficients_physical_regime_c2_near_minus_one(self):
-        # For gamma*dt << 1, c2 should be very close to -1 (makes reverse
-        # recurrence numerically well-conditioned).
+        # For gamma*dt << 1, c2 should be very close to -1 (the near-lossless
+        # oscillator limit).
         p = LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0)
-        _, c2, _, _ = compute_pole_coefficients((p,), dt=1e-17)
+        _, c2, _, _, _ = compute_pole_coefficients((p,), dt=1e-17)
         assert abs(c2[0] + 1.0) < 2e-4
 
     def test_multiple_poles(self):
@@ -129,7 +133,7 @@ class TestComputePoleCoefficients:
             LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0),
             DrudePole(plasma_frequency=5e15, damping=1e14),
         )
-        c1, _, c3, _ = compute_pole_coefficients(poles, dt=5e-18)
+        c1, _, c3, _, _ = compute_pole_coefficients(poles, dt=5e-18)
         assert c1.shape == (2,)
         # c3 for Drude should be non-zero because coupling_sq = omega_p**2
         assert c3[1] > 0
@@ -145,7 +149,7 @@ class TestComputePoleCoefficients:
         p = LorentzPole(resonance_frequency=1e12, damping=1e16, delta_epsilon=2.0)
         dt = 2.0 / p.gamma
         assert p.omega_0 * dt < 2.0
-        c1, c2, c3, _ = compute_pole_coefficients((p,), dt=dt)
+        c1, c2, c3, _, _ = compute_pole_coefficients((p,), dt=dt)
         assert np.all(np.isfinite(c1)) and np.all(np.isfinite(c3))
         assert np.allclose(c2, 0.0), "gamma * dt == 2 must put c2 exactly at zero"
 
@@ -159,7 +163,7 @@ class TestComputePoleCoefficients:
     def test_omega0_dt_just_below_two_is_ok(self):
         # Just under the bound must not raise.
         p = LorentzPole(resonance_frequency=1e15, damping=1e10, delta_epsilon=2.0)
-        c1, _, _, _ = compute_pole_coefficients((p,), dt=1.9 / p.omega_0)
+        c1, _, _, _, _ = compute_pole_coefficients((p,), dt=1.9 / p.omega_0)
         assert np.isfinite(c1[0])
 
     def test_zero_coupling_pole_skips_bounds(self):
@@ -167,7 +171,7 @@ class TestComputePoleCoefficients:
         # 0, so c3 = 0 and the polarization stays zero); its unused omega_0 / gamma
         # must not trip the stability bounds even when both products exceed 2.
         p = LorentzPole(resonance_frequency=3e17, damping=3e17, delta_epsilon=0.0)
-        c1, c2, c3, c4 = compute_pole_coefficients((p,), dt=1e-17)
+        c1, c2, c3, c4, _ = compute_pole_coefficients((p,), dt=1e-17)
         assert c3[0] == 0.0 and c4[0] == 0.0
         assert np.isfinite(c1[0]) and np.isfinite(c2[0])
 
@@ -195,10 +199,10 @@ class TestAllowedDispersiveCoefficients:
             "air": Material(permittivity=1.0),
             "si": Material(permittivity=11.7),
         }
-        c1, c2, c3, c4 = compute_allowed_dispersive_coefficients(mats, dt=1e-17, max_num_poles=0, num_components=1)
-        assert c1.shape == (2, 0, 1)
-        assert c2.shape == (2, 0, 1)
-        assert c3.shape == (2, 0, 1)
+        a1, a0, b1, c4, _ = compute_allowed_dispersive_coefficients(mats, dt=1e-17, max_num_poles=0, num_components=1)
+        assert a1.shape == (2, 0, 1)
+        assert a0.shape == (2, 0, 1)
+        assert b1.shape == (2, 0, 1)
         assert c4.shape == (2, 0, 1)
 
     def test_max_num_dispersive_poles_helper(self):
@@ -235,7 +239,7 @@ class TestAllowedDispersiveCoefficients:
                 ),
             ),
         }
-        c1, c2, c3, c4 = compute_allowed_dispersive_coefficients(mats, dt=1e-17, max_num_poles=2, num_components=1)
+        c1, c2, c3, c4, _ = compute_allowed_dispersive_coefficients(mats, dt=1e-17, max_num_poles=2, num_components=1)
         assert c1.shape == (3, 2, 1)
         # Lorentz/Drude materials have no dE/dt coupling -> c4 all zero.
         assert np.all(c4 == 0.0)
@@ -286,7 +290,7 @@ class TestCCPRPole:
         # from Lorentz/Drude — it produces b = coupling_edot != 0.
         p = CCPRPole(pole=complex(-1e13, -2e15), residue=complex(7e14, 3e14))
         assert p.coupling_edot != 0.0
-        _, _, _, c4 = compute_pole_coefficients((p,), dt=1e-17)
+        _, _, _, c4, _ = compute_pole_coefficients((p,), dt=1e-17)
         assert c4[0] != 0.0
 
     def test_lorentz_is_ccpr_special_case(self):
@@ -306,26 +310,38 @@ class TestCCPRPole:
             assert ccpr.susceptibility(omega) == pytest.approx(lorentz.susceptibility(omega), rel=1e-9)
 
     def test_coefficients_closed_form(self):
+        """Closed form of the default ``"centered_edot"`` scheme: the b*dE/dt term is
+        centred, so it splits symmetrically between c4 and c5 and leaves c3 = a*dt^2/D.
+        The legacy ``"central"`` closed form is pinned separately in
+        :class:`TestIntegratorSchemes`."""
         p = CCPRPole(pole=complex(-2.0e13, -1.8e15), residue=complex(3.0e14, -6.0e14))
+        assert p.integrator == "centered_edot"
         dt = 4e-18
-        c1, c2, c3, c4 = compute_pole_coefficients((p,), dt=dt)
+        c1, c2, c3, c4, c5 = compute_pole_coefficients((p,), dt=dt)
         denom = 1.0 + 0.5 * p.gamma * dt
         assert c1[0] == pytest.approx((2.0 - p.omega_0**2 * dt**2) / denom, rel=1e-12)
         assert c2[0] == pytest.approx(-(1.0 - 0.5 * p.gamma * dt) / denom, rel=1e-12)
-        assert c3[0] == pytest.approx((p.coupling_sq * dt**2 - p.coupling_edot * dt) / denom, rel=1e-12)
-        assert c4[0] == pytest.approx((p.coupling_edot * dt) / denom, rel=1e-12)
+        assert c3[0] == pytest.approx((p.coupling_sq * dt**2) / denom, rel=1e-12)
+        assert c4[0] == pytest.approx((p.coupling_edot * dt) / (2.0 * denom), rel=1e-12)
+        assert c5[0] == pytest.approx(-(p.coupling_edot * dt) / (2.0 * denom), rel=1e-12)
 
     def test_susceptibility_from_coefficients_roundtrip(self):
-        # susceptibility_from_coefficients inverts (c1..c4) back to the exact
-        # continuous (omega_0, gamma, a, b) and re-evaluates chi — so it must
-        # reproduce the analytic model susceptibility.
+        # susceptibility_from_coefficients evaluates the discrete transfer function
+        # of the stored observer coefficients, which approximates the analytic model
+        # susceptibility to the scheme's O((omega*dt)^2) truncation.
         p = CCPRPole(pole=complex(-2.0e13, -1.8e15), residue=complex(3.0e14, -6.0e14))
         dt = 4e-18
-        c1, c2, c3, c4 = compute_pole_coefficients((p,), dt=dt)
+        a1, a0, b1, c4, b0 = to_delta_form(*compute_pole_coefficients((p,), dt=dt))
         m = DispersionModel(poles=(p,))
         for omega in (0.5e15, 1.3e15, 2.4e15):
             chi = susceptibility_from_coefficients(
-                c1=c1[:, None], c2=c2[:, None], c3=c3[:, None], omega=omega, dt=dt, c4=c4[:, None]
+                a1=a1[:, None],
+                a0=a0[:, None],
+                b1=b1[:, None],
+                omega=omega,
+                dt=dt,
+                c4=c4[:, None],
+                b0=b0[:, None],
             )
             assert complex(chi[0]) == pytest.approx(m.susceptibility(omega), rel=1e-3)
 
@@ -334,17 +350,20 @@ class TestCCPRPole:
         # for a CCPR pole to high precision.
         p = CCPRPole(pole=complex(-2.0e13, -1.8e15), residue=complex(3.0e14, -6.0e14))
         dt = 4e-18
-        c1, c2, c3, c4 = compute_pole_coefficients((p,), dt=dt)
+        a1, a0, b1, c4, b0 = to_delta_form(*compute_pole_coefficients((p,), dt=dt))
         eps_inf = 2.25
         # shape coefficients to (num_poles, 1, 1) and inv_eps to (1, 1)
-        c1a, c2a, c3a, c4a = (x[:, None, None] for x in (c1, c2, c3, c4))
+        a1a, a0a, b1a, c4a, b0a = (x[:, None, None] for x in (a1, a0, b1, c4, b0))
         inv_eps = np.full((1, 1), 1.0 / eps_inf)
         omegas = np.array([0.7e15, 1.9e15, 3.0e15])
-        eps = compute_eps_spectrum_from_coefficients(c1a, c2a, c3a, inv_eps, omegas, dt, c4=c4a)
+        eps = compute_eps_spectrum_from_coefficients(a1a, a0a, b1a, inv_eps, omegas, dt, c4=c4a, b0=b0a)
         m = DispersionModel(poles=(p,))
         for i, omega in enumerate(omegas):
+            # The helper returns the DISCRETE eps the grid realizes, so it differs
+            # from the continuum model by the scheme's O((omega*dt)^2) truncation
+            # (~1e-5 relative here at omega*dt ~ 1.2e-2).
             expected = eps_inf + m.susceptibility(float(omega))
-            assert eps[i] == pytest.approx(expected, rel=1e-9)
+            assert eps[i] == pytest.approx(expected, rel=1e-4)
 
     def test_from_critical_point_matches_closed_form(self):
         # from_critical_point maps (A, phi, Omega, Gamma) to (q, r) that reproduce
@@ -479,7 +498,7 @@ class TestPerAxisCoefficients:
         de = (1.0, 2.0, 3.0)
         p = LorentzPole(resonance_frequency=w0, damping=g, delta_epsilon=de)
         dt = 4e-18
-        c1, c2, c3, c4 = compute_pole_coefficients_per_axis((p,), dt=dt)
+        c1, c2, c3, c4, _ = compute_pole_coefficients_per_axis((p,), dt=dt)
         assert c1.shape == (1, 3)
         for ax in range(3):
             denom = 1.0 + 0.5 * g[ax] * dt
@@ -489,7 +508,7 @@ class TestPerAxisCoefficients:
             assert c4[0, ax] == 0.0
 
     def test_empty_poles_return_empty_arrays(self):
-        c1, _c2, _c3, c4 = compute_pole_coefficients_per_axis((), dt=1e-17)
+        c1, _c2, _c3, c4, _ = compute_pole_coefficients_per_axis((), dt=1e-17)
         assert c1.shape == (0, 3)
         assert c4.shape == (0, 3)
 
@@ -499,8 +518,8 @@ class TestPerAxisCoefficients:
             DrudePole(plasma_frequency=2e15, damping=5e13),
         )
         dt = 4e-18
-        c1s, c2s, c3s, c4s = compute_pole_coefficients(poles, dt=dt)
-        c1a, c2a, c3a, c4a = compute_pole_coefficients_per_axis(poles, dt=dt)
+        c1s, c2s, c3s, c4s, _ = compute_pole_coefficients(poles, dt=dt)
+        c1a, c2a, c3a, c4a, _ = compute_pole_coefficients_per_axis(poles, dt=dt)
         assert c1s.shape == (2,)
         for scalar, axes in ((c1s, c1a), (c2s, c2a), (c3s, c3a), (c4s, c4a)):
             assert np.array_equal(scalar, axes[:, 0])
@@ -516,7 +535,7 @@ class TestPerAxisCoefficients:
         # A large gamma on the y axis alone is not a stability violation (only
         # omega_0 * dt >= 2 is); the coefficients must stay finite.
         p = LorentzPole(resonance_frequency=1e15, damping=(1e13, 3e17, 1e13), delta_epsilon=1.0)
-        c1, c2, c3, _ = compute_pole_coefficients_per_axis((p,), dt=1e-17)
+        c1, c2, c3, _, _ = compute_pole_coefficients_per_axis((p,), dt=1e-17)
         assert np.all(np.isfinite(c1)) and np.all(np.isfinite(c2)) and np.all(np.isfinite(c3))
 
     def test_per_axis_omega0_stability_check_names_axis(self):
@@ -533,7 +552,7 @@ class TestPerAxisCoefficients:
             damping=(1e13, 3e17, 3e17),
             delta_epsilon=(2.0, 0.0, 0.0),
         )
-        c1, c2, c3, _ = compute_pole_coefficients_per_axis((p,), dt=1e-17)
+        c1, c2, c3, _, _ = compute_pole_coefficients_per_axis((p,), dt=1e-17)
         # Inert axes carry zero coupling; the active x axis is fine (omega_0*dt<2).
         assert c3[0, 1] == 0.0 and c3[0, 2] == 0.0
         assert np.all(np.isfinite(c1)) and np.all(np.isfinite(c2))
@@ -543,35 +562,37 @@ class TestPerAxisCoefficients:
         # the per-axis susceptibilities (mirroring its eps_inf reduction).
         p = LorentzPole(resonance_frequency=(1e15, 2e15, 1.5e15), damping=1e13, delta_epsilon=(2.0, 1.0, 0.5))
         dt = 4e-18
-        c1, c2, c3, c4 = compute_pole_coefficients_per_axis((p,), dt=dt)
+        a1, a0, b1, c4, b0 = compute_pole_delta_coefficients_per_axis((p,), dt=dt)
         # shape (num_poles, 3, 1) with a single spatial cell
-        c1a, c2a, c3a, c4a = (x[:, :, None] for x in (c1, c2, c3, c4))
+        a1a, a0a, b1a, c4a, b0a = (x[:, :, None] for x in (a1, a0, b1, c4, b0))
         eps_inf = 2.25
         inv_eps = np.full((1, 1), 1.0 / eps_inf)
         omegas = np.array([0.7e15, 1.9e15])
-        eps = compute_eps_spectrum_from_coefficients(c1a, c2a, c3a, inv_eps, omegas, dt, c4=c4a)
+        eps = compute_eps_spectrum_from_coefficients(a1a, a0a, b1a, inv_eps, omegas, dt, c4=c4a, b0=b0a)
         m = DispersionModel(poles=(p,))
         for i, omega in enumerate(omegas):
             chi_axes = m.susceptibility_axes(float(omega))
             expected = eps_inf + sum(chi_axes) / 3.0
-            assert eps[i] == pytest.approx(expected, rel=1e-9)
+            # Discrete vs continuum: O((omega*dt)^2) truncation, see above.
+            assert eps[i] == pytest.approx(expected, rel=1e-4)
 
     def test_eps_spectrum_tensor_eps_inf_inverted_properly(self):
         # inv_eps_inf stores the inverse tensor: with off-diagonal entries,
         # diag(eps) != 1/diag(eps^-1), so the helper must invert per cell.
         p = LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0, orientation=(1.0, 1.0, 0.0))
         dt = 4e-18
-        c1, c2, c3, c4 = compute_pole_coefficients_tensor((p,), dt)
-        c1a, c2a, c3a, c4a = (x[:, :, None] for x in (c1, c2, c3, c4))
+        a1, a0, b1, c4, b0 = compute_pole_delta_coefficients_tensor((p,), dt)
+        a1a, a0a, b1a, c4a, b0a = (x[:, :, None] for x in (a1, a0, b1, c4, b0))
         eps_inf_mat = np.array([[2.5, 0.4, 0.0], [0.4, 2.0, 0.1], [0.0, 0.1, 3.0]])
         inv_eps = np.linalg.inv(eps_inf_mat).reshape(9, 1)
         omegas = np.array([0.7e15, 1.3e15])
-        eps = compute_eps_spectrum_from_coefficients(c1a, c2a, c3a, inv_eps, omegas, dt, c4=c4a)
+        eps = compute_eps_spectrum_from_coefficients(a1a, a0a, b1a, inv_eps, omegas, dt, c4=c4a, b0=b0a)
         m = DispersionModel(poles=(p,))
         for i, omega in enumerate(omegas):
             chi = m.susceptibility_tensor(float(omega))
             expected = np.trace(eps_inf_mat) / 3.0 + np.trace(chi) / 3.0
-            assert eps[i] == pytest.approx(expected, rel=1e-6)
+            # Discrete vs continuum: O((omega*dt)^2) truncation, see above.
+            assert eps[i] == pytest.approx(expected, rel=1e-4)
 
 
 class TestAllowedDispersiveCoefficientsPerAxis:
@@ -591,12 +612,12 @@ class TestAllowedDispersiveCoefficientsPerAxis:
                 ),
             ),
         }
-        c1, _c2, c3, _c4 = compute_allowed_dispersive_coefficients(mats, dt=1e-17, max_num_poles=1, num_components=3)
-        assert c1.shape == (2, 1, 3)
+        a1, _a0, b1, _c4, _ = compute_allowed_dispersive_coefficients(mats, dt=1e-17, max_num_poles=1, num_components=3)
+        assert a1.shape == (2, 1, 3)
         # air row is all zero
-        assert np.all(c1[0] == 0.0)
+        assert np.all(a1[0] == 0.0)
         # per-axis columns differ for the anisotropic material
-        assert c3[1, 0, 0] != c3[1, 0, 2]
+        assert b1[1, 0, 0] != b1[1, 0, 2]
 
     def test_num_components_one_with_anisotropic_material_raises(self):
         mats = {
@@ -656,7 +677,7 @@ class TestOrientedPoles:
     def test_tensor_coefficients_closed_form(self):
         p = LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0, orientation=(1.0, 1.0, 0.0))
         dt = 4e-18
-        c1, _c2, c3, c4 = compute_pole_coefficients_tensor((p,), dt)
+        c1, _c2, c3, c4, _ = compute_pole_coefficients_tensor((p,), dt)
         assert c1.shape == (1, 3) and c3.shape == (1, 9)
         u = np.asarray(p.orientation)
         denom = 1.0 + 0.5 * p.gamma * dt
@@ -670,8 +691,8 @@ class TestOrientedPoles:
     def test_tensor_coefficients_per_axis_pole_is_diagonal(self):
         pa = LorentzPole(resonance_frequency=(1e15, 2e15, 3e15), damping=1e13, delta_epsilon=(1.0, 2.0, 3.0))
         dt = 4e-18
-        _, _, c3t, _ = compute_pole_coefficients_tensor((pa,), dt)
-        _, _, c3a, _ = compute_pole_coefficients_per_axis((pa,), dt)
+        _, _, c3t, _, _ = compute_pole_coefficients_tensor((pa,), dt)
+        _, _, c3a, _, _ = compute_pole_coefficients_per_axis((pa,), dt)
         assert np.allclose(c3t[0].reshape(3, 3), np.diag(c3a[0]))
 
     def test_tensor_coefficients_negative_coupling_raises(self):
@@ -769,10 +790,16 @@ class TestMixedTierSampling:
     def test_susceptibility_from_coefficients_9_coupling(self):
         p = LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0, orientation=(1.0, 1.0, 0.0))
         dt = 4e-18
-        c1, c2, c3, c4 = compute_pole_coefficients_tensor((p,), dt)
+        a1, a0, b1, c4, b0 = compute_pole_delta_coefficients_tensor((p,), dt)
         omega = 1.3e15
         chi = susceptibility_from_coefficients(
-            c1=c1[:, :, None], c2=c2[:, :, None], c3=c3[:, :, None], omega=omega, dt=dt, c4=c4[:, :, None]
+            a1=a1[:, :, None],
+            a0=a0[:, :, None],
+            b1=b1[:, :, None],
+            omega=omega,
+            dt=dt,
+            c4=c4[:, :, None],
+            b0=b0[:, :, None],
         )
         assert chi.shape == (9, 1)
         m = DispersionModel(poles=(p,))
@@ -790,13 +817,14 @@ class TestMixedTierSampling:
         inv_eps = jnp.zeros((9, 2, 1, 1)).at[(0, 4, 8), :].set(1.0)
         p = LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=2.0, orientation=(1.0, 1.0, 0.0))
         dt = 4e-18
-        c1, c2, c3, _c4 = compute_pole_coefficients_tensor((p,), dt)
+        a1, a0, b1, _c4, b0 = compute_pole_delta_coefficients_tensor((p,), dt)
         # pole only in cell 0
-        c1a = jnp.zeros((1, 3, 2, 1, 1)).at[:, :, 0].set(c1[0][None, :, None, None])
-        c2a = jnp.zeros((1, 3, 2, 1, 1)).at[:, :, 0].set(c2[0][None, :, None, None])
-        c3a = jnp.zeros((1, 9, 2, 1, 1)).at[:, :, 0].set(c3[0][None, :, None, None])
+        a1a = jnp.zeros((1, 3, 2, 1, 1)).at[:, :, 0].set(a1[0][None, :, None, None])
+        a0a = jnp.zeros((1, 3, 2, 1, 1)).at[:, :, 0].set(a0[0][None, :, None, None])
+        b1a = jnp.zeros((1, 9, 2, 1, 1)).at[:, :, 0].set(b1[0][None, :, None, None])
+        b0a = jnp.zeros((1, 9, 2, 1, 1)).at[:, :, 0].set(b0[0][None, :, None, None])
         omega = 1.3e15
-        result = effective_inv_permittivity(inv_eps, c1a, c2a, c3a, omega, dt)
+        result = effective_inv_permittivity(inv_eps, a1a, a0a, b1a, omega, dt, b0=b0a)
         assert result.shape == (9, 2, 1, 1)
         assert bool(jnp.all(jnp.isfinite(result)))
         # vacuum cell stays identity
@@ -825,12 +853,12 @@ class TestAllowedCoefficientsCoupling:
         }
         with pytest.raises(ValueError, match="axis-aligned"):
             compute_allowed_dispersive_coefficients(mats, dt=1e-17, max_num_poles=1, num_components=3)
-        c1, _, c3, _ = compute_allowed_dispersive_coefficients(
+        a1, _, b1, _, _ = compute_allowed_dispersive_coefficients(
             mats, dt=1e-17, max_num_poles=1, num_components=3, coupling_components=9
         )
-        assert c1.shape == (1, 1, 3)
-        assert c3.shape == (1, 1, 9)
-        assert c3[0, 0, 1] != 0.0  # off-diagonal weight present
+        assert a1.shape == (1, 1, 3)
+        assert b1.shape == (1, 1, 9)
+        assert b1[0, 0, 1] != 0.0  # off-diagonal weight present
 
     def test_diagonal_material_reduces_exactly(self):
         mats = {
@@ -841,15 +869,15 @@ class TestAllowedCoefficientsCoupling:
                 ),
             ),
         }
-        _, _, c3_full, _ = compute_allowed_dispersive_coefficients(
+        _, _, b1_full, _, _ = compute_allowed_dispersive_coefficients(
             mats, dt=1e-17, max_num_poles=1, num_components=3, coupling_components=9
         )
-        _, _, c3_diag, _ = compute_allowed_dispersive_coefficients(
+        _, _, b1_diag, _, _ = compute_allowed_dispersive_coefficients(
             mats, dt=1e-17, max_num_poles=1, num_components=3, coupling_components=3
         )
-        assert np.allclose(c3_full[0, 0, (0, 4, 8)], c3_diag[0, 0])
+        assert np.allclose(b1_full[0, 0, (0, 4, 8)], b1_diag[0, 0])
         off_diag = [i for i in range(9) if i not in (0, 4, 8)]
-        assert np.allclose(c3_full[0, 0, off_diag], 0.0)
+        assert np.allclose(b1_full[0, 0, off_diag], 0.0)
 
     def test_per_axis_material_with_scalar_coupling_raises(self):
         # coupling_components=1 keeps only the xx entry, which would silently
@@ -866,3 +894,451 @@ class TestAllowedCoefficientsCoupling:
             compute_allowed_dispersive_coefficients(
                 mats, dt=1e-17, max_num_poles=1, num_components=3, coupling_components=1
             )
+
+
+class TestIntegratorSchemes:
+    """Per-pole time-integrator selection (central / centered_edot / bilinear)."""
+
+    # A gold-like critical point: complex pole and residue, so b = 2*Re(r) != 0.
+    Q = complex(-2.0e13, -1.8e15)
+    R = complex(3.0e14, -6.0e14)
+    DT = 1e-17
+
+    @staticmethod
+    def _chi_exact(omega, w0, gamma, a, b):
+        """Continuum susceptibility in the exp(-i omega t) convention."""
+        return (a - 1j * omega * b) / (w0**2 - omega**2 - 1j * gamma * omega)
+
+    @staticmethod
+    def _chi_discrete(omega, dt, c1, c2, c3, c4, c5):
+        """P-form transfer function chi_d(z) = (c4 z^2 + c3 z + c5)/(z^2 - c1 z - c2)."""
+        z = np.exp(-1j * omega * dt)
+        return (c4 * z * z + c3 * z + c5) / (z * z - c1 * z - c2)
+
+    def _scalars(self, scheme, dt=None):
+        p = CCPRPole(pole=self.Q, residue=self.R, integrator=scheme)
+        vals = compute_pole_coefficients((p,), dt=dt or self.DT)
+        return p, [float(v[0]) for v in vals]
+
+    def test_default_integrator_is_centered_edot(self):
+        assert LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=1.0).integrator == "centered_edot"
+        assert DrudePole(plasma_frequency=1e16, damping=1e13).integrator == "centered_edot"
+        assert CCPRPole(pole=self.Q, residue=self.R).integrator == "centered_edot"
+        assert (
+            CCPRPole.from_critical_point(amplitude=1.0, phase=0.3, resonance_frequency=4e15, damping=1e14).integrator
+            == "centered_edot"
+        )
+
+    def test_unknown_integrator_raises(self):
+        with pytest.raises(ValueError, match="Unknown dispersion integrator"):
+            LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=1.0, integrator="trapezoid")
+
+    def test_central_reproduces_legacy_closed_form(self):
+        """Regression lock: 'central' must stay bit-identical to the pre-change scheme."""
+        p, (c1, c2, c3, c4, c5) = self._scalars("central")
+        w0, g, a, b, dt = p.omega_0, p.gamma, p.coupling_sq, p.coupling_edot, self.DT
+        d = 1.0 + g * dt / 2.0
+        assert c1 == (2.0 - w0**2 * dt**2) / d
+        assert c2 == -(1.0 - g * dt / 2.0) / d
+        assert c3 == (a * dt**2 - b * dt) / d
+        assert c4 == b * dt / d
+        assert c5 == 0.0
+
+    def test_centered_edot_halves_c4_and_mirrors_it_into_c5(self):
+        _, central = self._scalars("central")
+        _, centered = self._scalars("centered_edot")
+        assert centered[0] == central[0]  # c1 unchanged
+        assert centered[1] == central[1]  # c2 unchanged
+        assert centered[3] == pytest.approx(central[3] / 2.0, rel=1e-14)
+        assert centered[4] == pytest.approx(-central[3] / 2.0, rel=1e-14)
+
+    @pytest.mark.parametrize(
+        "pole",
+        [
+            LorentzPole(resonance_frequency=3e15, damping=1e14, delta_epsilon=2.0),
+            DrudePole(plasma_frequency=1.2e16, damping=8e13),
+            CCPRPole(pole=complex(-1e13, -2e15), residue=complex(0.0, 5e14)),  # purely imaginary residue -> b = 0
+        ],
+    )
+    def test_centered_edot_identical_to_central_when_b_is_zero(self, pole):
+        """The new default must not perturb any Lorentz/Drude material, bit for bit."""
+        assert pole.coupling_edot == 0.0
+        cen = compute_pole_coefficients((pole.aset("integrator", "centered_edot"),), dt=self.DT)
+        cnt = compute_pole_coefficients((pole.aset("integrator", "central"),), dt=self.DT)
+        for a, b in zip(cen, cnt):
+            np.testing.assert_array_equal(a, b)
+
+    @pytest.mark.parametrize("scheme", ["central", "centered_edot", "bilinear"])
+    def test_observer_form_reproduces_p_form_transfer_function(self, scheme):
+        """to_observer_form must be an exact realization, not an approximation."""
+        _, (c1, c2, c3, c4, c5) = self._scalars(scheme)
+        _, _, beta1, c4o, beta0 = to_observer_form(*(np.array(v) for v in (c1, c2, c3, c4, c5)))
+        omegas = np.linspace(0.05, 2.0, 11) / self.DT
+        z = np.exp(-1j * omegas * self.DT)
+        chi_obs = c4o + (beta1 * z + beta0) / (z * z - c1 * z - c2)
+        chi_pform = self._chi_discrete(omegas, self.DT, c1, c2, c3, c4, c5)
+        np.testing.assert_allclose(chi_obs, chi_pform, rtol=1e-12, atol=0.0)
+
+    @pytest.mark.parametrize(
+        "scheme, expected_order",
+        [("central", 1.0), ("centered_edot", 2.0), ("bilinear", 2.0)],
+    )
+    def test_convergence_order_in_chi(self, scheme, expected_order):
+        """'central' is only first order once b != 0; the other two are second order."""
+        omega = 2.2e15
+        p = CCPRPole(pole=self.Q, residue=self.R)
+        exact = self._chi_exact(omega, p.omega_0, p.gamma, p.coupling_sq, p.coupling_edot)
+        errs = []
+        for pts_per_period in (10, 40, 160):
+            dt = 2.0 * np.pi / (omega * pts_per_period)
+            _, coeffs = self._scalars(scheme, dt=dt)
+            errs.append(abs(self._chi_discrete(omega, dt, *coeffs) - exact) / abs(exact))
+        order = np.log(errs[0] / errs[-1]) / np.log(16.0)
+        assert order == pytest.approx(expected_order, abs=0.25), f"{scheme}: order {order:.2f}, errors {errs}"
+
+    def test_central_is_first_order_only_because_of_b(self):
+        """With b = 0 the 'central' scheme recovers second order, pinning the cause."""
+        omega = 2.2e15
+        pole_no_b = CCPRPole(pole=self.Q, residue=complex(0.0, self.R.imag), integrator="central")
+        exact = self._chi_exact(
+            omega, pole_no_b.omega_0, pole_no_b.gamma, pole_no_b.coupling_sq, pole_no_b.coupling_edot
+        )
+        errs = []
+        for pts in (10, 160):
+            dt = 2.0 * np.pi / (omega * pts)
+            coeffs = [float(v[0]) for v in compute_pole_coefficients((pole_no_b,), dt=dt)]
+            errs.append(abs(self._chi_discrete(omega, dt, *coeffs) - exact) / abs(exact))
+        order = np.log(errs[0] / errs[-1]) / np.log(16.0)
+        assert order == pytest.approx(2.0, abs=0.25)
+
+    @pytest.mark.parametrize("omega0_dt", [0.1, 1.99, 2.0, 10.0, 100.0])
+    def test_bilinear_is_unconditionally_stable(self, omega0_dt):
+        """Roots stay inside the unit circle for bilinear at every omega_0 * dt."""
+        dt = self.DT
+        pole = LorentzPole(
+            resonance_frequency=omega0_dt / dt,
+            damping=0.2 / dt,  # gamma * dt = 0.2, a clear damping margin
+            delta_epsilon=1.0,
+            integrator="bilinear",
+        )
+        c1, c2, _, _, _ = (float(v[0]) for v in compute_pole_coefficients((pole,), dt=dt))
+        assert max(abs(np.roots([1.0, -c1, -c2]))) < 1.0
+
+    @pytest.mark.parametrize("scheme", ["central", "centered_edot"])
+    def test_central_schemes_keep_the_omega0_dt_bound(self, scheme):
+        dt = self.DT
+        pole = LorentzPole(resonance_frequency=2.0 / dt, damping=0.2 / dt, delta_epsilon=1.0, integrator=scheme)
+        with pytest.raises(ValueError, match="omega_0 \\* dt"):
+            compute_pole_coefficients((pole,), dt=dt)
+
+    def test_bilinear_is_exact_at_dc(self):
+        """chi_d(z=1) == chi(0) = a / omega_0^2 for the bilinear map."""
+        p, (c1, c2, c3, c4, c5) = self._scalars("bilinear")
+        chi_dc = (c4 + c3 + c5) / (1.0 - c1 - c2)
+        assert chi_dc == pytest.approx(p.coupling_sq / p.omega_0**2, rel=1e-12)
+
+    def test_bilinear_rejected_for_oriented_poles(self):
+        with pytest.raises(NotImplementedError, match="bilinear"):
+            LorentzPole(
+                resonance_frequency=1e15,
+                damping=1e13,
+                delta_epsilon=1.0,
+                orientation=(1.0, 1.0, 0.0),
+                integrator="bilinear",
+            )
+
+    def test_with_integrator_switches_every_pole(self):
+        model = DispersionModel(
+            poles=(
+                LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=1.0),
+                CCPRPole(pole=self.Q, residue=self.R),
+            )
+        )
+        switched = model.with_integrator("bilinear")
+        assert [p.integrator for p in switched.poles] == ["bilinear", "bilinear"]
+        # original untouched (pytrees are immutable)
+        assert [p.integrator for p in model.poles] == ["centered_edot", "centered_edot"]
+
+    def test_with_integrator_rejects_bilinear_for_oriented_model(self):
+        model = DispersionModel(
+            poles=(LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=1.0, orientation=(0.0, 1.0, 0.0)),)
+        )
+        with pytest.raises(NotImplementedError, match="bilinear"):
+            model.with_integrator("bilinear")
+
+    def test_with_integrator_rejects_unknown_scheme(self):
+        model = DispersionModel(poles=(DrudePole(plasma_frequency=1e16, damping=1e13),))
+        with pytest.raises(ValueError, match="Unknown dispersion integrator"):
+            model.with_integrator("newmark")
+
+    def test_rotated_preserves_integrator(self):
+        model = DispersionModel(
+            poles=(LorentzPole(resonance_frequency=1e15, damping=1e13, delta_epsilon=(2.0, 1.0, 0.0)),)
+        )
+        rotated = model.rotated((0.0, 0.0, 0.3))
+        assert rotated.num_poles > 0
+        assert all(p.integrator == "centered_edot" for p in rotated.poles)
+
+
+class TestDivisorScheme:
+    """The implicit E-update divisor of a realistic metal CCPR fit.
+
+    Silver fit of Prokopidis & Zografopoulos-style CCPR data (as used by
+    ``scripts/nanoparticle_sim_forward.py``). For a physical fit the total
+    1/omega tail must vanish, i.e. sum_p b_p = -sigma/eps0; the conductivity term
+    then cancels the 'centered_edot' c4 and the divisor sits near 1 at every
+    resolution, while 'central' puts twice that weight on E^{n+1} and marches
+    negative.
+    """
+
+    EPS_INF = 3.07
+    SIGMA = 1.49e7
+    POLES = (
+        (complex(-1.89e14, 0.0), complex(-1.00e18, 0.0)),
+        (complex(-5.46e14, -6.37e15), complex(1.30e15, 1.54e15)),
+        (complex(-5.68e14, -3.43e14), complex(1.61e17, 1.00e12)),
+    )
+
+    def _material(self, scheme):
+        model = DispersionModel(poles=tuple(CCPRPole(pole=q, residue=r, integrator=scheme) for q, r in self.POLES))
+        return Material(permittivity=self.EPS_INF, electric_conductivity=self.SIGMA, dispersion=model)
+
+    @staticmethod
+    def _dt(resolution_nm, courant_factor=0.8):
+        import math
+
+        from fdtdx import constants
+
+        return (courant_factor / math.sqrt(3.0)) * resolution_nm * 1e-9 / constants.c
+
+    def test_fit_is_physical_high_frequency_tail_cancels_conductivity(self):
+        """sum_p b_p == -sigma/eps0 to within the fit residual — the reason the
+        centered c4 and the trapezoidal conductivity term cancel."""
+        from fdtdx.constants import eps0
+
+        total_b = sum(2.0 * r.real for _, r in self.POLES)
+        assert total_b == pytest.approx(-self.SIGMA / eps0, rel=0.01)
+
+    @pytest.mark.parametrize(
+        "resolution_nm, central_divisor",
+        [(0.5, 0.7908), (1.0, 0.5816), (2.0, 0.1635), (4.0, -0.6717), (8.0, -2.3387)],
+    )
+    def test_central_divisor_collapses_with_resolution(self, resolution_nm, central_divisor):
+        from fdtdx.materials import _min_dispersive_divisor
+
+        div, _ = _min_dispersive_divisor(self._material("central"), self._dt(resolution_nm))
+        assert div == pytest.approx(central_divisor, abs=5e-4)
+
+    @pytest.mark.parametrize("resolution_nm", [0.5, 1.0, 2.0, 4.0, 8.0, 16.0])
+    @pytest.mark.parametrize("scheme", ["centered_edot", "bilinear"])
+    def test_second_order_schemes_keep_the_divisor_near_one(self, resolution_nm, scheme):
+        from fdtdx.materials import _min_dispersive_divisor
+
+        div, _ = _min_dispersive_divisor(self._material(scheme), self._dt(resolution_nm))
+        assert 0.9 < div < 1.1
+
+    def test_validator_rejects_central_and_accepts_centered(self):
+        from fdtdx.materials import validate_dispersive_divisor_stability
+
+        dt = self._dt(4.0)
+        with pytest.raises(ValueError, match="non-positive"):
+            validate_dispersive_divisor_stability({"Ag": self._material("central")}, dt=dt, courant_factor=0.8)
+        # no raise, no warning
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            validate_dispersive_divisor_stability({"Ag": self._material("centered_edot")}, dt=dt, courant_factor=0.8)
+
+    def test_validator_message_suggests_switching_integrator(self):
+        from fdtdx.materials import validate_dispersive_divisor_stability
+
+        with pytest.raises(ValueError, match="centered_edot"):
+            validate_dispersive_divisor_stability(
+                {"Ag": self._material("central")}, dt=self._dt(4.0), courant_factor=0.8
+            )
+
+    def test_validator_covers_bilinear_lorentz_despite_zero_edot(self):
+        """Under bilinear, c4 != 0 even at b = 0, so the 'skip Lorentz' shortcut
+        would wrongly bypass the check. A safe fit must still pass cleanly."""
+        import warnings
+
+        from fdtdx.materials import validate_dispersive_divisor_stability
+
+        model = DispersionModel(
+            poles=(LorentzPole(resonance_frequency=3e15, damping=1e14, delta_epsilon=2.0),)
+        ).with_integrator("bilinear")
+        mat = Material(permittivity=2.25, dispersion=model)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            validate_dispersive_divisor_stability({"lor": mat}, dt=self._dt(2.0), courant_factor=0.8)
+
+
+class TestDeltaBasis:
+    """The delta (zeta = z - 1) basis the FDTD loop stores and marches.
+
+    See the :mod:`fdtdx.dispersion` module docstring: storing ``a1 = 2 - c1`` and
+    ``a0 = 1 - c1 - c2`` instead of ``c1``/``c2`` is what makes float32
+    dispersion usable, because for a real pole ``a0`` is ``O((omega_0 dt)^2)`` —
+    orders of magnitude below the float32 resolution of ``c1 ~ 2`` itself.
+    """
+
+    # Gold's near-DC pole from the CCPR fit of Gedeon, Hassan & Cala Lesina,
+    # ACS Photonics 2023, 10, 3875 (Table 1): purely real pole and residue, so
+    # omega_0 = gamma / 2 and the ADE has a double root. Paired with the static
+    # conductivity sigma = 1.21e7 S/m whose 1/omega tail its `b` cancels.
+    AU_REAL_POLE = CCPRPole(pole=complex(-1.28e14, 0.0), residue=complex(-6.85e17, 0.0))
+    AU_COMPLEX_POLES = (
+        CCPRPole(pole=complex(-6.36e14, -3.89e15), residue=complex(2.06e15, 8.70e14)),
+        CCPRPole(pole=complex(-2.96e15, -6.12e15), residue=complex(1.60e13, 1.47e16)),
+    )
+    # dt at 1 nm / courant_factor 0.8 on a uniform 3D grid.
+    DT_1NM = 0.8 / np.sqrt(3.0) * 1e-9 / 299_792_458.0
+
+    ALL_POLES = (
+        LorentzPole(resonance_frequency=3e15, damping=1e14, delta_epsilon=2.0),
+        DrudePole(plasma_frequency=1.2e16, damping=8e13),
+        CCPRPole(pole=complex(-2.0e13, -1.8e15), residue=complex(3.0e14, -6.0e14)),
+        AU_REAL_POLE,
+    )
+
+    @pytest.mark.parametrize("scheme", ["central", "centered_edot", "bilinear"])
+    @pytest.mark.parametrize("pole", ALL_POLES)
+    def test_closed_forms_match_generic_conversion(self, pole, scheme):
+        """The cancellation-free closed forms agree with ``to_delta_form``.
+
+        Only to the accuracy the generic conversion can deliver: it forms
+        ``1 - c1 - c2`` from float64 O(1) numbers, so its ``a0`` carries an
+        absolute error of ~1e-16 regardless of how small ``a0`` really is.
+        """
+        p = pole.aset("integrator", scheme)
+        direct = compute_pole_delta_coefficients_per_axis((p,), dt=self.DT_1NM)
+        via_pform = to_delta_form(*compute_pole_coefficients_per_axis((p,), dt=self.DT_1NM))
+        for got, want in zip(direct, via_pform):
+            np.testing.assert_allclose(got, want, rtol=1e-6, atol=1e-15)
+
+    @pytest.mark.parametrize("scheme", ["central", "centered_edot", "bilinear"])
+    def test_closed_form_a0_is_exact_where_the_conversion_is_not(self, scheme):
+        """A Drude pole has omega_0 = 0, hence a0 == 0 *exactly* — the whole point.
+
+        ``1 - c1 - c2`` cannot deliver that: it lands on float64 round-off.
+        """
+        p = DrudePole(plasma_frequency=1.2e16, damping=8e13, integrator=scheme)
+        _, a0_direct, _, _, _ = compute_pole_delta_coefficients_per_axis((p,), dt=self.DT_1NM)
+        _, a0_conv, _, _, _ = to_delta_form(*compute_pole_coefficients_per_axis((p,), dt=self.DT_1NM))
+        np.testing.assert_array_equal(a0_direct, 0.0)
+        assert np.any(a0_conv != 0.0)
+
+    @pytest.mark.parametrize("scheme", ["central", "centered_edot", "bilinear"])
+    @pytest.mark.parametrize("pole", ALL_POLES)
+    def test_delta_form_reproduces_p_form_transfer_function(self, pole, scheme):
+        """The basis change must be exact, not an approximation."""
+        p = pole.aset("integrator", scheme)
+        c1, c2, c3, c4, c5 = (v[0, 0] for v in compute_pole_coefficients_per_axis((p,), dt=self.DT_1NM))
+        a1, a0, b1, c4d, b0 = (v[0, 0] for v in compute_pole_delta_coefficients_per_axis((p,), dt=self.DT_1NM))
+        omegas = np.linspace(0.02, 1.5, 17) / self.DT_1NM
+        z = np.exp(-1j * omegas * self.DT_1NM)
+        chi_pform = (c4 * z * z + c3 * z + c5) / (z * z - c1 * z - c2)
+        zeta = z - 1.0
+        chi_delta = c4d + (b1 * zeta + b0) / (zeta * zeta + a1 * zeta + a0)
+        np.testing.assert_allclose(chi_delta, chi_pform, rtol=1e-9, atol=0.0)
+
+    def test_zero_padded_slots_stay_all_zero(self):
+        """Padded pole slots must be inert, i.e. literally zero — not (a1, a0) = (2, 1).
+
+        ``to_delta_form`` applied to all-zero P-form coefficients would give
+        ``a1 = 2, a0 = 1``; the assembly path must zero-pad the delta
+        coefficients instead so ``b1 = b0 = 0`` pins the state at zero.
+        """
+        mats = {
+            "vacuum": Material(),
+            "gold": Material(permittivity=2.31, dispersion=DispersionModel(poles=(self.AU_REAL_POLE,))),
+        }
+        arrays = compute_allowed_dispersive_coefficients(mats, dt=self.DT_1NM, max_num_poles=3, num_components=1)
+        a1, a0, b1, _c4, _b0 = arrays
+        # gold carries one pole, so slots 1 and 2 are padding in every material
+        for arr in arrays:
+            assert arr.shape == (len(mats), 3, 1)
+            np.testing.assert_array_equal(arr[:, 1:], 0.0)
+        # the non-dispersive material is all-zero even in slot 0
+        non_disp_rows = [i for i in range(a1.shape[0]) if not np.any(b1[i])]
+        assert len(non_disp_rows) == 1
+        for arr in arrays:
+            np.testing.assert_array_equal(arr[non_disp_rows[0]], 0.0)
+        # ... and the dispersive one is not, so the test is not vacuously true
+        disp_row = 1 - non_disp_rows[0]
+        assert np.all(a1[disp_row, 0] > 0.0) and np.all(a0[disp_row, 0] > 0.0)
+
+    def test_det_equals_minus_c2(self):
+        """``1 - a1 + a0 == -c2`` pins the delta-basis denominator against the P-form."""
+        for scheme in ("central", "centered_edot", "bilinear"):
+            for pole in self.ALL_POLES:
+                p = pole.aset("integrator", scheme)
+                _, c2, _, _, _ = compute_pole_coefficients_per_axis((p,), dt=self.DT_1NM)
+                a1, a0, _, _, _ = compute_pole_delta_coefficients_per_axis((p,), dt=self.DT_1NM)
+                np.testing.assert_allclose(1.0 - a1 + a0, -c2, rtol=1e-12, atol=0.0)
+
+    def test_a0_is_quadratically_small_for_a_real_pole(self):
+        """The precision hazard itself: a0 sits far below the float32 ulp of c1."""
+        a1, a0, _, _, _ = compute_pole_delta_coefficients_per_axis((self.AU_REAL_POLE,), dt=self.DT_1NM)
+        # real pole: omega_0 = |q|, gamma = 2|q|, so with u = |q| dt and D = 1 + u
+        #   a1 = (2u + u^2) / D,   a0 = u^2 / D
+        u = abs(complex(self.AU_REAL_POLE.pole)) * self.DT_1NM
+        assert a0[0, 0] == pytest.approx(u**2 / (1.0 + u), rel=1e-9)
+        assert a1[0, 0] == pytest.approx((2.0 * u + u**2) / (1.0 + u), rel=1e-9)
+        # this is the whole problem: a0 is ~3.9e-8 while float32 resolves c1 ~ 2
+        # only to ~1.2e-7, so 1 - c1 - c2 in float32 would be pure noise
+        assert a0[0, 0] < np.spacing(np.float32(2.0))
+
+    def test_float32_storage_preserves_realized_eps_for_gold(self):
+        """Regression: the realized eps'' of the Au fit must survive a float32 cast.
+
+        Stored as ``(c1, c2, beta1, c4, beta0)`` this is wrong by tens of percent
+        at 1 nm and gets *worse* under refinement. In the delta basis the float32
+        cast must be a non-event.
+        """
+        eps0 = 8.8541878128e-12
+        poles = (self.AU_REAL_POLE, *self.AU_COMPLEX_POLES)
+        eps_inf, sigma = 2.31, 1.21e7
+        model = DispersionModel(poles=poles)
+        omega = 2.0 * np.pi * 299_792_458.0 / 560e-9
+
+        exact = eps_inf + model.susceptibility(omega) + 1j * sigma / (omega * eps0)
+        assert exact.imag == pytest.approx(1.2838, rel=1e-3)  # sanity: eps'' ~ 1.28
+
+        for dt in (self.DT_1NM, self.DT_1NM / 2.0, self.DT_1NM / 5.0):
+            coeffs = compute_pole_delta_coefficients_per_axis(poles, dt=dt)
+            a1, a0, b1, c4, b0 = (np.asarray(v[:, :1], dtype=np.float32) for v in coeffs)
+            chi = susceptibility_from_coefficients(a1, a0, b1, omega, dt, c4=c4, b0=b0)
+            realized = eps_inf + complex(np.asarray(chi)[0]) + 1j * sigma / (omega * eps0)
+            # 1% covers the scheme's own O((omega dt)^2) truncation at these dt;
+            # the float32 storage error is ~1e-3 of eps'' or better.
+            assert realized.imag == pytest.approx(exact.imag, rel=1e-2), f"dt={dt:g}"
+            assert realized.real == pytest.approx(exact.real, rel=1e-3), f"dt={dt:g}"
+
+    @pytest.mark.parametrize(
+        "pole",
+        [
+            LorentzPole(resonance_frequency=3e15, damping=1e14, delta_epsilon=2.0),
+            DrudePole(plasma_frequency=1.2e16, damping=8e13),
+            CCPRPole(pole=complex(-1e13, -2e15), residue=complex(0.0, 5e14)),  # b = 0
+        ],
+    )
+    @pytest.mark.parametrize("scheme", ["central", "centered_edot"])
+    def test_b0_equals_b1_exactly_when_no_pole_is_implicit(self, pole, scheme):
+        """``update_E`` substitutes ``b1`` for ``b0`` when the ``b0`` array is not
+        allocated. That is only sound if the two coincide *bit for bit* whenever
+        every pole has ``c4 = c5 = 0``, which is exactly the allocation condition.
+        """
+        p = pole.aset("integrator", scheme)
+        _, _, b1, c4, b0 = compute_pole_delta_coefficients_per_axis((p,), dt=self.DT_1NM)
+        np.testing.assert_array_equal(c4, 0.0)
+        np.testing.assert_array_equal(b0, b1)
+
+    def test_bilinear_always_allocates_b0(self):
+        """Under 'bilinear' even a b = 0 pole has c4 != 0, so b0 is always stored
+        and the b0-is-b1 substitution above is never reached."""
+        p = LorentzPole(resonance_frequency=3e15, damping=1e14, delta_epsilon=2.0, integrator="bilinear")
+        _, _, b1, c4, b0 = compute_pole_delta_coefficients_per_axis((p,), dt=self.DT_1NM)
+        assert np.all(c4 != 0.0)
+        assert np.any(b0 != b1)

--- a/tests/unit/test_dispersive_source_correction.py
+++ b/tests/unit/test_dispersive_source_correction.py
@@ -15,40 +15,39 @@ from fdtdx.dispersion import (
     LorentzPole,
     compute_eps_spectrum_from_coefficients,
     compute_impedance_corrected_temporal_profile,
-    compute_pole_coefficients,
+    compute_pole_delta_coefficients_per_axis,
 )
 
 _DT = 5e-18
 _SPATIAL_SHAPE = (2, 3, 4)  # arbitrary small block of cells
 
 
-def _broadcast_coeffs(c1_poles, c2_poles, c3_poles, spatial_shape):
-    """Expand a (num_poles,) coefficient vector to shape (num_poles, 1, *spatial).
+def _broadcast_coeffs(pole, spatial_shape, dt=_DT):
+    """Delta-basis coefficients of one pole in the ArrayContainer storage layout.
 
-    Matches the ArrayContainer storage layout used by fdtdx's ADE backend.
+    Returns ``(a1, a0, b1, b0)`` each of shape ``(1, 1, *spatial)``, matching
+    what fdtdx's ADE backend stores per cell.
     """
-    num_poles = c1_poles.shape[0]
-    target_shape = (num_poles, 1, *spatial_shape)
-    c1 = np.broadcast_to(c1_poles.reshape(num_poles, 1, 1, 1, 1), target_shape).copy()
-    c2 = np.broadcast_to(c2_poles.reshape(num_poles, 1, 1, 1, 1), target_shape).copy()
-    c3 = np.broadcast_to(c3_poles.reshape(num_poles, 1, 1, 1, 1), target_shape).copy()
-    return c1, c2, c3
+    vecs = compute_pole_delta_coefficients_per_axis((pole,), dt=dt)
+    a1, a0, b1, _c4, b0 = (np.asarray(v)[:, :1] for v in vecs)  # isotropic -> keep axis x
+    target_shape = (1, 1, *spatial_shape)
+    return tuple(np.broadcast_to(v.reshape(1, 1, 1, 1, 1), target_shape).copy() for v in (a1, a0, b1, b0))
 
 
 class TestEpsSpectrum:
     def test_non_dispersive_returns_eps_inf(self):
         """Zero ADE coefficients → spectrum is flat at eps_inf."""
-        c1 = np.zeros((0, 1, *_SPATIAL_SHAPE))
-        c2 = np.zeros((0, 1, *_SPATIAL_SHAPE))
-        c3 = np.zeros((0, 1, *_SPATIAL_SHAPE))
+        a1 = np.zeros((0, 1, *_SPATIAL_SHAPE))
+        a0 = np.zeros((0, 1, *_SPATIAL_SHAPE))
+        b1 = np.zeros((0, 1, *_SPATIAL_SHAPE))
         eps_inf_value = 2.25
         inv_eps_inf = np.full((1, *_SPATIAL_SHAPE), 1.0 / eps_inf_value)
 
         omegas = np.array([1e14, 1e15, 5e15], dtype=np.float64)
         spectrum = compute_eps_spectrum_from_coefficients(
-            c1=c1,
-            c2=c2,
-            c3=c3,
+            a1=a1,
+            a0=a0,
+            b1=b1,
             inv_eps_inf=inv_eps_inf,
             omegas=omegas,
             dt=_DT,
@@ -61,24 +60,19 @@ class TestEpsSpectrum:
     def test_matches_lorentz_model(self):
         """Reconstructed ε(ω) must match the analytic Lorentz formula."""
         pole = LorentzPole(resonance_frequency=2.0e15, damping=1.0e13, delta_epsilon=2.25)
-        c1_vec, c2_vec, c3_vec, _c4_vec = compute_pole_coefficients((pole,), dt=_DT)
-        c1, c2, c3 = _broadcast_coeffs(
-            np.asarray(c1_vec),
-            np.asarray(c2_vec),
-            np.asarray(c3_vec),
-            _SPATIAL_SHAPE,
-        )
+        a1, a0, b1, b0 = _broadcast_coeffs(pole, _SPATIAL_SHAPE)
         eps_inf = 1.0
         inv_eps_inf = np.full((1, *_SPATIAL_SHAPE), 1.0 / eps_inf)
 
         omegas = np.array([0.5e15, 1.0e15, 1.8e15, 3.0e15], dtype=np.float64)
         spectrum = compute_eps_spectrum_from_coefficients(
-            c1=c1,
-            c2=c2,
-            c3=c3,
+            a1=a1,
+            a0=a0,
+            b1=b1,
             inv_eps_inf=inv_eps_inf,
             omegas=omegas,
             dt=_DT,
+            b0=b0,
         )
 
         # The ADE discretization introduces O(ω·dt) warping; for dt=5e-18 and
@@ -95,24 +89,19 @@ class TestEpsSpectrum:
     def test_matches_drude_model(self):
         """Same check for a Drude pole (omega_0 = 0)."""
         pole = DrudePole(plasma_frequency=3.0e15, damping=5.0e13)
-        c1_vec, c2_vec, c3_vec, _c4_vec = compute_pole_coefficients((pole,), dt=_DT)
-        c1, c2, c3 = _broadcast_coeffs(
-            np.asarray(c1_vec),
-            np.asarray(c2_vec),
-            np.asarray(c3_vec),
-            _SPATIAL_SHAPE,
-        )
+        a1, a0, b1, b0 = _broadcast_coeffs(pole, _SPATIAL_SHAPE)
         eps_inf = 1.0
         inv_eps_inf = np.full((1, *_SPATIAL_SHAPE), 1.0 / eps_inf)
 
         omegas = np.array([1.5e15, 2.5e15, 4.0e15], dtype=np.float64)
         spectrum = compute_eps_spectrum_from_coefficients(
-            c1=c1,
-            c2=c2,
-            c3=c3,
+            a1=a1,
+            a0=a0,
+            b1=b1,
             inv_eps_inf=inv_eps_inf,
             omegas=omegas,
             dt=_DT,
+            b0=b0,
         )
         for w, got in zip(omegas, spectrum, strict=True):
             chi_analytic = -(pole.plasma_frequency**2) / (w**2 + 1j * pole.gamma * w)

--- a/tests/unit/test_materials.py
+++ b/tests/unit/test_materials.py
@@ -905,10 +905,14 @@ class TestDispersiveDivisorStability:
     DT = 1.9e-16
 
     @staticmethod
-    def _ccpr_material(re_residue, eps_inf=2.0, electric_conductivity=0.0):
+    def _ccpr_material(re_residue, eps_inf=2.0, electric_conductivity=0.0, integrator="central"):
         from fdtdx.dispersion import CCPRPole, DispersionModel
 
-        pole = CCPRPole(pole=complex(-1e13, -2e15), residue=complex(re_residue, 1e15))
+        # These tests exercise the validator machinery on a divisor that actually
+        # goes negative, which needs the large c4 = b*dt/D of the "central"
+        # scheme. Under the "centered_edot" default the same pole has half that
+        # c4 and stays safe — see test_centered_edot_rescues_the_same_material.
+        pole = CCPRPole(pole=complex(-1e13, -2e15), residue=complex(re_residue, 1e15), integrator=integrator)
         return Material(
             permittivity=eps_inf,
             electric_conductivity=electric_conductivity,
@@ -959,8 +963,8 @@ class TestDispersiveDivisorStability:
         from fdtdx.materials import _min_dispersive_divisor, validate_dispersive_divisor_stability
 
         poles = (
-            CCPRPole(pole=complex(-2e14, -2e15), residue=complex(-1.2e16, 1e15)),  # strong b < 0
-            CCPRPole(pole=complex(-4e15, -8e15), residue=complex(3e15, 5e14)),  # b > 0
+            CCPRPole(pole=complex(-2e14, -2e15), residue=complex(-1.2e16, 1e15), integrator="central"),
+            CCPRPole(pole=complex(-4e15, -8e15), residue=complex(3e15, 5e14), integrator="central"),
         )
         mat = Material(permittivity=2.0, dispersion=DispersionModel(poles=poles))
         with pytest.raises(ValueError) as exc:
@@ -980,6 +984,46 @@ class TestDispersiveDivisorStability:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             validate_dispersive_divisor_stability({"safe": mat}, dt=self.DT, courant_factor=0.99)
+
+    def test_centered_edot_rescues_the_same_material(self):
+        """The material that 'central' cannot run is safe under the default scheme.
+
+        'central' discretizes the b*dE/dt term with a forward difference, putting
+        the full b*dt on E^{n+1}; centering it halves that and lifts the divisor
+        back above zero. This is the practical payoff of the second-order scheme.
+        """
+        import warnings
+
+        from fdtdx.materials import _min_dispersive_divisor, validate_dispersive_divisor_stability
+
+        central = self._ccpr_material(-6e15, integrator="central")
+        centered = self._ccpr_material(-6e15, integrator="centered_edot")
+        div_central, _ = _min_dispersive_divisor(central, self.DT)
+        div_centered, _ = _min_dispersive_divisor(centered, self.DT)
+        assert div_central <= 0.0, "premise: 'central' must be unstable for this pole"
+        assert div_centered > 0.0
+        # Exactly the halving of c4: (1 + x) -> (1 + x/2).
+        assert div_centered == pytest.approx(0.5 * (1.0 + div_central), rel=1e-12)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            validate_dispersive_divisor_stability({"gold": centered}, dt=self.DT, courant_factor=0.99)
+
+    def test_bilinear_lorentz_is_not_skipped(self):
+        """Under 'bilinear' a Lorentz pole has c4 != 0, so the validator must not
+        skip it via the 'no dE/dt coupling' shortcut."""
+        import numpy as np
+
+        from fdtdx.dispersion import DispersionModel, LorentzPole, compute_pole_coefficients_tensor
+        from fdtdx.materials import _min_dispersive_divisor
+
+        model = DispersionModel(
+            poles=(LorentzPole(resonance_frequency=2e15, damping=1e13, delta_epsilon=1.5),)
+        ).with_integrator("bilinear")
+        mat = Material(permittivity=2.0, dispersion=model)
+        _, _, _, c4, _ = compute_pole_coefficients_tensor(model.poles, self.DT)
+        assert np.any(c4 != 0), "bilinear must give a non-zero c4 even at b = 0"
+        div, _ = _min_dispersive_divisor(mat, self.DT)
+        assert div > 0.0
 
     def test_lorentz_and_drude_are_skipped(self):
         import warnings


### PR DESCRIPTION
Dispersion in observer form, as the title suggests. This has both good the good previously implemented convergence for standard drude / lorentz poles as well as second order convergence for ccpr poles (previously first order). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable dispersion integrators (central, centered-edot, bilinear).
  * Added new public utilities for pole coefficient calculation and conversion between observer/delta representations.
  * Updated supported sources, mode detectors, and material handling to use the new dispersive coefficient format.

* **Documentation**
  * Expanded guidance on dispersive ADE behavior, stability, gradients/time-reversal constraints, and API usage.

* **Bug Fixes**
  * Improved implicit-disersion divisor handling and stability validation.
  * Updated and broadened regression coverage for dispersive simulations, gradient checkpointing, and dispersive source corrections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->