### PR TITLE
fix(sources): interpolate point dipoles on Yee grids

### DIFF
--- a/src/fdtdx/objects/sources/dipole.py
+++ b/src/fdtdx/objects/sources/dipole.py
@@ -266,8 +266,6 @@ class PointDipoleSource(Source):
         tuple[SliceTuple3D, SliceTuple3D, SliceTuple3D],
         tuple[jax.Array, jax.Array, jax.Array],
     ]:
-        if isinstance(self._source_support_slices, Null) or isinstance(self._source_weights, Null):
-            return self._single_cell_support()
         return self._source_support_slices, self._source_weights
 
     @property

--- a/src/fdtdx/objects/sources/dipole.py
+++ b/src/fdtdx/objects/sources/dipole.py
@@ -4,12 +4,16 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
+from fdtdx.config import SimulationConfig
 from fdtdx.core.axis import get_oriented_transverse_axes
+from fdtdx.core.grid import RectilinearGrid
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
 from fdtdx.core.linalg import rotate_vector
+from fdtdx.core.misc import ensure_slice_tuple
 from fdtdx.core.null import Null
 from fdtdx.dispersion import effective_inv_permittivity
 from fdtdx.objects.sources.source import Source
+from fdtdx.typing import SliceTuple3D
 
 
 def _contract_orientation(
@@ -48,13 +52,63 @@ def _axis_aligned_diagonal_injection(
     return inv_material.shape[0] in (1, 3)
 
 
+def _support_from_coordinates(
+    coordinates: np.ndarray,
+    position: float,
+) -> tuple[tuple[int, int], jax.Array]:
+    """Return linear interpolation support on a Yee coordinate axis."""
+    if coordinates.ndim != 1 or coordinates.size == 0:
+        raise ValueError("Source interpolation coordinates must be a nonempty 1D array")
+
+    if coordinates.size == 1:
+        return (0, 1), jnp.ones((1,), dtype=jnp.float32)
+
+    if position <= coordinates[0]:
+        return (0, 2), jnp.asarray([1.0, 0.0], dtype=jnp.float32)
+    if position >= coordinates[-1]:
+        return (
+            (coordinates.size - 2, coordinates.size),
+            jnp.asarray([0.0, 1.0], dtype=jnp.float32),
+        )
+
+    upper = int(np.searchsorted(coordinates, position, side="right"))
+    lower = upper - 1
+    upper_weight = float((position - coordinates[lower]) / (coordinates[upper] - coordinates[lower]))
+    return (
+        (lower, upper + 1),
+        jnp.asarray([1.0 - upper_weight, upper_weight], dtype=jnp.float32),
+    )
+
+
+def _field_component_coordinates(
+    grid: RectilinearGrid,
+    source_type: Literal["electric", "magnetic"],
+    component_axis: int,
+    coordinate_axis: int,
+) -> np.ndarray:
+    """Return the physical Yee coordinates of one field component."""
+    electric_centered = source_type == "electric" and coordinate_axis == component_axis
+    magnetic_centered = source_type == "magnetic" and coordinate_axis != component_axis
+    if electric_centered or magnetic_centered:
+        return np.asarray(grid.centers(coordinate_axis))
+    return np.asarray(grid.edges(coordinate_axis)[:-1])
+
+
+def _outer_product_weights(axis_weights: tuple[jax.Array, jax.Array, jax.Array]) -> jax.Array:
+    """Build a separable 3D interpolation stencil."""
+    wx, wy, wz = axis_weights
+    return wx[:, None, None] * wy[None, :, None] * wz[None, None, :]
+
+
 @autoinit
 class PointDipoleSource(Source):
     """Soft point dipole source (electric or magnetic).
 
-    Injects an impressed current at a single Yee cell. The source is "soft":
-    it adds to the field rather than overwriting, so scattered/reflected fields
-    pass through without artificial reflections.
+    Injects an impressed current into the Yee grid. With ``interpolate=False`` (the default), the
+    current is applied at one grid sample for backward compatibility. With ``interpolate=True``,
+    the continuous source position is distributed linearly over the neighboring, component-specific
+    Yee samples. The source is "soft": it adds to the field rather than overwriting, so
+    scattered/reflected fields pass through without artificial reflections.
 
     The dipole orientation starts along the ``polarization`` axis and is then
     rotated by ``azimuth_angle`` and ``elevation_angle`` (both in degrees),
@@ -75,10 +129,9 @@ class PointDipoleSource(Source):
     For a magnetic dipole, the dual applies during the H update with
     inv_permeability replacing inv_permittivity.
 
-    The medium permittivity/permeability at the source cell is sampled once
-    during :meth:`apply` — at the carrier angular frequency when a dispersive
-    coefficient arrays is provided — so dispersive media are handled correctly
-    without runtime overhead.
+    The medium permittivity/permeability is sampled once during :meth:`apply` at every injection
+    sample used by the selected mode. Dispersive coefficients are evaluated at the carrier angular
+    frequency, so dispersive media are handled without runtime material lookups.
     """
 
     #: Polarization axis (0=x, 1=y, 2=z).
@@ -96,16 +149,26 @@ class PointDipoleSource(Source):
     #: Source amplitude.
     amplitude: float = frozen_field(default=1.0)
 
+    #: Distribute a continuous source position onto neighboring Yee samples.
+    #: Disabled by default to preserve the legacy single-cell source behavior.
+    interpolate: bool = frozen_field(default=False)
+
     _inv_eps_local: jax.Array = private_field()
     _inv_mu_local: jax.Array | float = private_field()
     _inv_eps_oriented: jax.Array = private_field()
     _inv_mu_oriented: jax.Array = private_field()
+    _source_support_slices: tuple[SliceTuple3D, SliceTuple3D, SliceTuple3D] = private_field()
+    _source_weights: tuple[jax.Array, jax.Array, jax.Array] = private_field()
+    _inv_eps_oriented_components: tuple[jax.Array, jax.Array, jax.Array] = private_field()
+    _inv_mu_oriented_components: tuple[jax.Array, jax.Array, jax.Array] = private_field()
 
     def __post_init__(self):
         if self.source_type not in ("electric", "magnetic"):
             raise ValueError(f"source_type must be electric or magnetic, got {self.source_type}")
         if self.polarization not in (0, 1, 2):
             raise ValueError(f"polarization must be 0, 1, or 2, got {self.polarization}")
+        if not isinstance(self.interpolate, bool):
+            raise ValueError(f"interpolate must be a bool, got {self.interpolate!r}")
 
     def validate_placement(self, objects) -> list[str]:
         """Reject a dipole sitting on a symmetry plane.
@@ -127,6 +190,86 @@ class PointDipoleSource(Source):
             )
         return errors
 
+    def _requested_position(self, grid: RectilinearGrid) -> tuple[float, float, float]:
+        """Return the requested continuous position in resolved-grid coordinates."""
+        position = []
+        for axis in range(3):
+            real_position = self.partial_real_position[axis]
+            edges = grid.edges(axis)
+            domain_center = 0.5 * (float(edges[0]) + float(edges[-1]))
+            if real_position is None:
+                start, stop = self.grid_slice_tuple[axis]
+                local_edges = grid.edges(axis)[start : stop + 1]
+                position.append(0.5 * (float(local_edges[0]) + float(local_edges[-1])))
+            else:
+                position.append(domain_center + float(real_position))
+        return position[0], position[1], position[2]
+
+    def _single_cell_support(
+        self,
+    ) -> tuple[
+        tuple[SliceTuple3D, SliceTuple3D, SliceTuple3D],
+        tuple[jax.Array, jax.Array, jax.Array],
+    ]:
+        support_slices = (
+            self.grid_slice_tuple,
+            self.grid_slice_tuple,
+            self.grid_slice_tuple,
+        )
+        weight = jnp.ones(self.grid_shape, dtype=self._config.dtype)
+        return support_slices, (weight, weight, weight)
+
+    def _interpolated_support(
+        self, grid: RectilinearGrid
+    ) -> tuple[
+        tuple[SliceTuple3D, SliceTuple3D, SliceTuple3D],
+        tuple[jax.Array, jax.Array, jax.Array],
+    ]:
+        source_position = self._requested_position(grid)
+        support_slices: list[SliceTuple3D] = []
+        support_weights = []
+        for component_axis in range(3):
+            axis_bounds = []
+            axis_weights = []
+            for coordinate_axis in range(3):
+                coordinates = _field_component_coordinates(grid, self.source_type, component_axis, coordinate_axis)
+                bounds, weights = _support_from_coordinates(coordinates, source_position[coordinate_axis])
+                axis_bounds.append(bounds)
+                axis_weights.append(weights.astype(self._config.dtype))
+            support_slices.append((axis_bounds[0], axis_bounds[1], axis_bounds[2]))
+            support_weights.append(_outer_product_weights((axis_weights[0], axis_weights[1], axis_weights[2])))
+        return (
+            (support_slices[0], support_slices[1], support_slices[2]),
+            (support_weights[0], support_weights[1], support_weights[2]),
+        )
+
+    def place_on_grid(
+        self: Self,
+        grid_slice_tuple: SliceTuple3D,
+        config: SimulationConfig,
+        key: jax.Array,
+    ) -> Self:
+        self = super().place_on_grid(grid_slice_tuple, config, key)
+        grid = self._config.resolved_grid
+        if self.interpolate and self.grid_shape != (1, 1, 1):
+            raise ValueError(f"Interpolated point dipoles require grid_shape=(1, 1, 1), got {self.grid_shape}")
+        if self.interpolate and grid is not None:
+            support_slices, support_weights = self._interpolated_support(grid)
+        else:
+            support_slices, support_weights = self._single_cell_support()
+        self = self.aset("_source_support_slices", support_slices, create_new_ok=True)
+        return self.aset("_source_weights", support_weights, create_new_ok=True)
+
+    def _component_supports(
+        self,
+    ) -> tuple[
+        tuple[SliceTuple3D, SliceTuple3D, SliceTuple3D],
+        tuple[jax.Array, jax.Array, jax.Array],
+    ]:
+        if isinstance(self._source_support_slices, Null) or isinstance(self._source_weights, Null):
+            return self._single_cell_support()
+        return self._source_support_slices, self._source_weights
+
     @property
     def _orientation(self) -> jnp.ndarray:
         """Normalized orientation vector as a (3,) JAX array.
@@ -147,6 +290,60 @@ class PointDipoleSource(Source):
             axes_tuple=axes_tuple,
         )
 
+    def _oriented_components_from_material(
+        self,
+        material: jax.Array | float,
+        support_slices: tuple[SliceTuple3D, SliceTuple3D, SliceTuple3D],
+    ) -> tuple[jax.Array, jax.Array, jax.Array]:
+        """Sample and contract a material independently on each Yee support."""
+        components = []
+        for axis, support_slice in enumerate(support_slices):
+            if isinstance(material, jax.Array) and material.ndim > 0:
+                material_slice: jax.Array | float = material[:, *ensure_slice_tuple(support_slice)]
+            else:
+                material_slice = material
+            components.append(_contract_orientation(material_slice, self._orientation)[axis])
+        return components[0], components[1], components[2]
+
+    def _effective_inv_eps_components(
+        self,
+        inv_permittivities: jax.Array,
+        support_slices: tuple[SliceTuple3D, SliceTuple3D, SliceTuple3D],
+        dispersive_c1: jax.Array | None,
+        dispersive_c2: jax.Array | None,
+        dispersive_c3: jax.Array | None,
+    ) -> tuple[jax.Array, jax.Array, jax.Array]:
+        """Sample effective inverse permittivity on each electric support."""
+        components = []
+        for axis, support_slice in enumerate(support_slices):
+            source_slice = ensure_slice_tuple(support_slice)
+            inv_eps_slice = inv_permittivities[:, *source_slice]
+            if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
+                inv_eps_slice = effective_inv_permittivity(
+                    inv_eps=inv_eps_slice,
+                    c1=dispersive_c1[:, :, *source_slice],
+                    c2=dispersive_c2[:, :, *source_slice],
+                    c3=dispersive_c3[:, :, *source_slice],
+                    omega=2.0 * np.pi * self.wave_character.get_frequency(),
+                    dt=self._config.time_step_duration,
+                )
+            components.append(_contract_orientation(inv_eps_slice, self._orientation)[axis])
+        return components[0], components[1], components[2]
+
+    def _inject_interpolated(
+        self,
+        field: jax.Array,
+        oriented_components: tuple[jax.Array, jax.Array, jax.Array],
+        scale: jax.Array,
+        sign: float,
+    ) -> jax.Array:
+        """Add a weighted source contribution to each component-specific support."""
+        support_slices, weights = self._component_supports()
+        for axis in range(3):
+            injection = scale * oriented_components[axis] * weights[axis]
+            field = field.at[axis, *ensure_slice_tuple(support_slices[axis])].add(sign * injection.astype(field.dtype))
+        return field
+
     def apply(
         self: Self,
         key: jax.Array,
@@ -159,7 +356,20 @@ class PointDipoleSource(Source):
     ) -> Self:
         del key, electric_conductivity
 
-        # inv_permittivities shape: (num_components, Nx, Ny, Nz)
+        if self.interpolate:
+            support_slices, _ = self._component_supports()
+            if self.source_type == "electric":
+                inv_eps_components = self._effective_inv_eps_components(
+                    inv_permittivities,
+                    support_slices,
+                    dispersive_c1,
+                    dispersive_c2,
+                    dispersive_c3,
+                )
+                return self.aset("_inv_eps_oriented_components", inv_eps_components, create_new_ok=True)
+            inv_mu_components = self._oriented_components_from_material(inv_permeabilities, support_slices)
+            return self.aset("_inv_mu_oriented_components", inv_mu_components, create_new_ok=True)
+
         inv_eps_slice = inv_permittivities[:, *self.grid_slice]
 
         if dispersive_c1 is not None and dispersive_c2 is not None and dispersive_c3 is not None:
@@ -211,6 +421,21 @@ class PointDipoleSource(Source):
         )
 
         sign = -1.0 if not inverse else 1.0
