### PR TITLE
fix(detectors): colocate closed-surface Poynting flux

### DIFF
--- a/src/fdtdx/core/physics/metrics.py
+++ b/src/fdtdx/core/physics/metrics.py
@@ -157,6 +157,61 @@ def net_poynting_flux_through_box(
     return net
 
 
+def colocate_yee_fields_to_surface(
+    E: jax.Array,
+    H: jax.Array,
+    axis: int,
+    h_weights: tuple[float | jax.Array, float | jax.Array] = (0.5, 0.5),
+) -> tuple[jax.Array, jax.Array]:
+    """Co-locate Yee fields at the cell centers of a geometric surface.
+
+    The input has two cells across the surface normal and one halo cell on each transverse side.
+    Components centered across the normal are interpolated to the face using ``h_weights``;
+    components already on the face use local index 1. Along each transverse axis, edge samples are
+    averaged to the face-cell center and centered samples are restricted to the detector region.
+
+    Args:
+        E: Electric field with component axis first, two normal cells and transverse halos.
+        H: Magnetic field with the same layout as ``E``.
+        axis: Surface-normal spatial axis.
+        h_weights: Weights for the lower- and upper-cell magnetic samples. Uniform grids use
+            ``(0.5, 0.5)``; rectilinear grids use distance-based weights.
+
+    Returns:
+        The electric and magnetic fields on the face, retaining a singleton normal dimension.
+    """
+    if axis not in (0, 1, 2):
+        raise ValueError(f"axis must be 0, 1, or 2, got {axis}")
+    spatial_axis = axis + 1
+    if E.shape[spatial_axis] < 2 or H.shape[spatial_axis] < 2:
+        raise ValueError(f"Surface field slices need two cells along axis {axis}; got {E.shape=} and {H.shape=}")
+    if any(E.shape[a + 1] < 3 or H.shape[a + 1] < 3 for a in range(3) if a != axis):
+        raise ValueError(f"Surface field slices need transverse halos; got {E.shape=} and {H.shape=}")
+
+    def colocate_component(field: jax.Array, component: int, electric: bool) -> jax.Array:
+        centered_normal = component == axis if electric else component != axis
+        lower = jnp.take(field[component], jnp.asarray([0]), axis=axis)
+        upper = jnp.take(field[component], jnp.asarray([1]), axis=axis)
+        result = h_weights[0] * lower + h_weights[1] * upper if centered_normal else upper
+        for transverse_axis in range(3):
+            if transverse_axis == axis:
+                continue
+            centered = transverse_axis == component if electric else transverse_axis != component
+            index = [slice(None)] * 3
+            index[transverse_axis] = slice(1, -1)
+            inner = result[tuple(index)]
+            if centered:
+                result = inner
+            else:
+                index[transverse_axis] = slice(2, None)
+                result = 0.5 * (inner + result[tuple(index)])
+        return result
+
+    E_surface = jnp.stack([colocate_component(E, component, True) for component in range(3)])
+    H_surface = jnp.stack([colocate_component(H, component, False) for component in range(3)])
+    return E_surface, H_surface
+
+
 def compute_integrated_power(
     E: jax.Array,
     H: jax.Array,

--- a/src/fdtdx/fdtd/update.py
+++ b/src/fdtdx/fdtd/update.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Literal
 
 import jax
@@ -1063,25 +1064,48 @@ def update_detector_states(
         # The co-location stencil reads domain indices [s-1 .. e]; interior iff that stays in-bounds.
         return all(s >= 1 and e <= grid_shape[a] - 1 for a, (s, e) in enumerate(detector.grid_slice_tuple))
 
-    # The full-domain interpolation is only needed for exact detectors whose stencil reaches a domain edge.
-    full = None
-    if any(d.exact_interpolation and not is_interior(d) for d in to_update):
-        full = interpolate_fields(
-            E_pad=pad_fields_with_symmetry_mirror(arrays.fields.E, objects, config, "E"),
-            H_pad=pad_fields_with_symmetry_mirror((H_prev + arrays.fields.H) / 2, objects, config, "H"),
-            config=config,
-        )
-
-    def helper_fn(E: jax.Array, H: jax.Array, H_prev: jax.Array, detector: Detector) -> DetectorState:
+    def helper_fn(
+        E: jax.Array,
+        H: jax.Array,
+        H_prev: jax.Array,
+        detector: Detector,
+        detector_state: DetectorState,
+        *,
+        uses_padded_fields: bool,
+        shared_padded_fields: tuple[jax.Array, jax.Array] | None = None,
+        shared_full_fields: tuple[jax.Array, jax.Array] | None = None,
+    ) -> DetectorState:
         gs = detector.grid_slice
-        if not detector.exact_interpolation:
+        if uses_padded_fields:
+            if is_interior(detector):
+                block = (slice(None), *(slice(s - 1, e + 1) for s, e in detector.grid_slice_tuple))
+                E_reg = E[block]
+                H_reg = (H_prev[block] + H[block]) / 2
+            else:
+                padded_fields = shared_padded_fields
+                if padded_fields is None:
+                    padded_fields = (
+                        pad_fields_with_symmetry_mirror(E, objects, config, "E"),
+                        pad_fields_with_symmetry_mirror((H_prev + H) / 2, objects, config, "H"),
+                    )
+                block = (slice(None), *(slice(s, e + 2) for s, e in detector.grid_slice_tuple))
+                E_reg, H_reg = padded_fields[0][block], padded_fields[1][block]
+        elif not detector.exact_interpolation:
             E_reg, H_reg = E[:, *gs], H[:, *gs]
         elif is_interior(detector):
             block = (slice(None), *(slice(s - 1, e + 1) for (s, e) in detector.grid_slice_tuple))
             H_avg = (H_prev[block] + H[block]) / 2
             E_reg, H_reg = interpolate_fields(E[block], H_avg, config=config, region_slice=detector.grid_slice_tuple)
         else:
-            assert full is not None  # built above whenever an edge-touching exact detector exists
+            full = shared_full_fields
+            if full is None:
+                padded_fields = shared_padded_fields
+                if padded_fields is None:
+                    padded_fields = (
+                        pad_fields_with_symmetry_mirror(E, objects, config, "E"),
+                        pad_fields_with_symmetry_mirror((H_prev + H) / 2, objects, config, "H"),
+                    )
+                full = interpolate_fields(E_pad=padded_fields[0], H_pad=padded_fields[1], config=config)
             E_reg, H_reg = full[0][:, *gs], full[1][:, *gs]
         # inv_permeabilities is a plain scalar when all materials are non-magnetic.
         inv_mu = arrays.inv_permeabilities
@@ -1090,32 +1114,114 @@ def update_detector_states(
                 time_step=time_step,
                 E=E_reg,
                 H=H_reg,
-                state=state[detector.name],
+                state=detector_state,
                 inv_permittivity=arrays.inv_permittivities[:, *gs],
                 inv_permeability=inv_mu[:, *gs] if isinstance(inv_mu, jax.Array) and inv_mu.ndim > 0 else inv_mu,
             )
         except Exception as e:
             raise Exception(
-                f"Detector '{detector.name}': update() raised while recording (see exception above). Fields "
-                "and materials are passed to Detector.update() already restricted to the detector's "
-                "grid_slice, so slicing self.grid_slice inside update() (double slicing) is a common cause "
-                "of shape errors here."
+                f"Detector '{detector.name}': update() raised while recording (see exception above). Detector "
+                "inputs are already prepared for its sampling region, so slicing self.grid_slice again "
+                "(double slicing) is a common cause of shape errors."
             ) from e
-        _check_updated_state_layout(detector, state[detector.name], new_state)
+        _check_updated_state_layout(detector, detector_state, new_state)
         return new_state
 
-    for d in to_update:
+    def update_one(
+        detector: Detector,
+        detector_state: DetectorState,
+        shared_padded_fields: tuple[jax.Array, jax.Array] | None = None,
+        shared_full_fields: tuple[jax.Array, jax.Array] | None = None,
+    ) -> DetectorState:
         # E already lives at the detector's integer time step; H lives at half steps, so exact
         # detectors time-center H as (H_prev + H) / 2 on their region inside the branch.
-        state[d.name] = jax.lax.cond(
-            d._is_on_at_time_step_arr[time_step],
+        active_update = partial(
             helper_fn,
-            lambda e, h, h_prev, detector: state[detector.name],
+            detector_state=detector_state,
+            uses_padded_fields=getattr(detector, "_uses_padded_fields", False) is True,
+            shared_padded_fields=shared_padded_fields,
+            shared_full_fields=shared_full_fields,
+        )
+        return jax.lax.cond(
+            detector._is_on_at_time_step_arr[time_step],
+            active_update,
+            lambda e, h, h_prev, detector: detector_state,
             arrays.fields.E,
             arrays.fields.H,
             H_prev,
-            d,
+            detector,
         )
+
+    padded_edge_detectors = [
+        detector
+        for detector in to_update
+        if not is_interior(detector) and getattr(detector, "_uses_padded_fields", False) is True
+    ]
+    exact_edge_detectors = [
+        detector
+        for detector in to_update
+        if not is_interior(detector)
+        and detector.exact_interpolation
+        and getattr(detector, "_uses_padded_fields", False) is not True
+    ]
+    edge_detectors = padded_edge_detectors + exact_edge_detectors
+    grouped_names = {detector.name for detector in edge_detectors} if len(edge_detectors) > 1 else set()
+
+    for detector in to_update:
+        if detector.name not in grouped_names:
+            state[detector.name] = update_one(detector, state[detector.name])
+
+    def update_shared_edge_detectors(detector_states: dict[str, DetectorState]) -> dict[str, DetectorState]:
+        any_active = jnp.any(jnp.stack([detector._is_on_at_time_step_arr[time_step] for detector in edge_detectors]))
+
+        def active_updates(current_states):
+            padded_fields = (
+                pad_fields_with_symmetry_mirror(arrays.fields.E, objects, config, "E"),
+                pad_fields_with_symmetry_mirror((H_prev + arrays.fields.H) / 2, objects, config, "H"),
+            )
+            updated_states = dict(current_states)
+            for detector in padded_edge_detectors:
+                updated_states[detector.name] = update_one(
+                    detector,
+                    current_states[detector.name],
+                    shared_padded_fields=padded_fields,
+                )
+
+            if exact_edge_detectors:
+                exact_states = {detector.name: current_states[detector.name] for detector in exact_edge_detectors}
+
+                def active_exact_updates(current_exact_states):
+                    full_fields = interpolate_fields(E_pad=padded_fields[0], H_pad=padded_fields[1], config=config)
+                    return {
+                        detector.name: update_one(
+                            detector,
+                            current_exact_states[detector.name],
+                            shared_padded_fields=padded_fields,
+                            shared_full_fields=full_fields,
+                        )
+                        for detector in exact_edge_detectors
+                    }
+
+                if padded_edge_detectors:
+                    exact_active = jnp.any(
+                        jnp.stack([detector._is_on_at_time_step_arr[time_step] for detector in exact_edge_detectors])
+                    )
+                    exact_states = jax.lax.cond(
+                        exact_active,
+                        active_exact_updates,
+                        lambda current_exact_states: current_exact_states,
+                        exact_states,
+                    )
+                else:
+                    exact_states = active_exact_updates(exact_states)
+                updated_states.update(exact_states)
+            return updated_states
+
+        return jax.lax.cond(any_active, active_updates, lambda current_states: current_states, detector_states)
+
+    if grouped_names:
+        grouped_states = {name: state[name] for name in grouped_names}
+        state.update(update_shared_edge_detectors(grouped_states))
     arrays = arrays.aset("detector_states", state)
     return arrays
 

--- a/src/fdtdx/objects/detectors/detector.py
+++ b/src/fdtdx/objects/detectors/detector.py
@@ -69,6 +69,10 @@ class Detector(SimulationObject, ABC):
     #: non-negative quantities.
     _signed_data: ClassVar[bool] = True
 
+    #: Whether ``update`` receives a detector region with a one-cell Yee halo. Surface detectors use
+    #: this to sample both sides of their geometric faces.
+    _uses_padded_fields: ClassVar[bool] = False
+
     _num_time_steps_on: int = frozen_private_field()
     _is_on_at_time_step_arr: jax.Array = private_field()
     _time_step_to_arr_idx: jax.Array = private_field()
@@ -255,9 +259,10 @@ class Detector(SimulationObject, ABC):
     ) -> DetectorState:
         """Updates detector state with current field values.
 
-        Note that fields and materials arrive already restricted to this detector's ``grid_slice``
-        and, when ``exact_interpolation`` is set, already co-located onto the E_z Yee point, so
-        implementations must not slice ``grid_slice`` again.
+        Fields and materials normally arrive already restricted to this detector's ``grid_slice``
+        and, when ``exact_interpolation`` is set, co-located onto the E_z Yee point. Detectors with
+        the internal ``_uses_padded_fields`` flag instead receive a one-cell-haloed region so they
+        can sample both sides of geometric surfaces.
 
         Args:
             time_step (jax.Array): Current simulation time step.

--- a/src/fdtdx/objects/detectors/poynting_flux.py
+++ b/src/fdtdx/objects/detectors/poynting_flux.py
@@ -5,7 +5,10 @@ import jax.numpy as jnp
 
 from fdtdx.config import SimulationConfig
 from fdtdx.core.jax.pytrees import autoinit, frozen_field, private_field
-from fdtdx.core.physics.metrics import compute_poynting_flux, net_poynting_flux_through_box
+from fdtdx.core.physics.metrics import (
+    colocate_yee_fields_to_surface,
+    compute_poynting_flux,
+)
 from fdtdx.objects.detectors.detector import Detector, DetectorState
 from fdtdx.objects.detectors.phasor import PhasorDetector
 from fdtdx.typing import SliceTuple3D
@@ -69,6 +72,52 @@ def _phasor_poynting_vector(phasors: jax.Array) -> jax.Array:
     """
     E_ph, H_ph = phasors[:, :3], phasors[:, 3:]
     return compute_poynting_flux(E_ph, H_ph, axis=1).real
+
+
+def _surface_field_block(
+    fields: jax.Array,
+    axis: int,
+    side: Literal["min", "max"],
+) -> jax.Array:
+    """Extract a two-cell Yee block straddling one face of a haloed detector region."""
+    face_slice = []
+    for current_axis in range(3):
+        if current_axis == axis:
+            face_slice.append(slice(0, 2) if side == "min" else slice(-2, None))
+        else:
+            face_slice.append(slice(None))
+    return fields[:, *face_slice]
+
+
+def _surface_h_weights(
+    config: SimulationConfig,
+    slice_tuple: SliceTuple3D,
+    axis: int,
+    side: Literal["min", "max"],
+) -> tuple[float, float]:
+    """Distance weights for interpolating adjacent H samples to a rectilinear face."""
+    grid = config.resolved_grid
+    if grid is None:
+        return 0.5, 0.5
+    widths = grid.cell_widths(axis)
+    boundary = slice_tuple[axis][0 if side == "min" else 1]
+    lower_width = float(widths[max(boundary - 1, 0)])
+    upper_width = float(widths[min(boundary, widths.shape[0] - 1)])
+    total = lower_width + upper_width
+    return upper_width / total, lower_width / total
+
+
+def _surface_fields(
+    E: jax.Array,
+    H: jax.Array,
+    axis: int,
+    side: Literal["min", "max"],
+    h_weights: tuple[float, float],
+) -> tuple[jax.Array, jax.Array]:
+    """Return E/H co-located on one face from a haloed detector region."""
+    E_block = _surface_field_block(E, axis, side)
+    H_block = _surface_field_block(H, axis, side)
+    return colocate_yee_fields_to_surface(E_block, H_block, axis, h_weights)
 
 
 @autoinit
@@ -210,10 +259,13 @@ class ClosedSurfacePoyntingFluxDetector(Detector):
     weighting makes the surface integral exact on non-uniform grids, where cell
     areas differ across a single face.
 
-    A face pair on an axis of size one cancels to zero, so the default
-    ``axes`` (all axes with more than one cell) naturally reduces to a 4-face
-    surface for a quasi-2D / periodic setup and a 6-face surface in full 3D.
+    The default ``axes`` skips size-one dimensions, naturally reducing to a 4-face surface for a
+    quasi-2D / periodic setup and a 6-face surface in full 3D. A size-one axis may still be selected
+    explicitly when its two distinct geometric faces should contribute.
     """
+
+    #: Surface-current integration requires co-located electric and magnetic fields.
+    exact_interpolation: bool = frozen_field(default=True, init=False)
 
     #: ``"outward"`` (default) counts net power leaving the box as positive.
     #: ``"inward"`` flips the sign (net power entering, e.g. absorbed power).
@@ -224,9 +276,12 @@ class ClosedSurfacePoyntingFluxDetector(Detector):
     axes: tuple[int, ...] | None = frozen_field(default=None)
 
     _face_area_weights_per_axis: tuple | None = private_field(default=None)
+    _surface_h_weights_per_axis: tuple | None = private_field(default=None)
 
     # Net flux is signed (can be positive or negative).
     _signed_data: ClassVar[bool] = True
+
+    _uses_padded_fields: ClassVar[bool] = True
 
     def _resolve_active_axes(self) -> tuple[int, ...]:
         """Return the axes whose faces contribute (validated, size-one skipped by default)."""
@@ -251,7 +306,11 @@ class ClosedSurfacePoyntingFluxDetector(Detector):
             _resolve_face_area_weights(self._config, self.grid_slice_tuple, axis, self.dtype) for axis in range(3)
         )
         self = self.aset("_face_area_weights_per_axis", weights, create_new_ok=True)
-        return self
+        h_weights = tuple(
+            tuple(_surface_h_weights(self._config, self.grid_slice_tuple, axis, side) for side in ("min", "max"))
+            for axis in range(3)
+        )
+        return self.aset("_surface_h_weights_per_axis", h_weights, create_new_ok=True)
 
     def _shape_dtype_single_time_step(
         self,
@@ -268,14 +327,22 @@ class ClosedSurfacePoyntingFluxDetector(Detector):
         inv_permeability: jax.Array | float,
     ) -> DetectorState:
         del inv_permeability, inv_permittivity
-        if self._face_area_weights_per_axis is None:
+        if self._face_area_weights_per_axis is None or self._surface_h_weights_per_axis is None:
             raise Exception("Detector is not yet placed on the grid")
-        pf = compute_poynting_flux(E, H).real
-        net = net_poynting_flux_through_box(
-            poynting_vector=pf,
-            active_axes=self._resolve_active_axes(),
-            area_weights=self._face_area_weights_per_axis,
-        )
+        net = jnp.zeros((), dtype=self.dtype)
+        sides: tuple[tuple[Literal["min", "max"], float], ...] = (("min", -1.0), ("max", 1.0))
+        for axis in self._resolve_active_axes():
+            area = _slice_face(self._face_area_weights_per_axis[axis], axis, "min")
+            for side_index, (side, sign) in enumerate(sides):
+                E_face, H_face = _surface_fields(
+                    E,
+                    H,
+                    axis,
+                    side,
+                    self._surface_h_weights_per_axis[axis][side_index],
+                )
+                flux = compute_poynting_flux(E_face, H_face).real[axis]
+                net = net + sign * jnp.sum(flux * area)
         if self.orientation == "inward":
             net = -net
         net = net.reshape((1,)).astype(self.dtype)
@@ -400,10 +467,13 @@ class ClosedSurfacePhasorPoyntingFluxDetector(PhasorDetector):
     state is therefore ``O(surface)`` rather than ``O(volume)`` -- the interior
     phasors would be pure waste since the surface integral reads only the faces.
 
-    A face pair on an axis of size one cancels, so the default ``axes`` (every
-    axis with more than one cell) reduces to a 4-face surface for a quasi-2D setup
-    and a 6-face surface in full 3D, exactly like the time-domain version.
+    The default ``axes`` skips size-one dimensions, reducing to a 4-face surface for a quasi-2D
+    setup and a 6-face surface in full 3D. A size-one axis may still be selected explicitly when
+    its two distinct geometric faces should contribute, exactly like the time-domain version.
     """
+
+    #: Surface-current integration requires co-located electric and magnetic fields.
+    exact_interpolation: bool = frozen_field(default=True, init=False)
 
     #: ``"outward"`` (default) counts net power leaving the box as positive.
     #: ``"inward"`` flips the sign (net power entering, e.g. absorbed power).
@@ -427,9 +497,12 @@ class ClosedSurfacePhasorPoyntingFluxDetector(PhasorDetector):
 
     #: Per-axis face-area weights, each already reduced to a single boundary plane (size one on the normal axis).
     _face_area_weights_per_axis: tuple | None = private_field(default=None)
+    _surface_h_weights_per_axis: tuple | None = private_field(default=None)
 
     # Net flux is signed (can be positive or negative).
     _signed_data: ClassVar[bool] = True
+
+    _uses_padded_fields: ClassVar[bool] = True
 
     def _resolve_active_axes(self) -> tuple[int, ...]:
         """Return the axes whose faces contribute (validated, size-one skipped by default)."""
@@ -457,7 +530,11 @@ class ClosedSurfacePhasorPoyntingFluxDetector(PhasorDetector):
             for axis in range(3)
         )
         self = self.aset("_face_area_weights_per_axis", weights, create_new_ok=True)
-        return self
+        h_weights = tuple(
+            tuple(_surface_h_weights(self._config, self.grid_slice_tuple, axis, side) for side in ("min", "max"))
+            for axis in range(3)
+        )
+        return self.aset("_surface_h_weights_per_axis", h_weights, create_new_ok=True)
 
     def _shape_dtype_single_time_step(
         self,
@@ -483,20 +560,28 @@ class ClosedSurfacePhasorPoyntingFluxDetector(PhasorDetector):
         inv_permeability: jax.Array | float,
     ) -> DetectorState:
         del inv_permeability, inv_permittivity
+        if self._surface_h_weights_per_axis is None:
+            raise Exception("Detector is not yet placed on the grid")
         time_passed = time_step * self._config.time_step_duration
         static_scale = self._static_scale()
 
-        EH = jnp.stack([E[0], E[1], E[2], H[0], H[1], H[2]], axis=0)  # (6, nx, ny, nz)
         phase_angles = self._angular_frequencies * time_passed  # (num_freqs,)
-        phasors = jnp.exp(1j * phase_angles).reshape((len(self._angular_frequencies),) + (1,) * EH.ndim)
-        new_phasors = EH * phasors * static_scale  # (num_freqs, 6, nx, ny, nz)
 
         new_state = dict(state)
+        sides: tuple[Literal["min", "max"], ...] = ("min", "max")
         for a in self._resolve_active_axes():
-            # Spatial axis a maps to array axis a + 2 (leading freq and component axes).
-            for side in ("min", "max"):
+            for side_index, side in enumerate(sides):
                 key = f"phasor_axis{a}_{side}"
-                face = _slice_face(new_phasors, a + 2, side)[None, ...]  # (1, num_freqs, 6, *plane)
+                E_face, H_face = _surface_fields(
+                    E,
+                    H,
+                    a,
+                    side,
+                    self._surface_h_weights_per_axis[a][side_index],
+                )
+                EH = jnp.concatenate((E_face, H_face), axis=0)
+                phasors = jnp.exp(1j * phase_angles).reshape((len(self._angular_frequencies),) + (1,) * EH.ndim)
+                face = (EH * phasors * static_scale)[None, ...]
                 if self.inverse:
                     new_state[key] = (state[key] - face).astype(self.dtype)
                 else:
@@ -520,7 +605,7 @@ class ClosedSurfacePhasorPoyntingFluxDetector(PhasorDetector):
         real_dtype = jnp.float64 if self.dtype == jnp.complex128 else jnp.float32
         net = jnp.zeros((num_freqs,), dtype=real_dtype)
         for a in active_axes:
-            area = self._face_area_weights_per_axis[a]  # (*plane) with normal axis size one
+            area = self._face_area_weights_per_axis[a]
             for side, sign in (("max", 1.0), ("min", -1.0)):
                 phasors = state[f"phasor_axis{a}_{side}"][0]  # (num_freqs, 6, *plane)
                 s_a = _phasor_poynting_vector(phasors)[:, a]  # (num_freqs, *plane)

--- a/tests/unit/core/physics/test_metrics.py
+++ b/tests/unit/core/physics/test_metrics.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 import pytest
 
 from fdtdx.core.physics.metrics import (
+    colocate_yee_fields_to_surface,
     compute_energy,
     compute_poynting_flux,
     normalize_by_energy,
@@ -11,6 +12,43 @@ from fdtdx.core.physics.metrics import (
 )
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("axis", (0, 1, 2))
+def test_colocate_yee_fields_to_surface_respects_component_staggering(axis):
+    transverse_e = (axis + 1) % 3
+    transverse_h = (axis + 2) % 3
+    shape = [4, 4, 4]
+    shape[axis] = 2
+    E = jnp.zeros((3, *shape))
+    H = jnp.zeros_like(E)
+
+    edge_index = jnp.arange(shape[transverse_h], dtype=E.dtype).reshape(
+        tuple(shape[dim] if dim == transverse_h else 1 for dim in range(3))
+    )
+    normal_values = jnp.asarray([2.0, 6.0], dtype=H.dtype).reshape(
+        tuple(shape[dim] if dim == axis else 1 for dim in range(3))
+    )
+    E = E.at[transverse_e].set(jnp.broadcast_to(edge_index, shape))
+    H = H.at[transverse_h].set(jnp.broadcast_to(normal_values, shape))
+
+    E_surface, H_surface = colocate_yee_fields_to_surface(E, H, axis, h_weights=(0.25, 0.75))
+    flux = compute_poynting_flux(E_surface, H_surface)[axis]
+
+    expected_edge_values = jnp.asarray([1.5, 2.5])
+    expected = 5.0 * expected_edge_values.reshape(tuple(2 if dim == transverse_h else 1 for dim in range(3)))
+    assert flux.shape == tuple(1 if dim == axis else 2 for dim in range(3))
+    assert jnp.allclose(flux, expected)
+
+
+def test_colocate_yee_fields_to_surface_validates_surface_block():
+    fields = jnp.zeros((3, 2, 4, 4))
+    with pytest.raises(ValueError, match="axis must"):
+        colocate_yee_fields_to_surface(fields, fields, axis=3)
+    with pytest.raises(ValueError, match="two cells"):
+        colocate_yee_fields_to_surface(fields[:, :1], fields[:, :1], axis=0)
+    with pytest.raises(ValueError, match="transverse halos"):
+        colocate_yee_fields_to_surface(fields[:, :, :2], fields[:, :, :2], axis=0)
 
 
 def test_compute_energy_basic():

--- a/tests/unit/fdtd/test_update.py
+++ b/tests/unit/fdtd/test_update.py
@@ -775,6 +775,44 @@ class TestUpdateDetectorStates:
         assert mock_interp.call_args.kwargs.get("region_slice") is None
         assert jnp.allclose(det.update.call_args.kwargs["E"], full[0])  # EDGE_GST spans the whole domain
 
+        det._is_on_at_time_step_arr = [False] * 100
+        with (
+            patch("fdtdx.fdtd.update.interpolate_fields") as inactive_interp,
+            patch("fdtdx.fdtd.update.pad_fields_with_symmetry_mirror") as inactive_pad,
+            patch("fdtdx.fdtd.update.jax.lax.cond", side_effect=lambda cond, t, f, *args: f(*args)),
+        ):
+            update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=False)
+        inactive_interp.assert_not_called()
+        inactive_pad.assert_not_called()
+
+        det._is_on_at_time_step_arr = [True] * 100
+        det2 = self._make_detector(name="det2", exact_interpolation=True, grid_slice_tuple=self.EDGE_GST)
+        det2._uses_padded_fields = True
+        objects = self._make_det_objects(forward_detectors=[det, det2])
+        arrays = _make_arrays(detector_states={**self._init_state(det), **self._init_state(det2)})
+        with (
+            patch("fdtdx.fdtd.update.interpolate_fields", return_value=full) as shared_interp,
+            patch(
+                "fdtdx.fdtd.update.pad_fields_with_symmetry_mirror",
+                wraps=pad_fields_with_symmetry_mirror,
+            ) as shared_pad,
+            patch("fdtdx.fdtd.update.jax.lax.cond", side_effect=lambda cond, t, f, *args: t(*args)),
+        ):
+            update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=False)
+        shared_interp.assert_called_once()
+        assert shared_pad.call_count == 2
+
+        det._is_on_at_time_step_arr = [False] * 100
+        det2._is_on_at_time_step_arr = [False] * 100
+        with (
+            patch("fdtdx.fdtd.update.interpolate_fields") as inactive_shared_interp,
+            patch("fdtdx.fdtd.update.pad_fields_with_symmetry_mirror") as inactive_shared_pad,
+            patch("fdtdx.fdtd.update.jax.lax.cond", side_effect=lambda cond, t, f, *args: f(*args)),
+        ):
+            update_detector_states(jnp.array(0), arrays, objects, _make_config(), H_prev, inverse=False)
+        inactive_shared_interp.assert_not_called()
+        inactive_shared_pad.assert_not_called()
+
     def test_non_exact_passes_raw_region_slice(self):
         """exact_interpolation=False: detector receives the raw (non-interpolated) region slice."""
         det = self._make_detector(exact_interpolation=False, grid_slice_tuple=self.INTERIOR_GST)

--- a/tests/unit/objects/detectors/test_closed_surface_poynting.py
+++ b/tests/unit/objects/detectors/test_closed_surface_poynting.py
@@ -91,6 +91,11 @@ def _fields_for_Sx(ramp, shape):
     return E, H
 
 
+def _pad_fields(E, H):
+    padding = ((0, 0), (1, 1), (1, 1), (1, 1))
+    return jnp.pad(E, padding, mode="edge"), jnp.pad(H, padding, mode="edge")
+
+
 class TestClosedSurfaceDetector:
     def test_uniform_grid_constant_field_net_zero(self):
         config = SimulationConfig(
@@ -99,6 +104,7 @@ class TestClosedSurfaceDetector:
         placed = _place(config, ((0, 4), (0, 4), (0, 4)))
         shape = (4, 4, 4)
         E, H = _fields_for_Sx(jnp.ones(shape), shape)  # constant S_x
+        E, H = _pad_fields(E, H)
         state = placed.init_state()
         new_state = placed.update(jnp.asarray(0), E, H, state, jnp.ones((1, *shape)), 1.0)
         assert abs(float(new_state["poynting_flux"][0, 0])) < 1e-5
@@ -115,15 +121,32 @@ class TestClosedSurfaceDetector:
         config = SimulationConfig(time=20e-15, grid=grid, backend="cpu", dtype=jnp.float32, gradient_config=None)
         shape = (4, 3, 2)
         placed = _place(config, ((0, 4), (0, 3), (0, 2)))
-        E, H = _fields_for_Sx(_x_ramp(shape), shape)  # S_x = x cell index
+        E, H = _fields_for_Sx(_x_ramp(shape), shape)
+        E = jnp.pad(E, ((0, 0), (1, 1), (1, 1), (1, 1)), mode="edge")
+        H = jnp.pad(H, ((0, 0), (1, 1), (1, 1), (1, 1)), mode="edge")
+        # Ey is sampled on x-normal Yee faces. Set the upper ghost-face sample to nx so
+        # Sx=x has the analytic flux difference nx across an nx-cell-wide box.
+        E = E.at[1, -1, 1:-1, 1:-1].set(shape[0])
         state = placed.init_state()
         new_state = placed.update(jnp.asarray(0), E, H, state, jnp.ones((1, *shape)), 1.0)
         net = float(new_state["poynting_flux"][0, 0])
-        # Net = (S_x@max - S_x@min) * sum(dy_j * dz_k) = (nx-1) * A_x, using per-cell areas.
+        # Net = (S_x@max - S_x@min) * sum(dy_j * dz_k) = nx * A_x, using the requested
+        # geometric faces and per-cell transverse areas.
         dy = jnp.diff(grid.y_edges)
         dz = jnp.diff(grid.z_edges)
         area_x = float((dy[:, None] * dz[None, :]).sum())
-        assert net == pytest.approx((shape[0] - 1) * area_x, rel=1e-4)
+        assert net == pytest.approx(shape[0] * area_x, rel=1e-4)
+
+        # A transverse linear Ey profile is sampled on z edges and must be averaged to each
+        # face-cell center before multiplication by its nonuniform area.
+        E_linear = jnp.zeros_like(E).at[1, -1, 1:-1, 1:].set(jnp.asarray([0.0, 2.0, 3.0]))
+        H_linear = jnp.zeros_like(H).at[2].set(1.0)
+        linear_state = placed.update(
+            jnp.asarray(0), E_linear, H_linear, placed.init_state(), jnp.ones((1, *shape)), 1.0
+        )
+        z_centers = 0.5 * (jnp.asarray([0.0, 2.0]) + jnp.asarray([2.0, 3.0]))
+        expected_linear = float(dy.sum() * jnp.sum(z_centers * dz))
+        assert float(linear_state["poynting_flux"][0, 0]) == pytest.approx(expected_linear, rel=1e-4)
 
     def test_orientation_inward_negates(self):
         config = SimulationConfig(
@@ -131,6 +154,8 @@ class TestClosedSurfaceDetector:
         )
         shape = (4, 3, 3)
         E, H = _fields_for_Sx(_x_ramp(shape), shape)
+        E, H = _pad_fields(E, H)
+        E = E.at[1, -1, 1:-1, 1:-1].set(shape[0])
         out = _place(config, ((0, 4), (0, 3), (0, 3)), orientation="outward")
         inw = _place(config, ((0, 4), (0, 3), (0, 3)), orientation="inward")
         net_out = float(
@@ -139,8 +164,8 @@ class TestClosedSurfaceDetector:
         net_in = float(
             inw.update(jnp.asarray(0), E, H, inw.init_state(), jnp.ones((1, *shape)), 1.0)["poynting_flux"][0, 0]
         )
-        # (nx-1) * ny * nz * spacing**2 is the outward net for S_x = x cell index.
-        expected = (shape[0] - 1) * shape[1] * shape[2] * (1e-7) ** 2
+        # nx * ny * nz * spacing**2 is the outward net between the two geometric faces.
+        expected = shape[0] * shape[1] * shape[2] * (1e-7) ** 2
         assert net_out == pytest.approx(expected, rel=1e-4)
         assert net_in == pytest.approx(-net_out, rel=1e-5)
 
@@ -160,8 +185,11 @@ class TestClosedSurfaceDetector:
         H = jnp.stack([zeros2, zeros2, jnp.ones((2, ny, nz))])  # H_z = 1 -> S_x = E_y
 
         box = _place(config, ((0, 2), (0, ny), (0, nz)), axes=(0,))
+        E_box, H_box = _pad_fields(E, H)
         net = float(
-            box.update(jnp.asarray(0), E, H, box.init_state(), jnp.ones((1, 2, ny, nz)), 1.0)["poynting_flux"][0, 0]
+            box.update(jnp.asarray(0), E_box, H_box, box.init_state(), jnp.ones((1, 2, ny, nz)), 1.0)["poynting_flux"][
+                0, 0
+            ]
         )
 
         # Plane detector reading the max-x face (S_x = c there).

--- a/tests/unit/objects/detectors/test_phasor_poynting.py
+++ b/tests/unit/objects/detectors/test_phasor_poynting.py
@@ -244,6 +244,8 @@ class TestClosedSurfacePhasorDetector:
         shape = (4, 4, 4)
         E = jnp.stack([jnp.zeros(shape), jnp.ones(shape), jnp.zeros(shape)])
         H = jnp.stack([jnp.zeros(shape), jnp.zeros(shape), jnp.ones(shape)])
+        padding = ((0, 0), (1, 1), (1, 1), (1, 1))
+        E, H = jnp.pad(E, padding, mode="edge"), jnp.pad(H, padding, mode="edge")
         s1 = box.update(jnp.asarray(0), E, H, box.init_state(), jnp.ones((1, *shape)), 1.0)
         s2 = box.update(jnp.asarray(0), E, H, s1, jnp.ones((1, *shape)), 1.0)
         # two updates at the same time step exactly double every stored face


### PR DESCRIPTION
## What changed

- Co-locates staggered Yee-grid E and H fields on each geometric box face before calculating Poynting flux.
- Uses distance-weighted interpolation on rectilinear grids and per-cell face-area weights.
- Applies the same surface integration to time-domain and phasor closed-surface detectors.
- Supplies the required one-cell field halo while reusing padded fields across edge detectors.

## Why

The previous closed-surface detectors calculated `E × H` directly from fields stored at the same array indices, although the Yee-grid components represent different physical positions. This can bias total-flux measurements, particularly near sources and on nonuniform grids.

The updated implementation evaluates E and H at common physical face locations before integrating the outward flux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved closed-surface Poynting flux detection on uniform and nonuniform grids.
  * Added more accurate field interpolation at detector faces, including weighted surface sampling.
  * Added support for explicitly selecting size-one surface axes.

* **Bug Fixes**
  * Improved handling of detectors located at simulation-domain edges.
  * Avoided unnecessary field interpolation when detectors are inactive.
  * Corrected face averaging and flux calculations for edge and ghost-cell samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->