+        scale = c * self.amplitude * self.static_amplitude_factor * amplitude
+
+        if self.interpolate:
+            support_slices, _ = self._component_supports()
+            if isinstance(self._inv_eps_oriented_components, Null):
+                oriented_components = self._effective_inv_eps_components(
+                    inv_permittivities,
+                    support_slices,
+                    dispersive_c1=None,
+                    dispersive_c2=None,
+                    dispersive_c3=None,
+                )
+            else:
+                oriented_components = self._inv_eps_oriented_components
+            return self._inject_interpolated(E, oriented_components, scale, sign)
 
         if isinstance(self._inv_eps_oriented, Null):
             inv_eps_source = inv_permittivities[:, *self.grid_slice]
@@ -219,7 +444,6 @@ class PointDipoleSource(Source):
             inv_eps_source = self._inv_eps_local
             inv_eps_oriented = self._inv_eps_oriented
 
-        scale = c * self.amplitude * self.static_amplitude_factor * amplitude
         if _axis_aligned_diagonal_injection(inv_eps_source, self.azimuth_angle, self.elevation_angle):
             injection = scale * inv_eps_oriented[self.polarization]
             E = E.at[self.polarization, *self.grid_slice].add(sign * injection.astype(E.dtype))
@@ -252,6 +476,15 @@ class PointDipoleSource(Source):
         )
 
         sign = -1.0 if not inverse else 1.0
+        scale = c * self.amplitude * self.static_amplitude_factor * amplitude
+
+        if self.interpolate:
+            support_slices, _ = self._component_supports()
+            if isinstance(self._inv_mu_oriented_components, Null):
+                oriented_components = self._oriented_components_from_material(inv_permeabilities, support_slices)
+            else:
+                oriented_components = self._inv_mu_oriented_components
+            return self._inject_interpolated(H, oriented_components, scale, sign)
 
         if isinstance(self._inv_mu_oriented, Null):
             inv_mu_source: jax.Array | float = inv_permeabilities
@@ -262,7 +495,6 @@ class PointDipoleSource(Source):
             inv_mu_source = self._inv_mu_local
             inv_mu_oriented = self._inv_mu_oriented
 
-        scale = c * self.amplitude * self.static_amplitude_factor * amplitude
         if _axis_aligned_diagonal_injection(inv_mu_source, self.azimuth_angle, self.elevation_angle):
             injection = scale * inv_mu_oriented[self.polarization]
             H = H.at[self.polarization, *self.grid_slice].add(sign * injection.astype(H.dtype))

--- a/tests/unit/objects/sources/test_dipole.py
+++ b/tests/unit/objects/sources/test_dipole.py
@@ -12,7 +12,7 @@ import pytest
 from fdtdx.config import SimulationConfig
 from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.core.wavelength import WaveCharacter
-from fdtdx.objects.sources.dipole import PointDipoleSource
+from fdtdx.objects.sources.dipole import PointDipoleSource, _support_from_coordinates
 
 
 @pytest.fixture
@@ -112,6 +112,21 @@ class TestPointDipoleSourceInitialization:
         )
         assert source.azimuth_angle == 30.0
         assert source.elevation_angle == 15.0
+
+    def test_interpolation_support_handles_degenerate_and_boundary_axes(self):
+        for invalid_coordinates in (np.asarray([]), np.ones((1, 2))):
+            with pytest.raises(ValueError, match="nonempty 1D array"):
+                _support_from_coordinates(invalid_coordinates, 0.0)
+
+        cases = (
+            (np.asarray([1.0]), 1.0, (0, 1), [1.0]),
+            (np.asarray([1.0, 2.0, 3.0]), 0.0, (0, 2), [1.0, 0.0]),
+            (np.asarray([1.0, 2.0, 3.0]), 4.0, (1, 3), [0.0, 1.0]),
+        )
+        for coordinates, position, expected_bounds, expected_weights in cases:
+            bounds, weights = _support_from_coordinates(coordinates, position)
+            assert bounds == expected_bounds
+            assert jnp.allclose(weights, jnp.asarray(expected_weights))
 
 
 class TestPointDipoleSourceUpdateE:
@@ -266,7 +281,6 @@ class TestPointDipoleSourceUpdateE:
         config = micro_config.aset("grid", grid)
         source = PointDipoleSource(
             partial_grid_shape=(1, 1, 1),
-            partial_real_position=(0.0, 0.0, 0.0),
             wave_character=WaveCharacter(wavelength=1e-6),
             polarization=2,
             interpolate=True,
@@ -275,7 +289,7 @@ class TestPointDipoleSourceUpdateE:
         support, weights = source._component_supports()
         assert support[2] == ((1, 3), (1, 3), (1, 3))
         assert jnp.allclose(weights[2].sum(), 1.0)
-        assert jnp.allclose(weights[2].sum(axis=(1, 2)), jnp.asarray([1.0 / 3.0, 2.0 / 3.0]))
+        assert jnp.allclose(weights[2].sum(axis=(1, 2)), jnp.asarray([0.5, 0.5]))
 
     def test_interpolation_supports_dispersive_material(self, micro_config, jax_key):
         config = micro_config.aset(
@@ -403,12 +417,12 @@ class TestPointDipoleSourceUpdateH:
             partial_real_position=(0.25, 0.0, 0.0),
             interpolate=True,
         )
-        inv_mu = jnp.ones((3, 8, 8, 8), dtype=jnp.float32).at[2, 5, 3, 4].set(2.0)
+        inv_mu = jnp.ones((3, 8, 8, 8), dtype=jnp.float32).at[2, 3, 3, 4].set(2.0)
         applied = placed.apply(jax_key, jnp.ones_like(inv_mu), inv_mu)
         updated = applied.update_H(jnp.zeros_like(inv_mu), jnp.ones_like(inv_mu), inv_mu, jnp.array(10), False)
 
         abs_hz = jnp.abs(updated[2])
-        assert jnp.max(abs_hz) > jnp.min(abs_hz[abs_hz > 0])
+        assert jnp.allclose(abs_hz[3, 3, 4], 2.0 * abs_hz[3, 4, 4])
 
 
 class TestPointDipoleInterpolatedOrientation:

--- a/tests/unit/objects/sources/test_dipole.py
+++ b/tests/unit/objects/sources/test_dipole.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 from fdtdx.config import SimulationConfig
-from fdtdx.core.grid import UniformGrid
+from fdtdx.core.grid import RectilinearGrid, UniformGrid
 from fdtdx.core.wavelength import WaveCharacter
 from fdtdx.objects.sources.dipole import PointDipoleSource
 
@@ -84,6 +84,15 @@ class TestPointDipoleSourceInitialization:
                 polarization=3,
             )
 
+    def test_invalid_interpolate(self):
+        with pytest.raises(ValueError, match="interpolate must be a bool"):
+            PointDipoleSource(
+                partial_grid_shape=(1, 1, 1),
+                wave_character=WaveCharacter(wavelength=1e-6),
+                polarization=2,
+                interpolate="linear",
+            )
+
     def test_all_polarization_axes(self):
         for axis in (0, 1, 2):
             source = PointDipoleSource(
@@ -118,6 +127,28 @@ class TestPointDipoleSourceUpdateE:
         return source.place_on_grid(
             grid_slice_tuple=((4, 5), (4, 5), (4, 5)),
             config=micro_config,
+            key=jax_key,
+        )
+
+    def _make_interpolated_placed(self, micro_config, jax_key):
+        config = micro_config.aset(
+            "grid",
+            RectilinearGrid.uniform(
+                shape=(8, 8, 8),
+                spacing=1.0,
+                origin=(-4.0, -4.0, -4.0),
+            ),
+        )
+        source = PointDipoleSource(
+            partial_grid_shape=(1, 1, 1),
+            partial_real_position=(0.25, 0.0, 0.0),
+            wave_character=WaveCharacter(wavelength=1e-6),
+            polarization=2,
+            interpolate=True,
+        )
+        return source.place_on_grid(
+            grid_slice_tuple=((4, 5), (4, 5), (4, 5)),
+            config=config,
             key=jax_key,
         )
 
@@ -174,6 +205,111 @@ class TestPointDipoleSourceUpdateE:
         # Zero out the source cell — rest should still be zero
         E_check = E_updated.at[2, 4, 4, 4].set(0.0)
         assert jnp.allclose(E_check, 0.0)
+
+    def test_interpolation_uses_expected_yee_samples_and_weights(self, micro_config, jax_key):
+        placed = self._make_interpolated_placed(micro_config, jax_key)
+        E = jnp.zeros((3, 8, 8, 8), dtype=jnp.float32)
+        inv_perm = jnp.ones_like(E)
+
+        updated = placed.update_E(E, inv_perm, 1.0, jnp.array(10), inverse=False)
+        abs_ez = jnp.abs(updated[2])
+        nonzero = jnp.argwhere(abs_ez > 0)
+        expected = jnp.asarray(
+            [[4, 4, 3], [4, 4, 4], [5, 4, 3], [5, 4, 4]],
+            dtype=nonzero.dtype,
+        )
+
+        assert jnp.array_equal(nonzero, expected)
+        assert jnp.allclose(abs_ez[4, 4, 3], abs_ez[4, 4, 4])
+        assert jnp.allclose(abs_ez[5, 4, 3], abs_ez[5, 4, 4])
+        assert jnp.allclose(abs_ez[4, 4, 3], 3.0 * abs_ez[5, 4, 3])
+
+    def test_interpolation_samples_material_on_each_support(self, micro_config, jax_key):
+        placed = self._make_interpolated_placed(micro_config, jax_key)
+        inv_perm = jnp.ones((3, 8, 8, 8), dtype=jnp.float32)
+        inv_perm = inv_perm.at[2, 5, 4, 3].set(2.0)
+        placed = placed.apply(jax_key, inv_perm, 1.0)
+
+        updated = placed.update_E(
+            jnp.zeros_like(inv_perm),
+            jnp.ones_like(inv_perm),
+            1.0,
+            jnp.array(10),
+            inverse=False,
+        )
+        abs_ez = jnp.abs(updated[2])
+
+        assert jnp.allclose(abs_ez[5, 4, 3], 2.0 * abs_ez[5, 4, 4])
+        assert jnp.allclose(abs_ez[4, 4, 3], 1.5 * abs_ez[5, 4, 3])
+
+    def test_interpolation_supports_jit_and_material_gradient(self, micro_config, jax_key):
+        placed = self._make_interpolated_placed(micro_config, jax_key)
+        E = jnp.zeros((3, 8, 8, 8), dtype=jnp.float32)
+
+        @jax.jit
+        def response(local_inv_perm):
+            inv_perm = jnp.ones_like(E).at[2, 5, 4, 3].set(local_inv_perm)
+            updated = placed.update_E(E, inv_perm, 1.0, jnp.array(10), inverse=False)
+            return jnp.sum(updated[2] ** 2)
+
+        value, gradient = jax.value_and_grad(response)(jnp.asarray(2.0))
+        assert jnp.isfinite(value)
+        assert jnp.isfinite(gradient)
+        assert gradient != 0.0
+
+    def test_interpolation_uses_nonuniform_yee_coordinates(self, micro_config, jax_key):
+        grid = RectilinearGrid(
+            x_edges=jnp.asarray([-4.0, -2.0, 1.0, 4.0]),
+            y_edges=jnp.asarray([-4.0, -1.0, 1.0, 4.0]),
+            z_edges=jnp.asarray([-4.0, -2.0, 2.0, 4.0]),
+        )
+        config = micro_config.aset("grid", grid)
+        source = PointDipoleSource(
+            partial_grid_shape=(1, 1, 1),
+            partial_real_position=(0.0, 0.0, 0.0),
+            wave_character=WaveCharacter(wavelength=1e-6),
+            polarization=2,
+            interpolate=True,
+        ).place_on_grid(((1, 2), (1, 2), (1, 2)), config, jax_key)
+
+        support, weights = source._component_supports()
+        assert support[2] == ((1, 3), (1, 3), (1, 3))
+        assert jnp.allclose(weights[2].sum(), 1.0)
+        assert jnp.allclose(weights[2].sum(axis=(1, 2)), jnp.asarray([1.0 / 3.0, 2.0 / 3.0]))
+
+    def test_interpolation_supports_dispersive_material(self, micro_config, jax_key):
+        config = micro_config.aset(
+            "grid", RectilinearGrid.uniform(shape=(8, 8, 8), spacing=1e-7, origin=(-4e-7, -4e-7, -4e-7))
+        )
+        placed = PointDipoleSource(
+            partial_grid_shape=(1, 1, 1),
+            partial_real_position=(2.5e-8, 0.0, 0.0),
+            wave_character=WaveCharacter(wavelength=1e-6),
+            polarization=2,
+            interpolate=True,
+        ).place_on_grid(((4, 5), (4, 5), (4, 5)), config, jax_key)
+        shape = (3, 8, 8, 8)
+        inv_perm = jnp.ones(shape, dtype=jnp.float32)
+        coeff_shape = (1, *shape)
+        c1 = jnp.full(coeff_shape, 0.4, dtype=jnp.float32)
+        c2 = jnp.full(coeff_shape, 0.2, dtype=jnp.float32)
+        c3 = jnp.full(coeff_shape, 0.1, dtype=jnp.float32)
+        applied = placed.apply(jax_key, inv_perm, 1.0, c1, c2, c3)
+
+        plain = placed.update_E(jnp.zeros(shape), inv_perm, 1.0, jnp.array(10), inverse=False)
+        dispersive = applied.update_E(jnp.zeros(shape), inv_perm, 1.0, jnp.array(10), inverse=False)
+        assert jnp.all(jnp.isfinite(dispersive))
+        assert not jnp.allclose(dispersive, plain)
+
+    def test_interpolation_rejects_non_point_shape(self, micro_config, jax_key):
+        source = PointDipoleSource(
+            partial_grid_shape=(2, 1, 1),
+            wave_character=WaveCharacter(wavelength=1e-6),
+            polarization=2,
+            interpolate=True,
+        )
+        with pytest.raises(ValueError, match="require grid_shape"):
+            source.place_on_grid(((3, 5), (4, 5), (4, 5)), micro_config, jax_key)
 
     def test_axis_aligned_full_tensor_material_keeps_coupled_components(self, micro_config, jax_key):
         placed = self._make_placed(micro_config, jax_key, polarization=0)
@@ -239,6 +375,59 @@ class TestPointDipoleSourceUpdateH:
         H_fwd = placed.update_H(H, inv_perm, 1.0, time_step, inverse=False)
         H_back = placed.update_H(H_fwd, inv_perm, 1.0, time_step, inverse=True)
         assert jnp.allclose(H_back, H, atol=1e-6)
+
+    def test_interpolated_magnetic_dipole_uses_yee_support(self, micro_config, jax_key):
+        config = micro_config.aset(
+            "grid", RectilinearGrid.uniform(shape=(8, 8, 8), spacing=1.0, origin=(-4.0, -4.0, -4.0))
+        )
+        placed = self._make_placed(
+            config,
+            jax_key,
+            partial_real_position=(0.25, 0.0, 0.0),
+            interpolate=True,
+        )
+        H = jnp.zeros((3, 8, 8, 8), dtype=jnp.float32)
+        updated = placed.update_H(H, jnp.ones_like(H), 1.0, jnp.array(10), inverse=False)
+
+        assert jnp.count_nonzero(updated[2]) == 4
+        assert jnp.allclose(updated[0], 0.0)
+        assert jnp.allclose(updated[1], 0.0)
+
+    def test_interpolated_magnetic_dipole_samples_each_support(self, micro_config, jax_key):
+        config = micro_config.aset(
+            "grid", RectilinearGrid.uniform(shape=(8, 8, 8), spacing=1.0, origin=(-4.0, -4.0, -4.0))
+        )
+        placed = self._make_placed(
+            config,
+            jax_key,
+            partial_real_position=(0.25, 0.0, 0.0),
+            interpolate=True,
+        )
+        inv_mu = jnp.ones((3, 8, 8, 8), dtype=jnp.float32).at[2, 5, 3, 4].set(2.0)
+        applied = placed.apply(jax_key, jnp.ones_like(inv_mu), inv_mu)
+        updated = applied.update_H(jnp.zeros_like(inv_mu), jnp.ones_like(inv_mu), inv_mu, jnp.array(10), False)
+
+        abs_hz = jnp.abs(updated[2])
+        assert jnp.max(abs_hz) > jnp.min(abs_hz[abs_hz > 0])
+
+
+class TestPointDipoleInterpolatedOrientation:
+    def test_tilted_dipole_uses_component_specific_supports(self, micro_config, jax_key):
+        config = micro_config.aset(
+            "grid", RectilinearGrid.uniform(shape=(8, 8, 8), spacing=1.0, origin=(-4.0, -4.0, -4.0))
+        )
+        source = PointDipoleSource(
+            partial_grid_shape=(1, 1, 1),
+            partial_real_position=(0.25, 0.25, 0.25),
+            wave_character=WaveCharacter(wavelength=1e-6),
+            polarization=2,
+            azimuth_angle=35.0,
+            elevation_angle=20.0,
+            interpolate=True,
+        ).place_on_grid(((4, 5), (4, 5), (4, 5)), config, jax_key)
+        field = source.update_E(jnp.zeros((3, 8, 8, 8)), jnp.ones((3, 8, 8, 8)), 1.0, jnp.array(10), False)
+
+        assert all(int(jnp.count_nonzero(field[axis])) == 8 for axis in range(3))
 
 
 class TestPointDipoleArbitraryOrientation:


### PR DESCRIPTION
## What Changed

- Added optional continuous-position interpolation for `PointDipoleSource`.
- Distributes electric and magnetic dipoles onto neighboring component-specific Yee samples.
- Supports rectilinear grids, local material sampling, dispersive permittivity, JIT, and gradients.
- Preserves the existing single-cell behavior by default.

## Why

Point dipoles were previously snapped to a single Yee-grid sample, introducing position-dependent discretization errors. Interpolation represents off-grid dipole positions more accurately while remaining compatible with existing simulations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional interpolation for point dipole sources across neighboring Yee-grid samples.
  * Supports interpolated electric and magnetic dipoles on uniform and non-uniform grids.
  * Preserves existing single-cell behavior by default.

* **Bug Fixes**
  * Improved material sampling for interpolated dipoles, including dispersive materials and material gradients.
  * Added validation for invalid interpolation settings and unsupported grid shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->